### PR TITLE
Add support for legacy tpm2-tools v3

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -26,13 +26,13 @@ KEYLIME_GIT=https://github.com/mit-ll/keylime.git
 TPM4720_GIT=https://github.com/mit-ll/tpm4720-keylime.git
 GOLANG_SRC=https://dl.google.com/go
 TPM2TSS_GIT=https://github.com/tpm2-software/tpm2-tss.git
-TPM2TOOLS_GIT=https://github.com/mit-ll/tpm2-tools.git
+TPM2TOOLS_GIT=https://github.com/tpm2-software/tpm2-tools.git
 TPM2SIM_SRC=http://sourceforge.net/projects/ibmswtpm2/files/ibmtpm1119.tar.gz/download
 KEYLIME_VER="master"
 TPM4720_VER="master"
-GOLANG_VER="1.11.4"
-TPM2TSS_VER="master"
-TPM2TOOLS_VER="master"
+GOLANG_VER="1.12.4"
+TPM2TSS_VER="2.0.x"
+TPM2TOOLS_VER="3.X"
 
 # Minimum version requirements
 MIN_PYTHON_VERSION="2.7.10"


### PR DESCRIPTION
Currently Keylime only supports master branch of tpm2-tools (v4+).  This PR adds support for the legacy (v3.X) version of the tpm2-tools (currently used on RHEL, etc.)

Tools have all been upstreamed to 3.X.  Need to update the CI infrastructure to support both current (tpm2-tools v4 fork) and upstream 3.X (https://github.com/tpm2-software/tpm2-tools/tree/3.X) TPM tool code bases. 

PR couples with issue to update CI for v4 tpm2-tools upstream: https://github.com/keylime/keylime/issues/123