### PR TITLE
Implement stale bot in keylime/keylime

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - key_feature
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed after 7 days if no further activity occurs.
+  Thank you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
This (free) bot marks issues / PRs as stale when there is no activity
for 60 days. It will initially make a comment giving 7 days notice.

Should someone comment or apply a change to a PR, the issue will
no longer be considered stale and the automated close tag will be
aborted / revoked.

This really helps keep the PR / issue queue clean of issues
considered unimportant or PR's that have become abandoned.

More details are available here [0]

[0] https://probot.github.io/apps/stale/