### PR TITLE
If PR only contains .md files or in docs, abort CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,18 @@ language: ruby
 
 sudo: required
 
+# If the change is a markdown file, don't run CI build. Or at a later point
+# we can set a specific job in here (such as a markdown lint)
+before_install:
+- |
+    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+      TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
+    fi
+    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^doc)/' || {
+      echo "Only documentation files were updated, stopping build process."
+      exit
+    }
+
 env:
   global:
     - container_id: $(mktemp)


### PR DESCRIPTION
This change adds a conditional to check if a pull request
contains only markdown files or is placed into `docs/`.

If the conditional is true, the Travis CI build will be aborted.

Rename doc and markdown