### PR TITLE
Move logging code to separate file

### DIFF
--- a/auto-ipsec/libreswan/src/local_action_crashsa.py
+++ b/auto-ipsec/libreswan/src/local_action_crashsa.py
@@ -27,13 +27,14 @@ from M2Crypto import X509
 
 import keylime.secure_mount as secure_mount
 import keylime.common as common
+import keylime.keylime_logging as keylime_logging
 import keylime.cmd_exec as cmd_exec
 
 # read the config file
 config = ConfigParser.RawConfigParser()
 config.read(common.CONFIG_FILE)
 
-logger = common.init_logging('delete-sa')
+logger = keylime_logging.init_logging('delete-sa')
 
 def execute(revocation):
     serial = revocation.get("metadata",{}).get("cert_serial",None)

--- a/auto-ipsec/libreswan/src/local_action_update_crl.py
+++ b/auto-ipsec/libreswan/src/local_action_update_crl.py
@@ -27,13 +27,14 @@ import ConfigParser
 import keylime.tornado_requests as tornado_requests
 import keylime.ca_util as ca_util
 import keylime.secure_mount as secure_mount
-import keylime.common as common 
+import keylime.common as common
+import keylime.keylime_logging as keylime_logging
 
 # read the config file
 config = ConfigParser.RawConfigParser()
 config.read(common.CONFIG_FILE)
 
-logger = common.init_logging('update_crl')
+logger = keylime_logging.init_logging('update_crl')
 
 def execute(json_revocation):
     if json_revocation['type']!='revocation':

--- a/auto-ipsec/racoon/src/local_action_deletesa.py
+++ b/auto-ipsec/racoon/src/local_action_deletesa.py
@@ -26,6 +26,7 @@ import os
 from M2Crypto import X509
 
 import keylime.secure_mount as secure_mount
+import keylime.keylime_logging as keylime_logging
 import keylime.common as common
 import keylime.cmd_exec as cmd_exec
 
@@ -33,7 +34,7 @@ import keylime.cmd_exec as cmd_exec
 config = ConfigParser.RawConfigParser()
 config.read(common.CONFIG_FILE)
 
-logger = common.init_logging('delete-sa')
+logger = keylime_logging.init_logging('delete-sa')
 
 def execute(revocation):
     serial = revocation.get("metadata",{}).get("cert_serial",None)

--- a/auto-ipsec/racoon/src/local_action_update_crl.py
+++ b/auto-ipsec/racoon/src/local_action_update_crl.py
@@ -27,13 +27,14 @@ import ConfigParser
 import keylime.tornado_requests as tornado_requests
 import keylime.ca_util as ca_util
 import keylime.secure_mount as secure_mount
-import keylime.common as common 
+import keylime.common as common
+import keylime.keylime_logging as keylime_logging
 
 # read the config file
 config = ConfigParser.RawConfigParser()
 config.read(common.CONFIG_FILE)
 
-logger = common.init_logging('update_crl')
+logger = keylime_logging.init_logging('update_crl')
 
 def execute(json_revocation):
     if json_revocation['type']!='revocation':

--- a/demo/agent_monitor/tenant_agent_monitor.py
+++ b/demo/agent_monitor/tenant_agent_monitor.py
@@ -28,7 +28,8 @@ import sys
 sys.path.insert(0, '../../keylime/')
 
 import common
-logger = common.init_logging('agent_monitor')
+import keylime_logging
+logger = keylime_logging.init_logging('agent_monitor')
 
 import argparse
 import getpass

--- a/keylime/ca_impl_cfssl.py
+++ b/keylime/ca_impl_cfssl.py
@@ -19,6 +19,7 @@ violate any copyrights that exist in this work.
 '''
 
 import common
+import keylime_logging
 import json
 import ConfigParser
 import os
@@ -30,7 +31,7 @@ import base64
 import time
 import socket
 
-logger = common.init_logging('ca_impl_cfssl')
+logger = keylime_logging.init_logging('ca_impl_cfssl')
 
 config = ConfigParser.SafeConfigParser()
 config.read(common.CONFIG_FILE)

--- a/keylime/ca_impl_openssl.py
+++ b/keylime/ca_impl_openssl.py
@@ -23,6 +23,7 @@ from M2Crypto import X509, EVP, RSA, ASN1
 import ConfigParser
 
 import common
+import keylime_logging
 config = ConfigParser.SafeConfigParser()
 config.read(common.CONFIG_FILE)
 
@@ -120,6 +121,6 @@ def mk_signed_cert(cacert,ca_pk,name,serialnum):
     return cert, pk
 
 def gencrl(_,a,b):
-    logger = common.init_logging('ca_impl_openssl')
+    logger = keylime_logging.init_logging('ca_impl_openssl')
     logger.warning("CRL creation with openssl is not supported")
     return "" 

--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -21,7 +21,8 @@ violate any copyrights that exist in this work.
 '''
 
 import common
-logger = common.init_logging('ca-util')
+import keylime_logging
+logger = keylime_logging.init_logging('ca-util')
 
 import sys
 import os

--- a/keylime/cloud_agent.py
+++ b/keylime/cloud_agent.py
@@ -21,7 +21,8 @@ violate any copyrights that exist in this work.
 '''
 
 import common
-logger = common.init_logging('cloudagent')
+import keylime_logging
+logger = keylime_logging.init_logging('cloudagent')
 
 
 import BaseHTTPServer

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -25,6 +25,7 @@ import json
 import base64
 import time
 import common
+import keylime_logging
 import registrar_client
 import os
 import crypto
@@ -40,7 +41,7 @@ from tpm_abstract import TPM_Utilities, Hash_Algorithms, Encrypt_Algorithms, Sig
 
 
 # setup logging
-logger = common.init_logging('cloudverifier_common')
+logger = keylime_logging.init_logging('cloudverifier_common')
 
 # setup config
 config = ConfigParser.SafeConfigParser()

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -20,7 +20,8 @@ above. Use of this work other than as specifically authorized by the U.S. Govern
 violate any copyrights that exist in this work.
 '''
 import common
-logger = common.init_logging('cloudverifier')
+import keylime_logging
+logger = keylime_logging.init_logging('cloudverifier')
 
 import json
 import ConfigParser

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -20,13 +20,14 @@ violate any copyrights that exist in this work.
 
 import sys
 import common
+import keylime_logging
 import hashlib
 import struct
 import re
 import os
 import ConfigParser
 
-logger = common.init_logging('ima')
+logger = keylime_logging.init_logging('ima')
 
 # setup config
 config = ConfigParser.RawConfigParser()

--- a/keylime/keylime_logging.py
+++ b/keylime/keylime_logging.py
@@ -1,0 +1,85 @@
+import os.path
+import common
+import sys
+import logging.config
+
+def log_http_response(logger, loglevel, response_body):
+    """Takes JSON response payload and logs error info"""
+    if response_body is None:
+        return False
+    if logger is None:
+        return False
+
+    log_func = logger.info
+    if loglevel == logging.CRITICAL:
+        log_func = logger.critical
+    elif loglevel == logging.ERROR:
+        log_func = logger.error
+    elif loglevel == logging.WARNING:
+        log_func = logger.warning
+    elif loglevel == logging.INFO:
+        log_func = logger.info
+    elif loglevel == logging.DEBUG:
+        log_func = logger.debug
+
+    if "results" in response_body and "code" in response_body and "status" in response_body:
+        log_func("Response code %s: %s"%(response_body["code"], response_body["status"]))
+    else:
+        logger.error("Error: unexpected or malformed http response payload")
+        return False
+
+    return True
+
+LOG_TO_FILE=['cloudagent','registrar','provider_registrar','cloudverifier']
+# not clear that this works right.  console logging may not work
+LOG_TO_SYSCONSOLE=['cloudagent']
+LOG_TO_STREAM=['tenant_webapp']
+LOGDIR='/var/log/keylime'
+if not common.REQUIRE_ROOT:
+    LOGSTREAM = './keylime-stream.log'
+else:
+    LOGSTREAM=LOGDIR+'/keylime-stream.log'
+
+logging.config.fileConfig(common.CONFIG_FILE)
+def init_logging(loggername):
+    logger = logging.getLogger("keylime.%s"%(loggername))
+    logging.getLogger("requests").setLevel(logging.WARNING)
+    mainlogger = logging.getLogger("keylime")
+
+    if loggername in LOG_TO_FILE:
+        if not common.REQUIRE_ROOT:
+            logfilename = "./keylime-all.log"
+        else:
+            logfilename = "%s/%s.log"%(LOGDIR,loggername)
+            if os.getuid()!=0:
+                logger.warning("Unable to log to %s. please run as root"%logfilename)
+                return logger
+            else:
+                if not os.path.exists(LOGDIR):
+                    os.makedirs(LOGDIR, 0o750)
+                common.chownroot(LOGDIR,logger)
+                os.chmod(LOGDIR,0o750)
+
+        fh = logging.FileHandler(logfilename)
+        fh.setLevel(logger.getEffectiveLevel())
+        basic_formatter = logging.Formatter('%(created)s  %(name)s  %(levelname)s  %(message)s')
+        fh.setFormatter(basic_formatter)
+        mainlogger.addHandler(fh)
+
+    if loggername in LOG_TO_STREAM:
+        fh = logging.FileHandler(filename=LOGSTREAM,mode='w')
+        fh.setLevel(logger.getEffectiveLevel())
+        basic_formatter = logging.Formatter('%(created)s  %(name)s  %(levelname)s  %(message)s')
+        fh.setFormatter(basic_formatter)
+        mainlogger.addHandler(fh)
+
+    if loggername in LOG_TO_SYSCONSOLE:
+        if os.getuid()!=0:
+            logger.warning("unable to log to /dev/console. please run as root")
+        else:
+            fh = logging.FileHandler("/dev/console")
+            fh.setLevel(logger.getEffectiveLevel())
+            fh.setFormatter(basic_formatter)
+            mainlogger.addHandler(fh)
+
+    return logger

--- a/keylime/keylime_sqlite.py
+++ b/keylime/keylime_sqlite.py
@@ -19,7 +19,8 @@ violate any copyrights that exist in this work.
 '''
 
 import common
-logger = common.init_logging('keylime_sqlite')
+import keylime_logging
+logger = keylime_logging.init_logging('keylime_sqlite')
 import os
 import sqlite3
 import json

--- a/keylime/openstack.py
+++ b/keylime/openstack.py
@@ -19,10 +19,11 @@ violate any copyrights that exist in this work.
 '''
 
 import common
+import keylime_logging
 import uuid
 import tornado_requests
 
-logger = common.init_logging('openstack')
+logger = keylime_logging.init_logging('openstack')
 
 def get_openstack_uuid(uuid_service_ip='169.254.169.254',
                        uuid_service_resource='/openstack/2012-08-10/meta_data.json'):

--- a/keylime/provider_platform_init.py
+++ b/keylime/provider_platform_init.py
@@ -21,6 +21,7 @@ violate any copyrights that exist in this work.
 
 import sys
 import common
+import keylime_logging
 import ConfigParser
 import registrar_client
 import vtpm_manager
@@ -29,7 +30,7 @@ import os
 import errno
 import json
 
-logger = common.init_logging('provider_platform_init')
+logger = keylime_logging.init_logging('provider_platform_init')
 
 config = ConfigParser.RawConfigParser()
 config.read(common.CONFIG_FILE)

--- a/keylime/provider_registrar.py
+++ b/keylime/provider_registrar.py
@@ -21,7 +21,8 @@ violate any copyrights that exist in this work.
 '''
 
 import common
-logger = common.init_logging('provider-registrar')
+import keylime_logging
+logger = keylime_logging.init_logging('provider-registrar')
 
 import registrar_common
 import ConfigParser

--- a/keylime/provider_vtpm_add.py
+++ b/keylime/provider_vtpm_add.py
@@ -22,6 +22,7 @@ violate any copyrights that exist in this work.
 
 import sys
 import common
+import keylime_logging
 import ConfigParser
 import registrar_client
 import vtpm_manager
@@ -32,7 +33,7 @@ import json
 config = ConfigParser.RawConfigParser()
 config.read(common.CONFIG_FILE)
 
-logger = common.init_logging('platform-init')
+logger = keylime_logging.init_logging('platform-init')
 
 def add_vtpm(inputfile):
     # read in the file

--- a/keylime/registrar.py
+++ b/keylime/registrar.py
@@ -21,7 +21,8 @@ violate any copyrights that exist in this work.
 '''
 
 import common
-logger = common.init_logging('registrar')
+import keylime_logging
+logger = keylime_logging.init_logging('registrar')
 
 import registrar_common
 import ConfigParser

--- a/keylime/registrar_client.py
+++ b/keylime/registrar_client.py
@@ -23,11 +23,12 @@ import tornado_requests
 import crypto
 import base64
 import common
+import keylime_logging
 import ssl
 import os
 import logging
 
-logger = common.init_logging('registrar_client')
+logger = keylime_logging.init_logging('registrar_client')
 context = None
 
 def init_client_tls(config,section):

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -21,7 +21,8 @@ violate any copyrights that exist in this work.
 '''
 
 import common
-logger = common.init_logging('registrar-common')
+import keylime_logging
+logger = keylime_logging.init_logging('registrar-common')
 
 import BaseHTTPServer
 from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler

--- a/keylime/revocation_actions/print_metadata.py
+++ b/keylime/revocation_actions/print_metadata.py
@@ -20,14 +20,15 @@ above. Use of this work other than as specifically authorized by the U.S. Govern
 violate any copyrights that exist in this work.
 '''
 
-import keylime.common as common 
+import keylime.common as common
+import keylime.keylime_logging as keylime_logging
 import ConfigParser
 
 # read the config file
 config = ConfigParser.RawConfigParser()
 config.read(common.CONFIG_FILE)
 
-logger = common.init_logging('print_metadata')
+logger = keylime_logging.init_logging('print_metadata')
 
 def execute(json_revocation):
     print json_revocation.get("metadata",{})

--- a/keylime/revocation_actions/update_crl.py
+++ b/keylime/revocation_actions/update_crl.py
@@ -28,12 +28,13 @@ import keylime.tornado_requests as tornado_requests
 import keylime.ca_util as ca_util
 import keylime.secure_mount as secure_mount
 import keylime.common as common 
+import keylime.keylime_logging as keylime_logging
 
 # read the config file
 config = ConfigParser.RawConfigParser()
 config.read(common.CONFIG_FILE)
 
-logger = common.init_logging('update_crl')
+logger = keylime_logging.init_logging('update_crl')
 
 def execute(json_revocation):
     if json_revocation['type']!='revocation':

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -22,6 +22,7 @@ violate any copyrights that exist in this work.
 
 import zmq
 import common
+import keylime_logging
 import ConfigParser
 import json
 import crypto
@@ -33,7 +34,7 @@ import sys
 from multiprocessing import Process
 import signal
 
-logger = common.init_logging('revocation_notifier')
+logger = keylime_logging.init_logging('revocation_notifier')
 
 config = ConfigParser.SafeConfigParser()
 config.read(common.CONFIG_FILE)

--- a/keylime/secure_mount.py
+++ b/keylime/secure_mount.py
@@ -22,10 +22,11 @@ violate any copyrights that exist in this work.
 
 import cmd_exec
 import common
+import keylime_logging
 import os
 import ConfigParser
 
-logger = common.init_logging('secure_mount')
+logger = keylime_logging.init_logging('secure_mount')
 
 # read the config file
 config = ConfigParser.RawConfigParser()

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -24,6 +24,7 @@ import json
 import base64
 import ConfigParser
 import common
+import keylime_logging
 import registrar_client
 import sys
 import argparse
@@ -46,7 +47,7 @@ from tpm_abstract import TPM_Utilities, Hash_Algorithms, Encrypt_Algorithms, Sig
 
 
 # setup logging
-logger = common.init_logging('tenant')
+logger = keylime_logging.init_logging('tenant')
 
 # setup config
 config = ConfigParser.RawConfigParser()

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -331,7 +331,7 @@ class AgentsHandler(BaseHandler):
             if "pos" in rest_params and rest_params["pos"] is not None and rest_params["pos"].isdigit():
                 offset = int(rest_params["pos"])
             # intercept requests for logs
-            with open(common.LOGSTREAM,'r') as f:
+            with open(keylime_logging.LOGSTREAM,'r') as f:
                 logValue = f.readlines()
                 common.echo_json_response(self, 200, "Success", {'log':logValue[offset:]})
             return

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -38,8 +38,9 @@ import cloud_verifier_common
 import tenant
 import base64
 import common
+import keylime_logging
 
-logger = common.init_logging('tenant_webapp')
+logger = keylime_logging.init_logging('tenant_webapp')
 
 config = ConfigParser.SafeConfigParser()
 config.read(common.CONFIG_FILE)

--- a/keylime/tpm1.py
+++ b/keylime/tpm1.py
@@ -20,6 +20,7 @@ violate any copyrights that exist in this work.
 import base64
 import cmd_exec
 import common
+import keylime_logging
 import ConfigParser
 import crypto
 import hashlib
@@ -40,7 +41,7 @@ import time
 from tpm_abstract import *
 from tpm_ek_ca import *
 
-logger = common.init_logging('tpm1')
+logger = keylime_logging.init_logging('tpm1')
 
 # read the config file
 config = ConfigParser.RawConfigParser()

--- a/keylime/tpm2.py
+++ b/keylime/tpm2.py
@@ -36,11 +36,12 @@ from M2Crypto import m2
 
 import cmd_exec
 import common
+import keylime_logging
 import secure_mount
 from tpm_abstract import Hash_Algorithms, Encrypt_Algorithms, Sign_Algorithms, AbstractTPM, TPM_Utilities
 from tpm_ek_ca import atmel_trusted_keys, trusted_certs
 
-logger = common.init_logging('tpm2')
+logger = keylime_logging.init_logging('tpm2')
 
 # Read the config file
 config = ConfigParser.RawConfigParser()

--- a/keylime/tpm_abstract.py
+++ b/keylime/tpm_abstract.py
@@ -29,10 +29,11 @@ import string
 import struct
 
 import common
+import keylime_logging
 import crypto
 import ima
 
-logger = common.init_logging('tpm')
+logger = keylime_logging.init_logging('tpm')
 
 
 class Hash_Algorithms:

--- a/keylime/tpm_obj.py
+++ b/keylime/tpm_obj.py
@@ -25,7 +25,8 @@ import distutils.spawn
 import os
 
 import common
-logger = common.init_logging('tpmobj')
+import keylime_logging
+logger = keylime_logging.init_logging('tpmobj')
 import tpm1
 import tpm2
 

--- a/keylime/vtpm_manager.py
+++ b/keylime/vtpm_manager.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 
 import base64
 import common
+import keylime_logging
 import errno
 import hashlib
 import inspect
@@ -45,7 +46,7 @@ sys.path.append(os.path.dirname(__file__))
 from tpm_initialize import get_mod_from_pem
 
 # Logging boiler plate
-logger = common.init_logging('vtpmmgr')
+logger = keylime_logging.init_logging('vtpmmgr')
 logger.setLevel(logging.INFO)
 
 # ./utils/encaik -ek ~/tmp/LLSRC-tci/scripts/llsrc-vtpm-host0_pubek.pem -ik ~/tmp/LLSRC-tci/scripts/llsrc-vtpm-host0_pubek.pem -ok key.blob -oak key.aes


### PR DESCRIPTION
The logging code currently resides in common.py. By moving the code to a separate file, it can be imported independently of the common.py code. It should also enable the use of logging in common.py. The code is moved to keylime_logging.py and includes log_http_response() and init_logging() functions.

The license part is missing in keylime_logging.py and should be filled in.

Resolves #143