### PR TITLE
Fixes cut off response.status

### DIFF
--- a/keylime/registrar_client.py
+++ b/keylime/registrar_client.py
@@ -113,7 +113,7 @@ def getKeys(registrar_ip,registrar_port,agent_id):
             return None
 
         if "results" not in response_body:
-            logger.critical("Error: unexpected http response body from Registrar Server: %s"%str(response.statu))
+            logger.critical("Error: unexpected http response body from Registrar Server: %s"%str(response.status))
             return None
 
         if "aik" not in response_body["results"]:


### PR DESCRIPTION
`response.statu` was cut off during the Python 3 port.

This sets it properly `response.status`

Resolves: #148