### PR TITLE
change async calls to support python 3.6

### DIFF
--- a/keylime/cloud_agent.py
+++ b/keylime/cloud_agent.py
@@ -595,7 +595,7 @@ def main(argv=sys.argv):
                 try:
                     module = importlib.import_module(action)
                     execute = getattr(module,'execute')
-                    asyncio.run(execute(revocation))
+                    asyncio.get_event_loop().run_until_complete(execute(revocation))
                 except Exception as e:
                     logger.warn("Exception during execution of revocation action %s: %s"%(action,e))
         try:


### PR DESCRIPTION
use this method to call coroutines so that we don't need python3.7 and 3.6 is sufficient.  this means that compatibility with ubuntu 18.04 is easier