### PR TITLE
Set openssl as the default

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -112,7 +112,7 @@ while getopts ":shotkmp:" opt; do
             echo "Usage: $0 [option...]"
             echo "Options:"
             echo $'-k \t\t\t\t Download Keylime (stub installer mode)'
-            echo $'-o \t\t\t\t Use OpenSSL instead of CFSSL'
+            echo $'-o \t\t\t\t Use OpenSSL (vs. CFSSL). NOTE: OpenSSL does not support revocation'
             echo $'-t \t\t\t\t Create tarball with keylime_agent'
             echo $'-m \t\t\t\t Use modern TPM 2.0 libraries (vs. TPM 1.2)'
             echo $'-s \t\t\t\t Install TPM in socket/simulator mode (vs. chardev)'
@@ -229,16 +229,16 @@ echo "INFO: Using Keylime directory: $KEYLIME_DIR"
 
 
 # OpenSSL or cfssl?
-if [[ "$OPENSSL" -eq "1" ]] ; then
-    # Patch config file to use openssl
+if [[ "$OPENSSL" -eq "0" ]] ; then
+    # Patch config file to use cfssl
     echo
     echo "=================================================================================="
-    echo $'\t\t\tSwitching config to OpenSSL'
+    echo $'\t\t\tSwitching config to cfssl'
     echo "=================================================================================="
     cd $KEYLIME_DIR
-    patch --forward --verbose -s -p1 < $KEYLIME_DIR/patches/opensslconf-patch.txt \
+    patch --forward --verbose -s -p1 < $KEYLIME_DIR/patches/cfsslconf-patch.txt \
         && echo "INFO: Keylime config patched!"
-else
+
     # Pull in correct PATH under sudo (mainly for secure_path)
     if [[ -r "/etc/profile.d/go.sh" ]]; then
         source "/etc/profile.d/go.sh"
@@ -521,3 +521,4 @@ if [[ "$TARBALL" -eq "1" ]] ; then
     fi
     ./make_agent_bundle_tarball.sh $TAR_BUNDLE_FLAGS
 fi
+

--- a/keylime.conf
+++ b/keylime.conf
@@ -1,7 +1,7 @@
 [general]
 #=============================================================================
-# these options are self explanatory ip/port combinations to find the various 
-# keylime services on the network.  some services use these, some do not. 
+# these options are self explanatory ip/port combinations to find the various
+# keylime services on the network.  some services use these, some do not.
 # But they are used frequently enough that they end up here
 cloudverifier_port = 8881
 registrar_port = 8890
@@ -16,7 +16,7 @@ webapp_ip = 127.0.0.1
 cfssl_ip = 127.0.0.1
 cfssl_port = 8888
 
-# This is the port combination of the notification server.  The cloud verifier 
+# This is the port combination of the notification server.  The cloud verifier
 # will start a notification server automatically if the revocation_notifier
 # option is set to true
 revocation_notifier_ip = 127.0.0.1
@@ -32,19 +32,19 @@ tls_check_hostnames = False
 # valid options are 'cfssl' or 'openssl'  For cfssl to work, you must have the
 # go binary installed in your path or in /usr/local/
 # revocation list generation is only supported by cfssl
-ca_implementation = cfssl
+ca_implementation = openssl
 
 #=============================================================================
 [cloud_agent]
 #=============================================================================
-# What is the name of the rsa key that keylime should use for protecting 
+# What is the name of the rsa key that keylime should use for protecting
 # shares of U/V
 rsa_keyname = tci_rsa_key
 
 # what filename in /var/lib/keylime/secure should the encryption key be placed
 enc_keyname = derived_tci_key
 
-# what filename in /var/lib/keylime/secure should the optional decrypted 
+# what filename in /var/lib/keylime/secure should the optional decrypted
 # payload be placed
 dec_payload_file = decrypted_payload
 
@@ -53,8 +53,8 @@ dec_payload_file = decrypted_payload
 # the default below sets it to 1 megabyte
 secure_size = 1m
 
-# use this option to set the TPM ownerpassword to something you want to use.  
-# Set it to "generate" if you want keylime to choose a random owner password 
+# use this option to set the TPM ownerpassword to something you want to use.
+# Set it to "generate" if you want keylime to choose a random owner password
 # for you
 tpm_ownerpassword = keylime
 
@@ -64,7 +64,7 @@ tpm_ownerpassword = keylime
 # of the tmpfs partition above with secure_size option
 extract_payload_zip = True
 
-# set the agent's uuid to the given value.  
+# set the agent's uuid to the given value.
 # set to 'openstack', it will try to get the uuid from the metadata service
 # if you set this to 'generate', keylime will create a random uuid
 # if you set this to 'hash_ek', keylime will set the UUID to the result
@@ -74,18 +74,18 @@ agent_uuid = D432FBB3-D2F1-4A97-9EF7-75BD81C00000
 # whether to listen for revocation notifications from the verifier
 listen_notfications = True
 
-# path to the certificate to verify revocation messages received from the 
+# path to the certificate to verify revocation messages received from the
 # verifier.  path is relative to /var/lib/keylime
 # if set to "default", keylime will use the file RevocationNotifier-cert.crt
 # from the unzipped contents provided by the tenant
 revocation_cert = default
 
 # Comma separated list of python scripts to run upon receiving a revocation
-# message. Keylime will verify the signature first, then call these python 
+# message. Keylime will verify the signature first, then call these python
 # scripts with the json revocation message.  The scripts must be located in
 # revocation_actions directory
 #
-# keylime will also get the list of revocation actions from the file 
+# keylime will also get the list of revocation actions from the file
 # action_list in the unzipped contents provided by the verifier
 # all actions must be named local_action_[some name]
 revocation_actions=
@@ -124,40 +124,40 @@ tpm_signing_alg = rsassa
 # Cloud Verifier TLS options.  This is for authenticating the CV itself,
 # authenticating the users of the CV and securing the transmission of keys
 #
-# tls_dir option sets directory in /var/lib/keylime/ to put CA certificates 
-# and files for TLS.  
+# tls_dir option sets directory in /var/lib/keylime/ to put CA certificates
+# and files for TLS.
 # set to "generate" to automatically generate a CA/certificates in dir cv_ca
 # if set to "generate":  ca_cert, my_cert, and private_key must be "default"
 # if you specify generate, you can manage the CA that the verifier will create
-# using keylime_ca -d /var/lib/keylime/cv_ca/ 
+# using keylime_ca -d /var/lib/keylime/cv_ca/
 tls_dir = generate
 
 # the filename (in tls_dir) of the CA cert for verifying client certificates
 ca_cert = default
 
 # the filename (in tls_dir) of the cloud verifier certificate and private key
-# the following two options also take the string "default" to find a files 
-# with names <fully_qualified_name>-cert.crt and 
+# the following two options also take the string "default" to find a files
+# with names <fully_qualified_name>-cert.crt and
 # <fully_qualified_name>-public.pem for cert and private key respectively
 my_cert = default
 private_key = default
 
-# set the password to Decrypt the private key file.  this should be set to a 
+# set the password to Decrypt the private key file.  this should be set to a
 # strong password
-# if tls_dir=generate, this password will also be used to protect the 
+# if tls_dir=generate, this password will also be used to protect the
 # generated CA private key
 private_key_pw = default
 
-# Registrar client TLS options.  this allows the CV to authenticate the 
+# Registrar client TLS options.  this allows the CV to authenticate the
 # registar before asking for AIKs
-# this option sets the directory where the CA certificate for the registrar 
+# this option sets the directory where the CA certificate for the registrar
 # can be found
 # use "default" to use 'reg_ca' (this points it to the directory automatically
 # created by the registrar if it is set to "generate"
-# use "CV" to use 'cv_ca', the directory automatically created (and shared 
+# use "CV" to use 'cv_ca', the directory automatically created (and shared
 # with the registar) by the CV
 registrar_tls_dir = CV
-# the following three options set the filenames in tls_dir where the CA 
+# the following three options set the filenames in tls_dir where the CA
 # certificate, client certificate, and client private key file are
 # if tls_dir = default, then default values will be used for ca_cert =
 # cacert.pem, my_cert = client-cert.crt, and private_key = client-private.pem
@@ -165,7 +165,7 @@ registrar_ca_cert = default
 registrar_my_cert = default
 registrar_private_key = default
 
-# set the password to decrypt the private key file.  this should be set to a 
+# set the password to decrypt the private key file.  this should be set to a
 # strong password
 # if you are using the auto generated keys from the CV, set the same password
 # here as you did for private_key_pw in the [cloud_verifier] section
@@ -185,7 +185,7 @@ retry_interval = 1
 # integer number of retries to connect to an agent before giving up
 max_retries = 10
 
-# time between integrity measurement checks in seconds.  Set to 0 to do as 
+# time between integrity measurement checks in seconds.  Set to 0 to do as
 # fast as possible.  Floating point values accepted here
 quote_interval = 2
 
@@ -198,14 +198,14 @@ revocation_notifier = True
 #=============================================================================
 
 # Tenant client TLS options.  This is for authenticating the CV itself and
-# proving that the tenant can talk to the CV. 
-# tls_dir option sets directory in /var/lib/keylime/ to find client 
+# proving that the tenant can talk to the CV.
+# tls_dir option sets directory in /var/lib/keylime/ to find client
 # certificates for talking to the CV.
-# and files for TLS.  
+# and files for TLS.
 # set to default to use the CA setup by the cloud_verifier on the same machine
 # files will be in /var/lib/keylime/cv_ca/
 tls_dir = default
-# the following three options set the filenames in tls_dir where the CA 
+# the following three options set the filenames in tls_dir where the CA
 # certificate, client certificate, and client private key file are
 # if tls_dir = default, then default values will be used for ca_cert =
 # cacert.pem, my_cert = client-cert.crt, and private_key = client-private.pem
@@ -213,22 +213,22 @@ ca_cert = default
 my_cert = default
 private_key = default
 
-# set the password to decrypt the private key file.  this should be set to a 
+# set the password to decrypt the private key file.  this should be set to a
 # strong password
 # if you are using the auto generated keys from the CV, set the same password
 # here as you did for private_key_pw in the [cloud_verifier] section
 private_key_pw = default
 
-# Registrar client TLS options.  this allows the tenant to authenticate the 
+# Registrar client TLS options.  this allows the tenant to authenticate the
 # registar before asking for AIKs
-# this option sets the directory where the CA certificate for the registrar 
+# this option sets the directory where the CA certificate for the registrar
 # can be found
 # use "default" to use 'reg_ca' (this points it to the directory automatically
 # created by the registrar if it is set to "generate"
-# use "CV" to use 'cv_ca', the directory automatically created (and shared 
+# use "CV" to use 'cv_ca', the directory automatically created (and shared
 # with the registar) by the CV
 registrar_tls_dir = CV
-# the following three options set the filenames in tls_dir where the CA 
+# the following three options set the filenames in tls_dir where the CA
 # certificate, client certificate, and client private key file are
 # if tls_dir = default, then default values will be used for ca_cert =
 # cacert.pem, my_cert = client-cert.crt, and private_key = client-private.pem
@@ -236,7 +236,7 @@ registrar_ca_cert = default
 registrar_my_cert = default
 registrar_private_key = default
 
-# set the password to decrypt the private key file.  this should be set to a 
+# set the password to decrypt the private key file.  this should be set to a
 # strong password
 # if you are using the auto generated keys from the CV, set the same password
 # here as you did for private_key_pw in the [cloud_verifier] section
@@ -252,11 +252,11 @@ max_payload_size = 1048576
 # if specified
 cloudverifier_ip = 127.0.0.1
 
-# TPM policies are json structures that takes a list of accepted pcr values 
-# and will match any in the list for that pcr.  These can be a mixture of any 
-# hashing algorithms, potentially of varying digest lengths (default policy 
+# TPM policies are json structures that takes a list of accepted pcr values
+# and will match any in the list for that pcr.  These can be a mixture of any
+# hashing algorithms, potentially of varying digest lengths (default policy
 # below supports SHA1, SHA-256 and SHA-512)
-# note that you can't set a policy on PCR10 and PCR16 because 
+# note that you can't set a policy on PCR10 and PCR16 because
 # keylime uses them internally
 tpm_policy = {"22":["0000000000000000000000000000000000000001","0000000000000000000000000000000000000000000000000000000000000001","000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001","ffffffffffffffffffffffffffffffffffffffff","ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"],"15":["0000000000000000000000000000000000000000","0000000000000000000000000000000000000000000000000000000000000000","000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"]}
 
@@ -264,8 +264,8 @@ tpm_policy = {"22":["0000000000000000000000000000000000000001","0000000000000000
 vtpm_policy = {"23":["ffffffffffffffffffffffffffffffffffffffff","0000000000000000000000000000000000000000"],"15":"0000000000000000000000000000000000000000"}
 
 # specify the file containing whitelists for processing Linux IMA white lists
-# this file is used if tenant provides "default" as the IMA whitelist file 
-# this file should be in the form 
+# this file is used if tenant provides "default" as the IMA whitelist file
+# this file should be in the form
 # SHA1sum path_to_file
 ima_whitelist = whitelist.txt
 
@@ -273,18 +273,18 @@ ima_whitelist = whitelist.txt
 # use with great caution as it will affect the security of IMA
 ima_excludelist = exclude.txt
 
-# specify the acceptable crypto algorithms to use with the TPM for this agent. 
-# only algorithms specified below will be allowed for usage by an agent.  if a 
-# agent uses an algorithm not specified here, it will fail validation 
+# specify the acceptable crypto algorithms to use with the TPM for this agent.
+# only algorithms specified below will be allowed for usage by an agent.  if a
+# agent uses an algorithm not specified here, it will fail validation
 #
 # currently accepted values include:
 # hashing: sha512, sha384, sha256 and sha1
 # encryption: ecc and rsa
 # signing: rsassa, rsapss, ecdsa, ecdaa and ecschnorr
 #
-# NOTE: the TPM 1.2 standard only supports sha1 hashing, rsa encryption and 
-# rsassa signing protocols, therefore these are required for agents with 
-# TPM 1.2 being used 
+# NOTE: the TPM 1.2 standard only supports sha1 hashing, rsa encryption and
+# rsassa signing protocols, therefore these are required for agents with
+# TPM 1.2 being used
 accept_tpm_hash_algs = sha512,sha384,sha256,sha1
 accept_tpm_encryption_algs = ecc,rsa
 accept_tpm_signing_algs = ecschnorr,rsassa
@@ -309,8 +309,8 @@ max_retries = 10
 # MUST use the ek_check_script option below to specify a script that will
 # check the provided EK against a whitelist for the environment that has
 # been collected in a trustworthy way.  For example, the cloud provider
-# might provide a signed list of EK public key hashes.  Then you could write 
-# an ek_check_script that checks the signature of the whitelist and then 
+# might provide a signed list of EK public key hashes.  Then you could write
+# an ek_check_script that checks the signature of the whitelist and then
 # compares the hash of the given EK with the whistlist
 require_ek_cert = True
 
@@ -318,7 +318,7 @@ require_ek_cert = True
 # whitelist or any other additional EK processing you want to do. Runs in
 # /var/lib/keylime. You call also specify an absolute path to the script.
 # script should return 0 if the EK or EK certificate are valid.  Any other
-# return value will invalidate the tenant quote check and prevent 
+# return value will invalidate the tenant quote check and prevent
 # bootstrapping a key.
 #
 # The various keys are passed to the script via environment variables:
@@ -339,13 +339,13 @@ ek_check_script=
 # Registrar TLS options.  This is for authenticating the registrar to clients
 # who want to query AIKs
 #
-# tls_dir option sets directory in /var/lib/keylime/ to put CA certificates 
-# and files for TLS.  
+# tls_dir option sets directory in /var/lib/keylime/ to put CA certificates
+# and files for TLS.
 # set to "generate" to automatically generate a CA/certificates in dir reg_ca
 # if you specify generate, you can manage the CA that the verifier will create
-# using keylime_ca -d /var/lib/keylime/reg_ca/ 
-# 
-# set to "CV" to share the CA with the cloud verifier (which must be run first 
+# using keylime_ca -d /var/lib/keylime/reg_ca/
+#
+# set to "CV" to share the CA with the cloud verifier (which must be run first
 # once before starting the registrar so it can generate the keys)
 tls_dir = CV
 
@@ -353,28 +353,28 @@ tls_dir = CV
 ca_cert = default
 
 # the filename (in tls_dir) of the registrar certificate and private key
-# the following two options also take the string "default" to find a files 
-# with names <fully_qualified_name>-cert.crt and 
+# the following two options also take the string "default" to find a files
+# with names <fully_qualified_name>-cert.crt and
 # <fully_qualified_name>-public.pem for cert and private key respectively
 my_cert = default
 private_key = default
 
-# set the password to decrypt the private key file.  this should be set to a 
+# set the password to decrypt the private key file.  this should be set to a
 # strong password
-# if tls_dir=generate, this password will also be used to protect the 
+# if tls_dir=generate, this password will also be used to protect the
 # generated CA private key
 private_key_pw = default
 
-# Registrar client TLS options.  this allows the registrar to authenticate the 
+# Registrar client TLS options.  this allows the registrar to authenticate the
 # provider registrar before asking for AIKs
 # this option sets the directory where the CA certificate for the provider
 # registrar can be found
 # use "default" to use 'reg_ca' (this points it to the directory automatically
 # created by the registrar if it is set to "generate"
-# use "CV" to use 'cv_ca', the directory automatically created (and shared 
+# use "CV" to use 'cv_ca', the directory automatically created (and shared
 # with the registar) by the CV
 registrar_tls_dir = CV
-# the following three options set the filenames in tls_dir where the CA 
+# the following three options set the filenames in tls_dir where the CA
 # certificate, client certificate, and client private key file are
 # if tls_dir = default, then default values will be used for ca_cert =
 # cacert.pem, my_cert = client-cert.crt, and private_key = client-private.pem
@@ -382,7 +382,7 @@ registrar_ca_cert = default
 registrar_my_cert = default
 registrar_private_key = default
 
-# set the password to decrypt the private key file.  this should be set to a 
+# set the password to decrypt the private key file.  this should be set to a
 # strong password
 # if you are using the auto generated keys from the CV, set the same password
 # here as you did for private_key_pw in the [cloud_verifier] section
@@ -397,7 +397,7 @@ prov_db_filename = provider_reg_data.sqlite
 #=============================================================================
 [ca]
 #=============================================================================
-# These options set the metadata into the certificates that the keylime_ca 
+# These options set the metadata into the certificates that the keylime_ca
 # utility will use when creating certificates and CAs.
 # These options are also used by the verifier and registrar when using the
 # tls_dir=generate option
@@ -413,20 +413,20 @@ cert_lifetime=365
 cert_bits=2048
 
 # this setting allows you to specify where your CRL will be hosted
-# insert the relevant URL 
+# insert the relevant URL
 # use "default" to use the tenant machine FQDN as the CRL distribution point.
-# use "default" with caution as it will use the result python's 
-# socket.getfqdn() as the hostname.  This may not be a properly resolvable 
+# use "default" with caution as it will use the result python's
+# socket.getfqdn() as the hostname.  This may not be a properly resolvable
 # DNS name.  in which case you need to specify a hostname where you will
 # run the revocation listener (see below)
-# 
+#
 # you can then use keylime_ca -c listen -n ca/RevocationNotifier-cert.crt
 cert_crl_dist=http://localhost:38080/crl
 
 #=============================================================================
 # GLOBAL LOGGING CONFIGURATION
 #=============================================================================
-# the only thing really to change here is the default log levels for either 
+# the only thing really to change here is the default log levels for either
 # console or keylime loggers
 
 [loggers]
@@ -455,4 +455,4 @@ args = (sys.stdout,)
 [logger_keylime]
 level = INFO
 qualname = keylime
-handlers = 
+handlers =

--- a/patches/cfsslconf-patch.txt
+++ b/patches/cfsslconf-patch.txt
@@ -6,8 +6,8 @@ index c643e6b..5c731d2 100644
  # valid options are 'cfssl' or 'openssl'  For cfssl to work, you must have the
  # go binary installed in your path or in /usr/local/
  # revocation list generation is only supported by cfssl
--ca_implementation = cfssl
-+ca_implementation = openssl
+-ca_implementation = openssl
++ca_implementation = cfssl
  
  #=============================================================================
  [cloud_agent]


### PR DESCRIPTION
This change switches the default to openssl.

The idea is that openssl is a rudimentary implementation that
works out of the box with no additional installation steps
required.

This is not to suggest in anyway that cfssl is a second class
citizen, just more that openssl is a better default for testing
and base installations. Should someone want to use CFSSL they
can then perform the installation afterwards.

Another benefit to openssl, is that Keylime can then be deployed
on an air-gapped machine with no need to retrieve anything from
the internet (everything else is in packages now so can be served
by a mirror)

Last of all #145  is the future and CA's will be a pluggable
framework

Also cleaned up some white space.

Resolves: #173