### PR TITLE
Set standard shebang and only for exec files

### DIFF
--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.

--- a/keylime/cloud_agent.py
+++ b/keylime/cloud_agent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.
 

--- a/keylime/httpclient_requests.py
+++ b/keylime/httpclient_requests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import http.client
 
 def request(method, url, port, params=None, data=None,context=None):

--- a/keylime/ima_emulator_adapter.py
+++ b/keylime/ima_emulator_adapter.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.
 

--- a/keylime/provider_platform_init.py
+++ b/keylime/provider_platform_init.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.
 

--- a/keylime/provider_registrar.py
+++ b/keylime/provider_registrar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.

--- a/keylime/provider_vtpm_add.py
+++ b/keylime/provider_vtpm_add.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.

--- a/keylime/registrar.py
+++ b/keylime/registrar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.
 

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.
 

--- a/keylime/secure_mount.py
+++ b/keylime/secure_mount.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.
 

--- a/keylime/serve_uuid.py
+++ b/keylime/serve_uuid.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.
 

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 '''DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.
 This material is based upon work supported by the Assistant Secretary of Defense for

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.

--- a/keylime/tpm_obj.py
+++ b/keylime/tpm_obj.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.
 

--- a/keylime/user_data_encrypt.py
+++ b/keylime/user_data_encrypt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.

--- a/keylime/vtpm_manager.py
+++ b/keylime/vtpm_manager.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.
 


### PR DESCRIPTION
This change seeks to set a common shebang for files that are
executable only (e.g. set as entry_points in setup.py)

It is needed to pass `rpmlint` and allow package acceptence
upstream

Resolves: #175