### PR TITLE
Systemd changes

### DIFF
--- a/services/installer.sh
+++ b/services/installer.sh
@@ -17,9 +17,9 @@ fi
 echo "Using keylime scripts directory: ${KEYLIMEDIR}"
 
 # prepare keylime service files and store them in systemd path
-sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" $BASEDIR/keylime_agent.service.example > /etc/systemd/system/keylime_agent.service
-sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" $BASEDIR/keylime_registrar.service.example > /etc/systemd/system/keylime_registrar.service
-sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" $BASEDIR/keylime_verifier.service.example > /etc/systemd/system/keylime_verifier.service
+sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" $BASEDIR/keylime_agent.service.template > /etc/systemd/system/keylime_agent.service
+sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" $BASEDIR/keylime_registrar.service.template > /etc/systemd/system/keylime_registrar.service
+sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" $BASEDIR/keylime_verifier.service.template > /etc/systemd/system/keylime_verifier.service
 
 # set permissions
 chmod 664 /etc/systemd/system/keylime_agent.service

--- a/services/keylime_agent.service
+++ b/services/keylime_agent.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=The Keylime compute agent
+
+[Service]
+ExecStart=/usr/bin/keylime_agent
+
+[Install]
+WantedBy=default.target

--- a/services/keylime_agent.service.example
+++ b/services/keylime_agent.service.example
@@ -1,9 +1,0 @@
-[Unit]
-Wants=keylime_verifier.service keylime_registrar.service
-After=network.target keylime_verifier.service keylime_registrar.service
-
-[Service]
-ExecStart=KEYLIMEDIR/keylime_agent
-
-[Install]
-WantedBy=default.target

--- a/services/keylime_agent.service.template
+++ b/services/keylime_agent.service.template
@@ -1,0 +1,8 @@
+[Unit]
+Description=The Keylime compute agent
+
+[Service]
+ExecStart=KEYLIMEDIR/keylime_agent
+
+[Install]
+WantedBy=default.target

--- a/services/keylime_registrar.service
+++ b/services/keylime_registrar.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=The Keylime registrar service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/keylime_registrar
+
+[Install]
+WantedBy=default.target

--- a/services/keylime_registrar.service.template
+++ b/services/keylime_registrar.service.template
@@ -1,6 +1,6 @@
 [Unit]
-Wants=keylime_verifier.service
-After=network.target keylime_verifier.service
+Description=The Keylime registrar service
+After=network.target
 
 [Service]
 ExecStart=KEYLIMEDIR/keylime_registrar

--- a/services/keylime_verifier.service
+++ b/services/keylime_verifier.service
@@ -2,7 +2,7 @@
 After=network.target
 
 [Service]
-ExecStart=KEYLIMEDIR/keylime_verifier
+ExecStart=/usr/bin/keylime_verifier
 
 [Install]
 WantedBy=default.target

--- a/services/keylime_verifier.service.template
+++ b/services/keylime_verifier.service.template
@@ -1,0 +1,9 @@
+[Unit]
+Description=The Keylime verifier service
+After=network.target
+
+[Service]
+ExecStart=KEYLIMEDIR/keylime_verifier
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This allows standard naming (required for packaging) and also
renames .examples to .templates (so the installer script can still
be used).

It also removes the Unit dependencies which should not be there.
Any of the three services should not need a reliance on others (as
they could be installed on entirely different hosts)