### PR TITLE
Fixes revocation events signature format

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -383,7 +383,6 @@ def notifyError(agent, msgtype='revocation'):
         # print "verified? %s"%crypto.rsa_verify(signing_key, tosend['signature'], tosend['revocation'])
     else:
         tosend['siganture'] = "none"
-
     revocation_notifier.notify(tosend)
 
 # ===== sqlite stuff =====

--- a/keylime/crypto.py
+++ b/keylime/crypto.py
@@ -26,9 +26,10 @@ import secrets
 
 # Crypto implementation using python cryptography package
 from cryptography import exceptions
+from cryptography import x509
 import cryptography.hazmat.primitives.asymmetric
-from cryptography.hazmat.primitives.ciphers import ( Cipher, algorithms, modes )
-from cryptography.hazmat.primitives import (hashes,serialization )
+from cryptography.hazmat.primitives.ciphers import (Cipher, algorithms, modes)
+from cryptography.hazmat.primitives import (hashes, serialization)
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.backends import default_backend
@@ -36,23 +37,31 @@ from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
 
 aes_block_size = 16
 
+
 def rsa_import_pubkey(pubkey):
     """Import a public key
     We try / except this, as its possible that `pubkey` can arrive as either str or bytes.
     """
     try:
-        return serialization.load_pem_public_key(pubkey,backend=default_backend())
+        return serialization.load_pem_public_key(pubkey, backend=default_backend())
     except:
-        return serialization.load_pem_public_key(pubkey.encode('utf-8'),backend=default_backend())
+        return serialization.load_pem_public_key(pubkey.encode('utf-8'), backend=default_backend())
+
 
 def rsa_import_privkey(privkey):
     """Import a private key
     We try / except this, as its possible that `privkey` can arrive as either str or bytes.
     """
     try:
-        return serialization.load_pem_private_key(privkey,password=None,backend=default_backend())
+        return serialization.load_pem_private_key(privkey, password=None, backend=default_backend())
     except:
-        return serialization.load_pem_private_key(privkey.encode('utf-8'),password=None,backend=default_backend())
+        return serialization.load_pem_private_key(privkey.encode('utf-8'), password=None, backend=default_backend())
+
+
+def x509_import_pubkey(pubkey):
+    key = x509.load_pem_x509_certificate(
+        pubkey.encode('utf-8'),  backend=default_backend())
+    return key.public_key()
 
 
 def rsa_generate(size):
@@ -61,7 +70,7 @@ def rsa_generate(size):
         65537,
         size,
         default_backend()
-        )
+    )
     return private_key
 
 
@@ -78,21 +87,22 @@ def rsa_sign(key, message):
         padding.PSS(
             mgf=padding.MGF1(hashes.SHA256()),
             salt_length=padding.PSS.MAX_LENGTH
-            ),
-            hashes.SHA256()
-        )
-    return signature
+        ),
+        hashes.SHA256()
+    )
+    return base64.b64encode(signature)
+
 
 def rsa_verify(public_key, message, signature):
     """ RSA verify message  """
     verifier = public_key.verifier(
-            signature,
-            padding.PSS(
-                mgf=padding.MGF1(hashes.SHA256()),
-                salt_length=padding.PSS.MAX_LENGTH
-            ),
-            hashes.SHA256()
-        )
+        base64.b64decode(signature),
+        padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()),
+            salt_length=padding.PSS.MAX_LENGTH
+        ),
+        hashes.SHA256()
+    )
     verifier.update(message)
     try:
         verifier.verify()
@@ -105,35 +115,40 @@ def rsa_verify(public_key, message, signature):
 
 def rsa_export_pubkey(private_key):
     """ export public key  """
-    return private_key.public_key().public_bytes(encoding=serialization.Encoding.PEM,format=serialization.PublicFormat.SubjectPublicKeyInfo)
+    return private_key.public_key().public_bytes(encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo)
+
 
 def rsa_export_privkey(private_key):
     """ export private key  """
-    return private_key.private_bytes(encoding=serialization.Encoding.PEM,format=serialization.PrivateFormat.TraditionalOpenSSL,encryption_algorithm=serialization.NoEncryption())
+    return private_key.private_bytes(encoding=serialization.Encoding.PEM, format=serialization.PrivateFormat.TraditionalOpenSSL, encryption_algorithm=serialization.NoEncryption())
 
-def rsa_encrypt(key,message):
+
+def rsa_encrypt(key, message):
     """ RSA encrypt message  """
     return key.encrypt(bytes(message),
                        cryptography.hazmat.primitives.asymmetric.padding.OAEP(mgf=cryptography.hazmat.primitives.asymmetric.padding.MGF1(algorithm=hashes.SHA1()),
-                                    algorithm=hashes.SHA1(),
-                                    label=None))
+                                                                              algorithm=hashes.SHA1(),
+                                                                              label=None))
 
-def rsa_decrypt(key,ciphertext):
+
+def rsa_decrypt(key, ciphertext):
     """ RSA decrypt message  """
-    return key.decrypt(ciphertext,cryptography.hazmat.primitives.asymmetric.padding.OAEP(mgf=cryptography.hazmat.primitives.asymmetric.padding.MGF1(algorithm=hashes.SHA1()),
-                                               algorithm=hashes.SHA1(),
-                                               label=None))
+    return key.decrypt(ciphertext, cryptography.hazmat.primitives.asymmetric.padding.OAEP(mgf=cryptography.hazmat.primitives.asymmetric.padding.MGF1(algorithm=hashes.SHA1()),
+                                                                                          algorithm=hashes.SHA1(),
+                                                                                          label=None))
 
 
 def get_random_bytes(size):
     """ Generate random bytes  """
     return secrets.token_bytes(size)
 
+
 def generate_random_key(size=32):
     """ Generate random key using urandom wrapper  """
     return os.urandom(size)
 
-def strbitxor(a,b):
+
+def strbitxor(a, b):
     a = bytearray(a)
     b = bytearray(b)
     retval = bytearray(len(b))
@@ -141,11 +156,14 @@ def strbitxor(a,b):
         retval[i] = a[i] ^ b[i]
     return bytes(retval)
 
-def kdf(password,salt):
-    mykdf = PBKDF2HMAC(algorithm=hashes.SHA256(),length=32,salt=bytes(salt, encoding='utf8'),iterations=100000,backend=default_backend())
+
+def kdf(password, salt):
+    mykdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=bytes(
+        salt, encoding='utf8'), iterations=100000, backend=default_backend())
     return mykdf.derive(password.encode('utf-8'))
 
-def do_hmac(key,value):
+
+def do_hmac(key, value):
     """ Generate HMAC  """
     h = hmac.new(key, msg=None, digestmod=hashlib.sha384)
     h.update(value.encode('utf-8'))
@@ -159,6 +177,7 @@ def _is_multiple_16(s):
     if not (len(s) % 16) == 0:
         raise Exception("Ciphertext was not a multiple of 16 in length")
 
+
 def _has_iv_material(s):
     """
     Make sure enough material for IV in ciphertext
@@ -166,18 +185,22 @@ def _has_iv_material(s):
     if len(s) < aes_block_size:
         raise Exception("Ciphertext did not contain enough material for an IV")
 
+
 def encrypt(plaintext, key):
     """ Encrypt object """
     if plaintext is None:
         plaintext = b''
     iv = generate_random_key(aes_block_size)
-    encryptor = Cipher(algorithms.AES(key), modes.GCM(iv), backend=default_backend()).encryptor()
+    encryptor = Cipher(algorithms.AES(key), modes.GCM(
+        iv), backend=default_backend()).encryptor()
     # The following try/except captures both str and bytes
     try:
-        cipher_text = encryptor.update(plaintext.encode('ascii')) + encryptor.finalize()
+        cipher_text = encryptor.update(
+            plaintext.encode('ascii')) + encryptor.finalize()
     except:
         cipher_text = encryptor.update(plaintext) + encryptor.finalize()
     return base64.b64encode(iv+cipher_text+encryptor.tag)
+
 
 def decrypt(ciphertext, key):
     """ Decrypt object """
@@ -190,5 +213,3 @@ def decrypt(ciphertext, key):
                        modes.GCM(iv, tag),
                        backend=default_backend()).decryptor()
     return decryptor.update(ciphertext) + decryptor.finalize()
-
-

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -44,6 +44,7 @@ config.read(common.CONFIG_FILE)
 
 broker_proc = None
 
+
 def start_broker():
     def worker():
         context = zmq.Context(1)
@@ -54,7 +55,8 @@ def start_broker():
 
         # Socket facing services
         backend = context.socket(zmq.PUB)
-        backend.bind("tcp://*:%s"%config.getint('general','revocation_notifier_port'))
+        backend.bind("tcp://*:%s" %
+                     config.getint('general', 'revocation_notifier_port'))
 
         zmq.device(zmq.FORWARDER, frontend, backend)
 
@@ -66,7 +68,8 @@ def start_broker():
 def stop_broker():
     global broker_proc
     if broker_proc is not None:
-        os.kill(broker_proc.pid,signal.SIGKILL)
+        os.kill(broker_proc.pid, signal.SIGKILL)
+
 
 def notify(tosend):
     def worker(tosend):
@@ -76,22 +79,25 @@ def notify(tosend):
         # wait 100ms for connect to happen
         time.sleep(0.2)
         # now send it out vi 0mq
-        for i in range(config.getint('cloud_verifier','max_retries')):
+        for i in range(config.getint('cloud_verifier', 'max_retries')):
             try:
                 mysock.send_string(json.dumps(tosend))
                 break
             except Exception as e:
-                logger.debug("Unable to publish revocation message %d times, trying again in %f seconds: %s"%(i,config.getfloat('cloud_verifier','retry_interval'),e))
-                time.sleep(config.getfloat('cloud_verifier','retry_interval'))
+                logger.debug("Unable to publish revocation message %d times, trying again in %f seconds: %s" % (
+                    i, config.getfloat('cloud_verifier', 'retry_interval'), e))
+                time.sleep(config.getfloat('cloud_verifier', 'retry_interval'))
         mysock.close()
 
-    cb = functools.partial(worker,tosend)
+    cb = functools.partial(worker, tosend)
     t = threading.Thread(target=cb)
     t.start()
 
-cert_key=None
 
-def await_notifications(callback,revocation_cert_path):
+cert_key = None
+
+
+def await_notifications(callback, revocation_cert_path):
     global cert_key
 
     if revocation_cert_path is None:
@@ -100,32 +106,38 @@ def await_notifications(callback,revocation_cert_path):
     context = zmq.Context()
     mysock = context.socket(zmq.SUB)
     mysock.setsockopt(zmq.SUBSCRIBE, b'')
-    mysock.connect("tcp://%s:%s"%(config.get('general','revocation_notifier_ip'),config.getint('general','revocation_notifier_port')))
+    mysock.connect("tcp://%s:%s" % (config.get('general', 'revocation_notifier_ip'),
+                                    config.getint('general', 'revocation_notifier_port')))
 
-    logger.info('Waiting for revocation messages on 0mq %s:%s'%
-                (config.get('general','revocation_notifier_ip'),config.getint('general','revocation_notifier_port')))
+    logger.info('Waiting for revocation messages on 0mq %s:%s' %
+                (config.get('general', 'revocation_notifier_ip'), config.getint('general', 'revocation_notifier_port')))
 
     while True:
         rawbody = mysock.recv()
         body = json.loads(rawbody)
+
         if cert_key is None:
             # load up the CV signing public key
             if revocation_cert_path is not None and os.path.exists(revocation_cert_path):
-                logger.info("Lazy loading the revocation certificate from %s"%revocation_cert_path)
-                with open(revocation_cert_path,'r') as f:
+                logger.info(
+                    "Lazy loading the revocation certificate from %s" % revocation_cert_path)
+                with open(revocation_cert_path, 'r') as f:
                     certpem = f.read()
-                cert_key = crypto.rsa_import_pubkey(certpem)
+                cert_key = crypto.x509_import_pubkey(certpem)
 
         if cert_key is None:
-            logger.warning("Unable to check signature of revocation message: %s not available"%revocation_cert_path)
-        elif 'signature' not in body or body['signature']=='none':
+            logger.warning(
+                "Unable to check signature of revocation message: %s not available" % revocation_cert_path)
+        elif 'signature' not in body or body['signature'] == 'none':
             logger.warning("No signature on revocation message from server")
-        elif not crypto.rsa_verify(cert_key,body['msg'].encode('utf-8'),body['signature'].encode('utf-8')):
-            logger.error("Invalid revocation message siganture %s"%body)
+        elif not crypto.rsa_verify(cert_key, body['msg'].encode('utf-8'), body['signature'].encode('utf-8')):
+            logger.error("Invalid revocation message siganture %s" % body)
         else:
             message = json.loads(body['msg'])
-            logger.debug("Revocation signature validated for revocation: %s"%message)
+            logger.debug(
+                "Revocation signature validated for revocation: %s" % message)
             callback(message)
+
 
 def main():
     start_broker()
@@ -134,14 +146,15 @@ def main():
 
     def worker():
         def print_notification(revocation):
-            logger.warning("Received revocation: %s"%revocation)
+            logger.warning("Received revocation: %s" % revocation)
 
-        keypath = '%s/unzipped/RevocationNotifier-cert.crt'%(secure_mount.mount())
-        await_notifications(print_notification,revocation_cert_path=keypath)
+        keypath = '%s/unzipped/RevocationNotifier-cert.crt' % (
+            secure_mount.mount())
+        await_notifications(print_notification, revocation_cert_path=keypath)
 
     t = threading.Thread(target=worker)
     t.start()
-    #time.sleep(0.5)
+    # time.sleep(0.5)
 
     json_body2 = {
         'v': 'vbaby',
@@ -154,7 +167,7 @@ def main():
         'ima_whitelist': '{}',
         'revocation_key': '',
         'revocation': '{"cert_serial":"1"}',
-        }
+    }
 
     print("sending notification")
     notify(json_body2)
@@ -166,5 +179,6 @@ def main():
     sys.exit(0)
     print("done")
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Revocation events are currently failing (silently) as they cannot
be parsed by `json.dumps`

This is an artefact from the Python 3 port.

Resolves: #220