### PR TITLE
Log that a revocation event is being sent

### DIFF
--- a/keylime/cloud_agent.py
+++ b/keylime/cloud_agent.py
@@ -590,7 +590,7 @@ def main(argv=sys.argv):
                         sys.path.append(uzpath)
 
             for action in actionlist:
-                logger.debug("executing revocation action %s"%action)
+                logger.info("executing revocation action %s"%action)
                 try:
                     module = importlib.import_module(action)
                     execute = getattr(module,'execute')

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -79,6 +79,7 @@ def notify(tosend):
         # wait 100ms for connect to happen
         time.sleep(0.2)
         # now send it out vi 0mq
+        logger.info("Sending revocation event to listening nodes..")
         for i in range(config.getint('cloud_verifier', 'max_retries')):
             try:
                 mysock.send_string(json.dumps(tosend))


### PR DESCRIPTION
Currently we do not provide any notification that a revocation event is being sent.

This line adds a simple logger entry to inform the user.