### PR TITLE
Added agent UUID in verifier IMA log message

### DIFF
--- a/keylime/cloud_agent.py
+++ b/keylime/cloud_agent.py
@@ -590,7 +590,7 @@ def main(argv=sys.argv):
                         sys.path.append(uzpath)
 
             for action in actionlist:
-                logger.debug("executing revocation action %s"%action)
+                logger.info("executing revocation action %s"%action)
                 try:
                     module = importlib.import_module(action)
                     execute = getattr(module,'execute')

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -240,7 +240,8 @@ def process_quote_response(agent, json_response):
             "TPM Quote is using an unaccepted signing algorithm: %s" % sign_alg)
 
     if tpm.is_deep_quote(quote):
-        validQuote = tpm.check_deep_quote(agent['nonce'],
+        validQuote = tpm.check_deep_quote(agent['agent_id'],
+                                          agent['nonce'],
                                           received_public_key,
                                           quote,
                                           agent['registrar_keys']['aik'],
@@ -250,7 +251,8 @@ def process_quote_response(agent, json_response):
                                           ima_measurement_list,
                                           agent['ima_whitelist'])
     else:
-        validQuote = tpm.check_quote(agent['nonce'],
+        validQuote = tpm.check_quote(agent['agent_id'],
+                                     agent['nonce'],
                                      received_public_key,
                                      quote,
                                      agent['registrar_keys']['aik'],

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -329,11 +329,12 @@ class UnprotectedHandler(BaseHTTPRequestHandler):
                 provider_keys = registrar_client.getKeys(config.get('general', 'provider_registrar_ip'), config.get('general', 'provider_registrar_tls_port'), agent_id)
                 # we already have the vaik
                 tpm = tpm_obj.getTPM(need_hw_tpm=False,tpm_version=agent['tpm_version'])
-                if not tpm.check_deep_quote(hashlib.sha1(agent['key']).hexdigest(),
-                                                  agent_id+agent['aik']+agent['ek'],
-                                                  deepquote,
-                                                  agent['aik'],
-                                                  provider_keys['aik']):
+                if not tpm.check_deep_quote(agent_id,
+                                            hashlib.sha1(agent['key']).hexdigest(),
+                                            agent_id+agent['aik']+agent['ek'],
+                                            deepquote,
+                                            agent['aik'],
+                                            provider_keys['aik']):
                     raise Exception("Deep quote invalid")
 
                 self.server.db.update_agent(agent_id, 'active',True)

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -79,6 +79,7 @@ def notify(tosend):
         # wait 100ms for connect to happen
         time.sleep(0.2)
         # now send it out vi 0mq
+        logger.info("Sending revocation event to listening nodes..")
         for i in range(config.getint('cloud_verifier', 'max_retries')):
             try:
                 mysock.send_string(json.dumps(tosend))

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -396,7 +396,7 @@ class Tenant():
             return False
 
         tpm = tpm_obj.getTPM(need_hw_tpm=False,tpm_version=tpm_version)
-        if not tpm.check_quote(self.nonce,public_key,quote,reg_keys['aik'],hash_alg=hash_alg):
+        if not tpm.check_quote(self.agent_uuid,self.nonce,public_key,quote,reg_keys['aik'],hash_alg=hash_alg):
             if reg_keys['regcount'] > 1:
                 logger.error("WARNING: This UUID had more than one ek-ekcert registered to it!  This might indicate that your system is misconfigured or a malicious host is present.  Run 'regdelete' for this agent and restart")
                 exit()

--- a/keylime/tpm1.py
+++ b/keylime/tpm1.py
@@ -664,7 +664,7 @@ class tpm1(tpm_abstract.AbstractTPM):
         retDict = self.__run(cmd,lock=False)
         return retDict['retout']
 
-    def check_deep_quote(self,nonce,data,quote,vAIK,hAIK,vtpm_policy={},tpm_policy={},ima_measurement_list=None,ima_whitelist={}):
+    def check_deep_quote(self,agent_id,nonce,data,quote,vAIK,hAIK,vtpm_policy={},tpm_policy={},ima_measurement_list=None,ima_whitelist={}):
         quoteFile=None
         vAIKFile=None
         hAIKFile=None
@@ -732,7 +732,8 @@ class tpm1(tpm_abstract.AbstractTPM):
                 pcrs.append(line)
 
         # don't pass in data to check pcrs for physical quote
-        return self.check_pcrs(tpm_policy,pcrs,None,False,None,None) and self.check_pcrs(vtpm_policy, vpcrs, data, True,ima_measurement_list,ima_whitelist)
+        return self.check_pcrs(agent_id,tpm_policy,pcrs,None,False,None,None) and \
+            self.check_pcrs(agent_id,vtpm_policy, vpcrs, data, True,ima_measurement_list,ima_whitelist)
 
     def __check_quote_c(self, aikFile, quoteFile, extData):
         os.putenv('TPM_SERVER_PORT', '9999')
@@ -758,7 +759,7 @@ class tpm1(tpm_abstract.AbstractTPM):
             retDict = self.__run("checkquote -aik %s -quote %s -nonce %s"%(aikFile, quoteFile, extData),lock=False)
             return retDict['retout']
 
-    def check_quote(self,nonce,data,quote,aikFromRegistrar,tpm_policy={},ima_measurement_list=None,ima_whitelist={},hash_alg=None):
+    def check_quote(self,agent_id,nonce,data,quote,aikFromRegistrar,tpm_policy={},ima_measurement_list=None,ima_whitelist={},hash_alg=None):
         quoteFile=None
         aikFile=None
 
@@ -810,7 +811,7 @@ class tpm1(tpm_abstract.AbstractTPM):
             if pcrs is not None:
                 pcrs.append(line.decode('utf-8'))
 
-        return self.check_pcrs(tpm_policy,pcrs,data,False,ima_measurement_list,ima_whitelist)
+        return self.check_pcrs(agent_id,tpm_policy,pcrs,data,False,ima_measurement_list,ima_whitelist)
 
     def extendPCR(self,pcrval,hashval,hash_alg=None,lock=True):
         if hash_alg is None:

--- a/keylime/tpm2.py
+++ b/keylime/tpm2.py
@@ -111,7 +111,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         errout = ''.join(common.list_convert(retDict['reterr']))
         if code != tpm_abstract.AbstractTPM.EXIT_SUCESS:
             raise Exception("Error establishing tpm2-tools version using TPM2_Startup: %s"+str(code)+": "+str(errout))
-        
+
         # Extract the `version="x.x.x"` from tools
         version_str = re.search(r'version="([^"]+)"', output).group(1)
         # Extract the full semver release number.
@@ -879,7 +879,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             raise Exception("get_tpm_manufacturer failed with code "+str(code)+": "+str(reterr))
 
         # Clean up TPM manufacturer information (strip control characters)
-        # These strings are supposed to be printable ASCII characters, but 
+        # These strings are supposed to be printable ASCII characters, but
         # some TPM manufacturers put control characters in here
         for i, s in enumerate(output):
             output[i] = re.sub(r"[\x01-\x1F\x7F]", "", s.decode('utf-8')).encode('utf-8')
@@ -992,7 +992,7 @@ class tpm2(tpm_abstract.AbstractTPM):
     def __checkdeepquote_c(self, hAIK, vAIK, deepquoteFile, nonce):
         raise Exception("vTPM support and deep quotes not yet implemented with TPM 2.0!")
 
-    def check_deep_quote(self, nonce, data, quote, vAIK, hAIK, vtpm_policy={}, tpm_policy={}, ima_measurement_list=None, ima_whitelist={}):
+    def check_deep_quote(self, agent_id, nonce, data, quote, vAIK, hAIK, vtpm_policy={}, tpm_policy={}, ima_measurement_list=None, ima_whitelist={}):
         raise Exception("vTPM support and deep quotes not yet implemented with TPM 2.0!")
 
     def __check_quote_c(self, pubaik, nonce, quoteFile, sigFile, pcrFile, hash_alg):
@@ -1021,7 +1021,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         retDict = self.__run(command.format(**cmdargs), lock=False)
         return retDict
 
-    def check_quote(self, nonce, data, quote, aikFromRegistrar, tpm_policy={}, ima_measurement_list=None, ima_whitelist={}, hash_alg=None):
+    def check_quote(self, agent_id, nonce, data, quote, aikFromRegistrar, tpm_policy={}, ima_measurement_list=None, ima_whitelist={}, hash_alg=None):
         if hash_alg is None:
             hash_alg = self.defaults['hash']
 
@@ -1110,7 +1110,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         if len(pcrs) == 0:
             pcrs = None
 
-        return self.check_pcrs(tpm_policy, pcrs, data, False, ima_measurement_list, ima_whitelist)
+        return self.check_pcrs(agent_id, tpm_policy, pcrs, data, False, ima_measurement_list, ima_whitelist)
 
     def extendPCR(self, pcrval, hashval, hash_alg=None, lock=True):
         if hash_alg is None:

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -576,7 +576,8 @@ class TestRestful(unittest.TestCase):
         self.assertIn("pubkey", json_response["results"], "Malformed response body!")
 
         # Check the quote identity
-        self.assertTrue(tpm.check_quote(nonce,json_response["results"]["pubkey"],json_response["results"]["quote"],aik), "Invalid quote!")
+        self.assertTrue(tpm.check_quote(tenant_templ.agent_uuid,nonce,json_response["results"]["pubkey"],json_response["results"]["quote"],aik),
+                        "Invalid quote!")
 
     @unittest.skip("Testing of agent's POST /v2/keys/vkey disabled!  (spawned CV should do this already)")
 
@@ -748,7 +749,8 @@ class TestRestful(unittest.TestCase):
         tpm_version = json_response["results"]["tpm_version"]
         hash_alg = json_response["results"]["hash_alg"]
 
-        validQuote = tpm.check_quote(nonce,
+        validQuote = tpm.check_quote(tenant_templ.agent_uuid,
+                                            nonce,
                                             public_key,
                                             quote,
                                             aik,


### PR DESCRIPTION
Currently, when several agents are polled from the verifier the same
message is printed for each of them. This is ambiguous for the user,
as it provides no info to the user. This change will add agent UUID
in a log message to distinguish between more than one agent.

Resolves: #230