### PR TITLE
Added code to fallback agent port to configparser set value

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -156,9 +156,9 @@ class Tenant():
         if "agent_ip" in args:
             self.cloudagent_ip = args["agent_ip"]
 
-        if "agent_port" in args:
-            self.cloudagent_port = args["agent_port"]
-
+        if 'agent_port' in args and args['agent_port'] is not None:
+            self.cloudagent_port = args['agent_port']
+            
         if 'cv_agent_ip' in args and args['cv_agent_ip'] is not None:
             self.cv_cloudagent_ip = args['cv_agent_ip']
         else:


### PR DESCRIPTION
Currently, not providing agent port in keylime tenant instantiation
results in a crash. This code change adds fallback to configparser
set value if the port is not provided in the command line.

Resolves: #235