### PR TITLE
Implements Kernel TPM Resource Manager

### DIFF
--- a/.ci/test_wrapper.sh
+++ b/.ci/test_wrapper.sh
@@ -8,17 +8,7 @@ chmod +x init_tpm_server
 chmod +x tpm_serverd
 install -c tpm_serverd /usr/local/bin/tpm_serverd
 install -c init_tpm_server /usr/local/bin/init_tpm_server
-# Server needs to be running, or tpm2-abrmd.service will fail.
 /usr/local/bin/tpm_serverd
-
-export TPM2TOOLS_TCTI="tabrmd:bus_name=com.intel.tss2.Tabrmd"
-pkill -HUP dbus-daemon
-
-# Configure tpm2-abrmd systemd
-sed -i 's/.*ExecStart.*/ExecStart=\/usr\/sbin\/tpm2-abrmd --tcti=mssim/' /usr/lib/systemd/system/tpm2-abrmd.service
-systemctl daemon-reload
-systemctl enable tpm2-abrmd
-systemctl start tpm2-abrmd
 
 # Run tests
 cd ${KEYLIME_HOME}/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - tpm12image: lukehinds/keylime-ci-tpm12
       tpm12tag: v500
     - tpm20image: lukehinds/keylime-ci-tpm20
-      tpm20tag: v501
+      tpm20tag: v550
 
 services:
   - docker
@@ -31,7 +31,7 @@ before_install:
 
 script:
     # Run TPM 2.0 Tests
-  - docker run --detach --privileged -v $(pwd):/root/keylime -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${tpm20image}:${tpm20tag} > ${container_id}
+  - docker run --detach --privileged -e TPM2TOOLS_TCTI="mssim:host=localhost,port=2321" -v $(pwd):/root/keylime ${tpm20image}:${tpm20tag} > ${container_id}
   - docker exec -u 0 -it --tty "$(cat ${container_id})" /bin/bash /root/keylime/.ci/test_wrapper.sh
     # Run TPM 1.2 Tests
   - >

--- a/docker/Dockerfile-tpm20
+++ b/docker/Dockerfile-tpm20
@@ -5,9 +5,9 @@
 # It is not recommended for use beyond testing scenarios.
 ##############################################################################
 
-FROM fedora:30
+FROM fedora:31
 MAINTAINER Luke Hinds <lhinds@redhat.com>
-LABEL version="5.0.1" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
+LABEL version="5.5.0" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
 
 ENV container docker
 # environment variables
@@ -38,7 +38,6 @@ RUN dnf -y install git \
            libtool \
            tpm2-tss \
            tpm2-tools \
-           tpm2-abrmd \
            gcc \
            make \
            automake \
@@ -53,21 +52,6 @@ RUN dnf -y install git \
 
 RUN dnf clean all
 
-RUN cd "/lib/systemd/system/sysinit.target.wants/"; \
-    for i in *; do [ $i = systemd-tmpfiles-setup.service ] || rm -f "$i"; done
-
-RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
-    /etc/systemd/system/*.wants/* \
-    /lib/systemd/system/local-fs.target.wants/* \
-    /lib/systemd/system/sockets.target.wants/*udev* \
-    /lib/systemd/system/sockets.target.wants/*initctl* \
-    /lib/systemd/system/basic.target.wants/* \
-    /lib/systemd/system/anaconda.target.wants/*
-
-RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
-
-
 # Build and install TPM 2.0 simulator
 WORKDIR ${TPM_HOME}
 RUN wget --content-disposition http://sourceforge.net/projects/ibmswtpm2/files/ibmtpm1119.tar.gz/download
@@ -75,7 +59,3 @@ RUN tar -zxvf ibmtpm1119.tar.gz
 WORKDIR ${TPM_HOME}/src
 RUN make
 RUN install -c tpm_server /usr/local/bin/tpm_server
-
-VOLUME [ "/sys/fs/cgroup" ]
-
-ENTRYPOINT ["/lib/systemd/systemd"]


### PR DESCRIPTION
Use the TPM Kernerl resource manager, instead of tpm2-abrmd

This allows us to test in a container without having to use systemd
for the dbus requirements of tpm2-abrmd

Resolves: #258