### PR TITLE
Added config for bump2version and fixed version across project

### DIFF
--- a/.bump2version.cfg
+++ b/.bump2version.cfg
@@ -1,0 +1,15 @@
+[bumpversion]
+current_version 5.5.0
+commit = False
+tag = False
+serialize = 
+    {major}.{minor}.{patch}
+
+
+[bumpversion:file:setup.py]
+serach = 'Development Status :: {current_version} - Beta'
+replace = 'Development Status :: {new_version} - Beta'
+
+[bumpversion:file:./docker/Dockerfile*]
+search = LABEL version="{current_version}" description="Keylime - Bootstrapping and Maintaining Trust"
+replace = LABEL version="{new_version}" description="Keylime - Bootstrapping and Maintaining Trust"

--- a/docker/Dockerfile-tpm12
+++ b/docker/Dockerfile-tpm12
@@ -7,7 +7,7 @@
 
 FROM fedora:30
 MAINTAINER Luke Hinds <lhinds@redhat.com>
-LABEL version="5.0.0" description="Keylime - Bootstrapping and Maintaining Trust"
+LABEL version="5.5.0" description="Keylime - Bootstrapping and Maintaining Trust"
 
 # environment variables
 ARG BRANCH=master

--- a/docker/Dockerfile-tpm20
+++ b/docker/Dockerfile-tpm20
@@ -7,7 +7,7 @@
 
 FROM fedora:30
 MAINTAINER Luke Hinds <lhinds@redhat.com>
-LABEL version="5.0.1" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
+LABEL version="5.5.0" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
 
 ENV container docker
 # environment variables

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2',
+    version='5.5.0',
 
     description='TPM-based key bootstrapping and system integrity measurement system for cloud',
     long_description=long_description,
@@ -74,8 +74,7 @@ setup(
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
-        'Development Status :: 5.3.1 - Beta',
-
+        'Development Status :: 4 - Beta',
         # Indicate who your project is intended for
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',


### PR DESCRIPTION
solves #158. Added a config for `bump2version` which can be installed through `pip`

It can be used as follows `bump2version --current-version 5.5.0 minor setup.py docker/*`
Replacing minor with major or patch will autoincrement accordingly. It can also be setup to tag and commit as well. I have it set to false right now but I can switch that if wanted. 

https://github.com/bu3alwa/keylime/blob/c3f6937d59ba3897f11704232b26037176749be8/setup.py#L77
Also, is the project considered in beta still? If not I can move the classifier to production instead.

Also if I missed someplace else where version is set please let me know.