### PR TITLE
Fixes incompatibility between keylime and tpm2-tools >= 4.2

### DIFF
--- a/keylime/tpm2.py
+++ b/keylime/tpm2.py
@@ -136,7 +136,7 @@ class tpm2(tpm_abstract.AbstractTPM):
 
         if tools_version == "3.2":
             retDict = self.__run("tpm2_getcap -c algorithms")
-        elif tools_version == "4.0" or tools_version == "4.2" :
+        elif tools_version in ["4.0", "4.2"]:
             retDict = self.__run("tpm2_getcap algorithms")
 
         output = common.list_convert(retDict['retout'])
@@ -388,7 +388,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             logger.info("Flushing old ek handle: %s"%hex(current_handle))
             if tools_version == "3.2":
                 retDict = self.__run("tpm2_getcap -c handles-persistent", raiseOnError=False)
-            elif tools_version == "4.0" or tools_version == "4.2":
+            elif tools_version in ["4.0", "4.2"]:
                 retDict = self.__run("tpm2_getcap handles-persistent", raiseOnError=False)
             output = retDict['retout']
             reterr = retDict['reterr']
@@ -469,7 +469,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         if tools_version == "3.2":
             retDict = self.__run("tpm2_takeownership -c", raiseOnError=False)
             retDict = self.__run("tpm2_takeownership -o %s -e %s"%(owner_pw, owner_pw), raiseOnError=False)
-        elif tools_version == "4.0" or tools_version == "4.2" :
+        elif tools_version in ["4.0", "4.2"]:
             retDict = self.__run("tpm2_changeauth -c o %s"%(owner_pw), raiseOnError=False)
             retDict = self.__run("tpm2_changeauth -c e %s"%(owner_pw), raiseOnError=False)
 
@@ -479,7 +479,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             # if we fail, see if already owned with this pw
             if tools_version == "3.2":
                 retDict = self.__run("tpm2_takeownership -o %s -e %s -O %s -E %s"%(owner_pw, owner_pw, owner_pw, owner_pw), raiseOnError=False)
-            elif tools_version == "4.0" or tools_version == "4.2" :
+            elif tools_version in ["4.0", "4.2"]:
                 retDict = self.__run("tpm2_changeauth -c o -p %s %s"%(owner_pw, owner_pw), raiseOnError=False)
                 retDict = self.__run("tpm2_changeauth -c e -p %s %s"%(owner_pw, owner_pw), raiseOnError=False)
 
@@ -564,7 +564,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             if tools_version == "3.2":
                 logger.info("Flushing old ak handle: %s"%hex(aik_handle))
                 retDict = self.__run("tpm2_getcap -c handles-persistent", raiseOnError=False)
-            elif tools_version == "4.0" or tools_version == "4.2" :
+            elif tools_version in ["4.0", "4.2"]:
                 logger.info("Flushing old ak handle: %s"%aik_handle)
                 retDict = self.__run("tpm2_getcap handles-persistent", raiseOnError=False)
             output = common.list_convert(retDict['retout'])
@@ -594,7 +594,7 @@ class tpm2(tpm_abstract.AbstractTPM):
                 if code != tpm_abstract.AbstractTPM.EXIT_SUCESS:
                     if tools_version == "3.2":
                         logger.info("Failed to flush old ak handle: %s.  Code %s"%(hex(aik_handle), str(code)+": "+str(reterr)))
-                    elif tools_version == "4.0" or tools_version == "4.2" :
+                    elif tools_version in ["4.0", "4.2"]:
                         logger.info("Failed to flush old ak handle: %s.  Code %s"%(aik_handle, str(code)+": "+str(reterr)))
 
                 self._set_tpm_metadata('aik', None)
@@ -613,7 +613,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         #make a temp file for the output
         with tempfile.NamedTemporaryFile() as akpubfile:
             secpath = ""
-            if tools_version == "4.0" or tools_version == "4.2" :
+            if tools_version in ["4.0", "4.2"]:
                 # ok lets write out the key now
                 secdir = secure_mount.mount() # confirm that storage is still securely mounted
                 secfd, secpath = tempfile.mkstemp(dir=secdir)
@@ -631,7 +631,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             }
             if tools_version == "3.2":
                 command = "tpm2_getpubak -E {ekhandle} -k 0x81010008 -g {asymalg} -D {hashalg} -s {signalg} -f {akpubfile} -e {epw} -P {apw} -o {opw}".format(**cmdargs)
-            elif tools_version == "4.0" or tools_version == "4.2" :
+            elif tools_version in ["4.0", "4.2"]:
                 command = "tpm2_createak -C {ekhandle} -c {aksession} -G {asymalg} -g {hashalg} -s {signalg} -u {akpubfile} -f pem -p {apw} -P {epw}".format(**cmdargs)
             retDict = self.__run(command, outputpaths=akpubfile.name)
             retout = retDict['retout']
@@ -674,7 +674,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         logger.debug("Flushing keys from TPM...")
         if tools_version == "3.2":
                 retDict = self.__run("tpm2_getcap -c handles-persistent")
-        elif tools_version == "4.0" or tools_version == "4.2" :
+        elif tools_version in ["4.0", "4.2"]:
                 retDict = self.__run("tpm2_getcap handles-persistent")
         # retout = retDict['retout']
         retout = common.list_convert(retDict['retout'])
@@ -875,7 +875,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         vendorStr = None
         if tools_version == "3.2":
             retDict = self.__run("tpm2_getcap -c properties-fixed")
-        elif tools_version == "4.0" or tools_version == "4.2" :
+        elif tools_version in ["4.0", "4.2"]:
             retDict = self.__run("tpm2_getcap properties-fixed")
         output = retDict['retout']
         reterr = retDict['reterr']
@@ -1143,7 +1143,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             hash_alg = self.defaults['hash']
         if tools_version == "3.2":
             output = common.list_convert(self.__run("tpm2_pcrlist")['retout'])
-        elif tools_version == "4.0" or tools_version == "4.2" :
+        elif tools_version in ["4.0", "4.2"]:
             output = common.list_convert(self.__run("tpm2_pcrread")['retout'])
 
         jsonout = common.yaml_to_dict(output)
@@ -1200,7 +1200,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             # Check for RSA EK cert in NVRAM (and get length)
             if tools_version == "3.2":
                 retDict = self.__run("tpm2_nvlist", raiseOnError=False)
-            elif tools_version == "4.0" or tools_version == "4.2" :
+            elif tools_version in ["4.0", "4.2"]:
                 retDict = self.__run("tpm2_nvreadpublic", raiseOnError=False)
             output = retDict['retout']
             reterr = retDict['reterr']
@@ -1209,7 +1209,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             if code != tpm_abstract.AbstractTPM.EXIT_SUCESS:
                 if tools_version == "3.2":
                     raise Exception("tpm2_nvlist for ekcert failed with code "+str(code)+": "+str(reterr))
-                elif tools_version == "4.0" or tools_version == "4.2" :
+                elif tools_version in ["4.0", "4.2"]:
                     raise Exception("tpm2_nvreadpublic for ekcert failed with code "+str(code)+": "+str(reterr))
 
             outjson = common.yaml_to_dict(output)
@@ -1223,7 +1223,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             # Read the RSA EK cert from NVRAM (DER format)
             if tools_version == "3.2":
                 retDict = self.__run("tpm2_nvread -x 0x1c00002 -s %s -f %s -a 0x01c00002"%(ekcert_size, nvpath.name), raiseOnError=False, outputpaths=nvpath.name)
-            elif tools_version == "4.0" or tools_version == "4.2" :
+            elif tools_version in ["4.0", "4.2"]:
                 retDict = self.__run("tpm2_nvread 0x1c00002 -s %s -o %s"%(ekcert_size, nvpath.name), raiseOnError=False, outputpaths=nvpath.name)
             output = common.list_convert(retDict['retout'])
             errout = common.list_convert(retDict['reterr'])

--- a/keylime/tpm2.py
+++ b/keylime/tpm2.py
@@ -118,7 +118,10 @@ class tpm2(tpm_abstract.AbstractTPM):
         # Extract the full semver release number.
         tools_version = version_str.split("-")
 
-        if StrictVersion(tools_version[0]) >= StrictVersion("4.0.0"):
+        if StrictVersion(tools_version[0]) >= StrictVersion("4.2"):
+            logger.info(f"TPM2-TOOLS Version: {tools_version[0]}")
+            tools_version = "4.2"
+        elif StrictVersion(tools_version[0]) >= StrictVersion("4.0.0"):
             logger.info(f"TPM2-TOOLS Version: {tools_version[0]}")
             tools_version = "4.0"
         elif StrictVersion(tools_version[0]) >= StrictVersion("3.2.0"):
@@ -133,7 +136,7 @@ class tpm2(tpm_abstract.AbstractTPM):
 
         if tools_version == "3.2":
             retDict = self.__run("tpm2_getcap -c algorithms")
-        elif tools_version == "4.0":
+        elif tools_version == "4.0" or tools_version == "4.2" :
             retDict = self.__run("tpm2_getcap algorithms")
 
         output = common.list_convert(retDict['retout'])
@@ -385,7 +388,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             logger.info("Flushing old ek handle: %s"%hex(current_handle))
             if tools_version == "3.2":
                 retDict = self.__run("tpm2_getcap -c handles-persistent", raiseOnError=False)
-            elif tools_version == "4.0":
+            elif tools_version == "4.0" or tools_version == "4.2":
                 retDict = self.__run("tpm2_getcap handles-persistent", raiseOnError=False)
             output = retDict['retout']
             reterr = retDict['reterr']
@@ -429,6 +432,8 @@ class tpm2(tpm_abstract.AbstractTPM):
                 command = "tpm2_getpubek -H 0x81010007 -g {asymalg} -f {ekpubfile} -P {ekpw} -o {opw} -e {epw}".format(**cmdargs)
             elif tools_version == "4.0":
                 command = "tpm2_createek -c - -G {asymalg} -u {ekpubfile} -p {ekpw} -w {opw} -P {epw}".format(**cmdargs)
+            elif tools_version == "4.2":
+                command = "tpm2_createek -c - -G {asymalg} -u {ekpubfile} -w {opw} -P {epw}".format(**cmdargs)
             retDict = self.__run(command, raiseOnError=False, outputpaths=tmppath.name)
             output = retDict['retout']
             reterr = retDict['reterr']
@@ -464,7 +469,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         if tools_version == "3.2":
             retDict = self.__run("tpm2_takeownership -c", raiseOnError=False)
             retDict = self.__run("tpm2_takeownership -o %s -e %s"%(owner_pw, owner_pw), raiseOnError=False)
-        elif tools_version == "4.0":
+        elif tools_version == "4.0" or tools_version == "4.2" :
             retDict = self.__run("tpm2_changeauth -c o %s"%(owner_pw), raiseOnError=False)
             retDict = self.__run("tpm2_changeauth -c e %s"%(owner_pw), raiseOnError=False)
 
@@ -474,7 +479,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             # if we fail, see if already owned with this pw
             if tools_version == "3.2":
                 retDict = self.__run("tpm2_takeownership -o %s -e %s -O %s -E %s"%(owner_pw, owner_pw, owner_pw, owner_pw), raiseOnError=False)
-            elif tools_version == "4.0":
+            elif tools_version == "4.0" or tools_version == "4.2" :
                 retDict = self.__run("tpm2_changeauth -c o -p %s %s"%(owner_pw, owner_pw), raiseOnError=False)
                 retDict = self.__run("tpm2_changeauth -c e -p %s %s"%(owner_pw, owner_pw), raiseOnError=False)
 
@@ -559,7 +564,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             if tools_version == "3.2":
                 logger.info("Flushing old ak handle: %s"%hex(aik_handle))
                 retDict = self.__run("tpm2_getcap -c handles-persistent", raiseOnError=False)
-            elif tools_version == "4.0":
+            elif tools_version == "4.0" or tools_version == "4.2" :
                 logger.info("Flushing old ak handle: %s"%aik_handle)
                 retDict = self.__run("tpm2_getcap handles-persistent", raiseOnError=False)
             output = common.list_convert(retDict['retout'])
@@ -589,7 +594,7 @@ class tpm2(tpm_abstract.AbstractTPM):
                 if code != tpm_abstract.AbstractTPM.EXIT_SUCESS:
                     if tools_version == "3.2":
                         logger.info("Failed to flush old ak handle: %s.  Code %s"%(hex(aik_handle), str(code)+": "+str(reterr)))
-                    elif tools_version == "4.0":
+                    elif tools_version == "4.0" or tools_version == "4.2" :
                         logger.info("Failed to flush old ak handle: %s.  Code %s"%(aik_handle, str(code)+": "+str(reterr)))
 
                 self._set_tpm_metadata('aik', None)
@@ -608,7 +613,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         #make a temp file for the output
         with tempfile.NamedTemporaryFile() as akpubfile:
             secpath = ""
-            if tools_version == "4.0":
+            if tools_version == "4.0" or tools_version == "4.2" :
                 # ok lets write out the key now
                 secdir = secure_mount.mount() # confirm that storage is still securely mounted
                 secfd, secpath = tempfile.mkstemp(dir=secdir)
@@ -626,7 +631,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             }
             if tools_version == "3.2":
                 command = "tpm2_getpubak -E {ekhandle} -k 0x81010008 -g {asymalg} -D {hashalg} -s {signalg} -f {akpubfile} -e {epw} -P {apw} -o {opw}".format(**cmdargs)
-            elif tools_version == "4.0":
+            elif tools_version == "4.0" or tools_version == "4.2" :
                 command = "tpm2_createak -C {ekhandle} -c {aksession} -G {asymalg} -g {hashalg} -s {signalg} -u {akpubfile} -f pem -p {apw} -P {epw}".format(**cmdargs)
             retDict = self.__run(command, outputpaths=akpubfile.name)
             retout = retDict['retout']
@@ -669,7 +674,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         logger.debug("Flushing keys from TPM...")
         if tools_version == "3.2":
                 retDict = self.__run("tpm2_getcap -c handles-persistent")
-        elif tools_version == "4.0":
+        elif tools_version == "4.0" or tools_version == "4.2" :
                 retDict = self.__run("tpm2_getcap handles-persistent")
         # retout = retDict['retout']
         retout = common.list_convert(retDict['retout'])
@@ -870,7 +875,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         vendorStr = None
         if tools_version == "3.2":
             retDict = self.__run("tpm2_getcap -c properties-fixed")
-        elif tools_version == "4.0":
+        elif tools_version == "4.0" or tools_version == "4.2" :
             retDict = self.__run("tpm2_getcap properties-fixed")
         output = retDict['retout']
         reterr = retDict['reterr']
@@ -1138,7 +1143,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             hash_alg = self.defaults['hash']
         if tools_version == "3.2":
             output = common.list_convert(self.__run("tpm2_pcrlist")['retout'])
-        elif tools_version == "4.0":
+        elif tools_version == "4.0" or tools_version == "4.2" :
             output = common.list_convert(self.__run("tpm2_pcrread")['retout'])
 
         jsonout = common.yaml_to_dict(output)
@@ -1195,7 +1200,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             # Check for RSA EK cert in NVRAM (and get length)
             if tools_version == "3.2":
                 retDict = self.__run("tpm2_nvlist", raiseOnError=False)
-            elif tools_version == "4.0":
+            elif tools_version == "4.0" or tools_version == "4.2" :
                 retDict = self.__run("tpm2_nvreadpublic", raiseOnError=False)
             output = retDict['retout']
             reterr = retDict['reterr']
@@ -1204,7 +1209,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             if code != tpm_abstract.AbstractTPM.EXIT_SUCESS:
                 if tools_version == "3.2":
                     raise Exception("tpm2_nvlist for ekcert failed with code "+str(code)+": "+str(reterr))
-                elif tools_version == "4.0":
+                elif tools_version == "4.0" or tools_version == "4.2" :
                     raise Exception("tpm2_nvreadpublic for ekcert failed with code "+str(code)+": "+str(reterr))
 
             outjson = common.yaml_to_dict(output)
@@ -1218,7 +1223,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             # Read the RSA EK cert from NVRAM (DER format)
             if tools_version == "3.2":
                 retDict = self.__run("tpm2_nvread -x 0x1c00002 -s %s -f %s -a 0x01c00002"%(ekcert_size, nvpath.name), raiseOnError=False, outputpaths=nvpath.name)
-            elif tools_version == "4.0":
+            elif tools_version == "4.0" or tools_version == "4.2" :
                 retDict = self.__run("tpm2_nvread 0x1c00002 -s %s -o %s"%(ekcert_size, nvpath.name), raiseOnError=False, outputpaths=nvpath.name)
             output = common.list_convert(retDict['retout'])
             errout = common.list_convert(retDict['reterr'])
@@ -1236,6 +1241,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             retDict = self.__run("tpm2_nvread -x 0x1500018 -a 0x40000001 -s %s -P %s"%(common.BOOTSTRAP_KEY_SIZE, owner_pw), raiseOnError=False)
         else:
             retDict = self.__run("tpm2_nvread 0x1500018 -C 0x40000001 -s %s -P %s"%(common.BOOTSTRAP_KEY_SIZE, owner_pw), raiseOnError=False)
+
         output = retDict['retout']
         errout = common.list_convert(retDict['reterr'])
         code = retDict['code']
@@ -1245,6 +1251,9 @@ class tpm2(tpm_abstract.AbstractTPM):
                 logger.debug("No stored U in TPM NVRAM")
                 return None
             elif len(errout) > 0 and "ERROR: Failed to read NVRAM public area at index" in "\n".join(errout):
+                logger.debug("No stored U in TPM NVRAM")
+                return None
+            elif len(errout) > 0 and "the handle is not correct for the use" in "\n".join(errout):
                 logger.debug("No stored U in TPM NVRAM")
                 return None
             else:


### PR DESCRIPTION
This commit implements a fix for the keylime_agent when used with a more
recent (03/2020) version of tpm2-tools. At this point, this commit makes
the minimal amount of changes required to have keylime operational, by
simply defining a new "version point" (4.2) and adding the appropriate
conditionals in the multiple if-elif-else statements. Moving forward, a
cleaner refactoring (e.g. using a "command vs tpm2-tools version"
dictionary) looks like a more robust solution in the long term.

Resolves: #272