### PR TITLE
[trivial] Add NVChip to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,5 @@ docs/_build/
 swtpm2_scripts/NVChip
 test/.auditing-*
 test/NVChip
+NVChip
 test/testdata.sqlite


### PR DESCRIPTION
The NVChip file is created also on the root repo dir when running
tests.