### PR TITLE
Reduce size of docker image for tpm20 tests

### DIFF
--- a/docker/Dockerfile-tpm20
+++ b/docker/Dockerfile-tpm20
@@ -9,50 +9,50 @@ FROM fedora:30
 MAINTAINER Luke Hinds <lhinds@redhat.com>
 LABEL version="5.5.1" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
 
-ENV container docker
 # environment variables
 ARG BRANCH=master
-
 ENV container docker
 ENV HOME /root
 ENV KEYLIME_HOME ${HOME}/keylime
 ENV TPM_HOME ${HOME}/swtpm2
 
 # Packaged dependencies
-RUN dnf -y update
-RUN dnf -y install dnf-plugins-core --allowerasing
-RUN dnf -y install git \
-           dbus-devel \
-           openssl-devel \
-           python3-devel \
-           python3-pip \
-           python3-setuptools \
-           python3-tornado \
-           python3-virtualenv \
-           python3-zmq \
-           python3-yaml \
-           python3-dbus \
-           python3-m2crypto \
-           python3-cryptography \
-           python3-sqlalchemy \
-           procps \
-           libtool \
-           tpm2-tss \
-           tpm2-tools \
-           tpm2-abrmd \
-           gcc \
-           make \
-           automake \
-           redhat-rpm-config \
-           libselinux-python3 \
-           gnulib \
-           glib2-devel \
-           glib2-static \
-           uthash-devel \
-           wget \
-           which
+ENV PKGS_DEPS="automake \
+dbus-devel \
+dnf-plugins-core \
+gcc \
+git \
+glib2-devel \
+glib2-static \
+gnulib \
+libselinux-python3 \
+libtool \
+make \
+openssl-devel \
+procps \
+python3-cryptography \
+python3-dbus \
+python3-devel \
+python3-m2crypto \
+python3-pip \
+python3-setuptools \
+python3-sqlalchemy \
+python3-tornado \
+python3-virtualenv \
+python3-yaml \
+python3-zmq \
+redhat-rpm-config \
+tpm2-abrmd \
+tpm2-tools \
+tpm2-tss \
+uthash-devel \
+wget \
+which"
 
-RUN dnf clean all
+RUN dnf makecache && \
+  dnf -y install $PKGS_DEPS && \
+  dnf clean all && \
+  rm -rf /var/cache/dnf/*
 
 RUN cd "/lib/systemd/system/sysinit.target.wants/"; \
     for i in *; do [ $i = systemd-tmpfiles-setup.service ] || rm -f "$i"; done
@@ -68,14 +68,13 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
 RUN systemctl set-default multi-user.target
 ENV init /lib/systemd/systemd
 
-
 # Build and install TPM 2.0 simulator
 WORKDIR ${TPM_HOME}
-RUN wget --content-disposition http://sourceforge.net/projects/ibmswtpm2/files/ibmtpm1119.tar.gz/download
-RUN tar -zxvf ibmtpm1119.tar.gz
+RUN wget --content-disposition http://sourceforge.net/projects/ibmswtpm2/files/ibmtpm1119.tar.gz/download && \
+  tar -zxvf ibmtpm1119.tar.gz
 WORKDIR ${TPM_HOME}/src
-RUN make
-RUN install -c tpm_server /usr/local/bin/tpm_server
+RUN make && \
+  install -c tpm_server /usr/local/bin/tpm_server
 
 VOLUME [ "/sys/fs/cgroup" ]
 


### PR DESCRIPTION
Some improvements to reduce the final size of the image:
Using a list of packages for dependencies
Aggregating some RUN commands
Initializing dnf cache
Removing dnf cache

Also removed duplicate ENV container docker entry

The total size save is around 300MB