### PR TITLE
Separate setup config from setup code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ var/
 .installed.cfg
 *.egg
 MANIFEST
+AUTHORS
+ChangeLog
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -146,18 +146,16 @@ Keylime requires Python 3.6.
 
 #### Python-based prerequisites
 
-The following python packages are required:
+The list of Python packages needed to install keylime can be found in
+ [requirements.txt](https://github.com/keylime/keylime/tree/master/requirements.txt)
 
-* cryptography
-* tornado>=5.0.2
-* m2crypto>=0.21.1
-* pyzmq>=14.4
-* setuptools>=0.7
-* python-dev
-* pyyaml
-
-The latter of these are usually available as distro packages. See [installer.sh](https://github.com/keylime/keylime/blob/master/installer.sh) for more information if you want to install them this way.
-You can also let keylime's `setup.py` install them via PyPI.
+Some of them are usually available as distro packages.
+See [installer.sh](https://github.com/keylime/keylime/blob/master/installer.sh)
+ for more information if you want to install them this way.
+You can also install them using pip:
+```bash
+python3 -m pip install -r requirements.txt
+```
 
 #### TPM utility prerequisites
 
@@ -292,7 +290,7 @@ To talk directly to a real TPM: `export TPM2TOOLS_TCTI="device:/dev/tpm0"`
 
 You're finally ready to install keylime!
 ```bash
-sudo python setup.py install
+sudo python3 -m pip install . -r requirements.txt
 ```
 
 #### To run on OSX 10.11+

--- a/installer.sh
+++ b/installer.sh
@@ -595,7 +595,7 @@ cd $KEYLIME_DIR
 if [[ "$NEED_PYTHON_DIR" -eq "1" ]] ; then
     mkdir -p /usr/local/lib/python3.6/site-packages/
 fi
-python3 setup.py install
+python3 -m pip install . -r requirements.txt
 
 if [[ -f "/etc/keylime.conf" ]] ; then
     if [[ $(diff -N "/etc/keylime.conf" "keylime.conf") ]] ; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+cryptography>=2.1.4 # BSD/Apache-2.0
+tornado>=5.0.2 # Apache-2.0
+m2crypto>=0.21.1 # MIT
+pyzmq>=14.4 # LGPL+BSD
+pyyaml>=3.11 # MIT
+simplejson>=3.8 # MIT
+requests>=2.6 # Apache-2.0
+sqlalchemy>=1.3 # MIT

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,45 @@
+[metadata]
+name = keylime
+summary =
+    TPM-based key bootstrapping and system integrity measurement system for cloud
+description-file =
+    README.md
+author = MIT Lincoln Laboratory
+author-email = nabil@ll.mit.edu
+home-page = https://github.com/keylime/keylime
+python-requires = >=3.6
+classifier =
+    Environment :: Console
+    Intended Audience :: Developers
+    Intended Audience :: Information Technology
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: BSD License
+    Operating System :: POSIX :: Linux
+    Programming Language :: Python
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Topic :: System :: Hardware
+
+[files]
+data_files =
+    etc =
+        keylime.conf
+packages =
+    keylime
+
+[entry_points]
+console_scripts =
+    keylime_verifier = keylime.cloud_verifier_tornado:main
+    keylime_agent = keylime.cloud_agent:main
+    keylime_tenant = keylime.tenant:main
+    keylime_userdata_encrypt = keylime.user_data_encrypt:main
+    keylime_registrar = keylime.registrar:main
+    keylime_provider_registrar = keylime.provider_registrar:main
+    keylime_provider_platform_init = keylime.provider_platform_init:main
+    keylime_provider_vtpm_add = keylime.provider_vtpm_add:main
+    keylime_ca = keylime.ca_util:main
+    keylime_ima_emulator = keylime.ima_emulator_adapter:main
+    keylime_webapp = keylime.tenant_webapp:main

--- a/setup.py
+++ b/setup.py
@@ -1,153 +1,44 @@
-'''
+"""
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.
 
-This material is based upon work supported by the Assistant Secretary of Defense for
-Research and Engineering under Air Force Contract No. FA8721-05-C-0002 and/or
-FA8702-15-D-0001. Any opinions, findings, conclusions or recommendations expressed in this
-material are those of the author(s) and do not necessarily reflect the views of the
-Assistant Secretary of Defense for Research and Engineering.
+This material is based upon work supported by the Assistant Secretary of
+Defense for Research and Engineering under Air Force Contract No.
+FA8721-05-C-0002 and/or FA8702-15-D-0001.
+Any opinions, findings, conclusions or recommendations expressed in this
+material are those of the author(s) and do not necessarily reflect the
+views of the Assistant Secretary of Defense for Research and Engineering.
 
 Copyright 2015 Massachusetts Institute of Technology.
 
 The software/firmware is provided to you on an As-Is basis
 
 Delivered to the US Government with Unlimited Rights, as defined in DFARS Part
-252.227-7013 or 7014 (Feb 2014). Notwithstanding any copyright notice, U.S. Government
-rights in this work are defined by DFARS 252.227-7013 or DFARS 252.227-7014 as detailed
-above. Use of this work other than as specifically authorized by the U.S. Government may
-violate any copyrights that exist in this work.
-'''
+252.227-7013 or 7014 (Feb 2014). Notwithstanding any copyright notice, U.S.
+Government rights in this work are defined by DFARS 252.227-7013 or
+DFARS 252.227-7014 as detailed above.
+Use of this work other than as specifically authorized by the U.S. Government
+may violate any copyrights that exist in this work.
+"""
 
-
-# Always prefer setuptools over distutils
-from setuptools import setup, find_packages, Extension
-# To use a consistent encoding
-from codecs import open
-from os import path
-from os import walk
+import setuptools
+from setuptools import Extension
 import sys
 
-here = path.abspath(path.dirname(__file__))
-
-# Get the long description from the relevant file
-with open(path.join(here, 'DESCRIPTION.md'), encoding='utf-8') as f:
-    long_description = f.read()
-
-# cLime only builds against glibc at the moment. If we ever want to change this
-# it shouldn't be too hard.
 extensions = []
+
 if '--with-clime' in sys.argv:
     if 'linux' in sys.platform:
-        extensions.append(Extension('_cLime',
-                                    define_macros=[('MAJOR_VERSION', '1'),
-                                                   ('MINOR_VERSION', '0')],
-                                    include_dirs=['/usr/local/include'],
-                                    libraries=['tpm', 'keylime'],
-                                    library_dirs=['/usr/local/lib'],
-                                    runtime_library_dirs=['/usr/local/lib'],
-                                    sources=['keylime/_cLime.c']))
+        extensions.append(
+            Extension('_cLime', ['keylime/_cLime.c'],
+                      define_macros=[('MAJOR_VERSION', '1'),
+                                     ('MINOR_VERSION', '0')],
+                      include_dirs=['/usr/local/include'],
+                      libraries=['tpm', 'keylime'],
+                      library_dirs=['/usr/local/lib'],
+                      runtime_library_dirs=['/usr/local/lib']))
     sys.argv.remove('--with-clime')
 
-# enumerate all of the data files we need to package up
-data_files = [('/etc', ['keylime.conf'])]
-
-setup(
-    name='keylime',
-
-    # Versions should comply with PEP440.  For a discussion on single-sourcing
-    # the version across setup.py and the project code, see
-    # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2',
-
-    description='TPM-based key bootstrapping and system integrity measurement system for cloud',
-    long_description=long_description,
-
-    # The project's main homepage.
-    url='https://github.com/keylime/keylime',
-
-    # Author details
-    author='MIT Lincoln Laboratory',
-    author_email='nabil@ll.mit.edu',
-
-    # Choose your license
-    license='BSD-2-Clause',
-
-    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    classifiers=[
-        'Development Status :: 5.3.1 - Beta',
-
-        # Indicate who your project is intended for
-        'Intended Audience :: Developers',
-        'Intended Audience :: System Administrators',
-
-        # where does it run
-        'Environment :: Console',
-        'Operating System :: POSIX',
-        'Operating System :: POSIX :: Linux',
-
-        # Pick your license as you wish (should match "license" above)
-        'License :: OSI Approved :: BSD License',
-
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 3.7',
-    ],
-
-    # What does your project relate to?
-    keywords='tpm cloud cloud-init tls',
-
-    # You can just specify the packages manually here if your project is
-    # simple. Or you can use find_packages().
-    packages=['keylime'],
-    package_data={'keylime': ['static/*/*', 'static/*/*/*']},
-
-    # List run-time dependencies here.  These will be installed by pip when
-    # your project is installed. For an analysis of "install_requires" vs pip's
-    # requirements files see:
-    # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['cryptography>=2.1.4', 'tornado>=5.0.2', 'm2crypto>=0.21.1',
-        'pyzmq>=14.4', 'pyyaml>=3.11', 'simplejson>=3.8', 'requests>=2.6', 'sqlalchemy>=1.3'],
-
-    # test packages required
-    tests_require=['green', 'coverage'],
-
-    # List additional groups of dependencies here (e.g. development
-    # dependencies). You can install these using the following syntax,
-    # for example:
-    # $ pip install -e .[dev,test]
-    # extras_require={
-    #    'dev': ['check-manifest'],
-    #    'test': ['coverage'],
-    # },
-
-    # If there are data files included in your packages that need to be
-    # installed, specify them here.  If using Python 2.6 or less, then these
-    # have to be included in MANIFEST.in as well.
-
-    # Although 'package_data' is the preferred approach, in some case you may
-    # need to place data files outside of your packages. See:
-    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
-    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    data_files=data_files,
-
-    # To provide executable scripts, use entry points in preference to the
-    # "scripts" keyword. Entry points provide cross-platform support and allow
-    # pip to create the appropriate form of executable for the target platform.
-    entry_points={
-        'console_scripts': [
-            'keylime_verifier=keylime.cloud_verifier_tornado:main',
-            'keylime_agent=keylime.cloud_agent:main',
-            'keylime_tenant=keylime.tenant:main',
-            'keylime_userdata_encrypt=keylime.user_data_encrypt:main',
-            'keylime_registrar=keylime.registrar:main',
-            'keylime_provider_registrar=keylime.provider_registrar:main',
-            'keylime_provider_platform_init=keylime.provider_platform_init:main',
-            'keylime_provider_vtpm_add=keylime.provider_vtpm_add:main',
-            'keylime_ca=keylime.ca_util:main',
-            'keylime_ima_emulator=keylime.ima_emulator_adapter:main',
-            'keylime_webapp=keylime.tenant_webapp:main',
-        ],
-    },
-
-    ext_modules=extensions
-)
+setuptools.setup(
+    setup_requires=['pbr'],
+    pbr=True,
+    ext_modules=extensions)

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -187,7 +187,7 @@ echo "==========================================================================
 echo $'\t\t\tInstalling Keylime'
 echo "=================================================================================="
 cd $KEYLIME_DIR
-python3 setup.py install
+python3 -m pip install . -r requirements.txt
 
 # Run the tests as necessary
 if [[ "$COVERAGE" -eq "1" ]] ; then


### PR DESCRIPTION
Use a setup.cfg file to ease managing setup configuration and add
a requirements file to simplify tracking dependencies, leaving
setup.py to take care of the simple setup execution.
Also start using pbr to manage versions.