### PR TITLE
Remove the need for systemd-udev in container

### DIFF
--- a/.ci/run_local.sh
+++ b/.ci/run_local.sh
@@ -9,7 +9,7 @@ REPO=${KEYLIME_REPO_PATH:-${1:-/home/${USER}/keylime}}
 tpm12image="lukehinds/keylime-ci-tpm12"
 tpm12tag="v500"
 tpm20image="lukehinds/keylime-ci-tpm20"
-tpm20tag="v552"
+tpm20tag="v101"
 
 echo -e "Grabbing latest images"
 

--- a/.ci/test_wrapper.sh
+++ b/.ci/test_wrapper.sh
@@ -16,18 +16,14 @@ export TPM2TOOLS_TCTI="tabrmd:bus_name=com.intel.tss2.Tabrmd"
 pkill -HUP dbus-daemon
 
 # Configure tpm2-abrmd systemd
+# systemd-udev-settle is not needed to run tpm2-tools in container
+sed -i 's/^After/#&/' /usr/lib/systemd/system/tpm2-abrmd.service
+sed -i 's/^Requires/#&/' /usr/lib/systemd/system/tpm2-abrmd.service
+# the tpm device is not needed to run tpm2-tools in container with the
+# tpm emulator
 sed -i 's/^ConditionPathExists/#&/' /usr/lib/systemd/system/tpm2-abrmd.service
 sed -i 's/.*ExecStart.*/ExecStart=\/usr\/sbin\/tpm2-abrmd --tcti=mssim/' /usr/lib/systemd/system/tpm2-abrmd.service
 systemctl daemon-reload
-# Check that system-udev-settle is present or tpm2-abrmd will fail
-systemctl start systemd-udev-settle.service
-sleep 1
-while true; do
-    if (systemctl -q is-active systemd-udev-settle.service); then
-        break
-    fi
-    sleep 1
-done
 systemctl enable tpm2-abrmd
 systemctl start tpm2-abrmd
 # Check that tpm2-abrmd is actually running as starting it won't report failures

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - tpm12image: lukehinds/keylime-ci-tpm12
       tpm12tag: v500
     - tpm20image: lukehinds/keylime-ci-tpm20
-      tpm20tag: v100
+      tpm20tag: v101
 
 services:
   - docker

--- a/docker/Dockerfile-tpm20
+++ b/docker/Dockerfile-tpm20
@@ -7,7 +7,7 @@
 
 FROM fedora:31
 MAINTAINER Luke Hinds <lhinds@redhat.com>
-LABEL version="1.0.0" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
+LABEL version="1.0.1" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
 
 # environment variables
 ARG BRANCH=master


### PR DESCRIPTION
We don't actually need to run systemd-udev-settle in container, so
commenting the requirements out from the tpm2-abrmd unit test file.

This should make the new Fedora 31 with tag v101 image works as is
with also the latest size improvement change that removed the
systemd-udev package.
