### PR TITLE
Fix arg reference in the print_metadata.py

### DIFF
--- a/keylime/revocation_actions/print_metadata.py
+++ b/keylime/revocation_actions/print_metadata.py
@@ -35,5 +35,5 @@ config.read(common.CONFIG_FILE)
 
 logger = keylime_logging.init_logging('print_metadata')
 
-def execute(json_revocation):
+def execute(revocation):
     print(json.loads(revocation['meta_data']))

--- a/keylime/revocation_actions/print_metadata.py
+++ b/keylime/revocation_actions/print_metadata.py
@@ -20,6 +20,8 @@ above. Use of this work other than as specifically authorized by the U.S. Govern
 violate any copyrights that exist in this work.
 '''
 
+import asyncio
+
 from keylime import common
 import keylime.keylime_logging as keylime_logging
 import configparser
@@ -35,5 +37,6 @@ config.read(common.CONFIG_FILE)
 
 logger = keylime_logging.init_logging('print_metadata')
 
-def execute(revocation):
+async def execute(revocation):
     print(json.loads(revocation['meta_data']))
+


### PR DESCRIPTION
The argument reference in print_metadata.execute was changed to
revocation, but the argument itself was not.