### PR TITLE
Improve base http request

### DIFF
--- a/keylime/httpclient_requests.py
+++ b/keylime/httpclient_requests.py
@@ -1,53 +1,39 @@
 import http.client
 
-def request(method, url, port, params=None, data=None,context=None):
-    """
-    http client connection handler
+
+def request(method, host, port, params=None, data=None, context=None,
+            timeout=5):
+    """http client connection handler
 
     :param method: Contains the method type (e.g. GET, POST)
-    :param url: Is the connection IP (could use a rename to `ip`)
+    :param host: The host will be connected to
     :param port: The connection port
-    :param params: Is the url specifics (e.g /v1/agent/)
+    :param params: The URL path (e.g /v1/agent/)
     :param data: The data to provide
     :param context: The SSL context
+    :param timeout: Timeout for the http connection, in seconds.
     :returns: The http response or exception
     :note: to add more failure types, refer to https://docs.python.org/3/library/exceptions.html
     """
-    flag = False
-    counter = 0
     if context is not None:
-        conn =  http.client.HTTPSConnection(
-            url,
+        conn = http.client.HTTPSConnection(
+            host,
             port,
             context=context,
-            timeout=5)
+            timeout=timeout)
     else:
-        conn =  http.client.HTTPConnection(
-            url,
+        conn = http.client.HTTPConnection(
+            host,
             port,
-            timeout=5)
+            timeout=timeout)
 
-    while True:
-        counter += 1
-        if data is not None:
-            try:
-                conn.request(method, params, data)
-            except http.client.HTTPException as e:
-                return(500, str(e))
-            except ConnectionError:
-                return(503)
-            except TimeoutError:
-                return(504)
-        else:
-            try:
-                conn.request(method, params)
-            except http.client.HTTPException as e:
-                return(500, str(e))
-            except ConnectionError:
-                return(503)
-            except TimeoutError:
-                return(504)
-        if counter>9:
-           break
-        response = conn.getresponse()
-        return response
+    try:
+        conn.request(method, params, body=data)
+    except http.client.HTTPException as e:
+        return 500, str(e)
+    except ConnectionError:
+        return 503
+    except TimeoutError:
+        return 504
+    response = conn.getresponse()
+    return response


### PR DESCRIPTION
Make timeout configurable from argument, and we can make it
configurable in the configuration file in the future.

Remove retry count as it doesn't work as expected, we can add retry
mechanism after we sort out which kind of status should be retried.

Use the same code path whether there is body in the request because it's
only a difference in the argument.

Also renamed a few arguments to reflect their real meaning to be less
confusing.