### PR TITLE
Singletonize configuration reading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ var/
 .installed.cfg
 *.egg
 MANIFEST
+AUTHORS
+ChangeLog
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -146,18 +146,16 @@ Keylime requires Python 3.6.
 
 #### Python-based prerequisites
 
-The following python packages are required:
+The list of Python packages needed to install keylime can be found in
+ [requirements.txt](https://github.com/keylime/keylime/tree/master/requirements.txt)
 
-* cryptography
-* tornado>=5.0.2
-* m2crypto>=0.21.1
-* pyzmq>=14.4
-* setuptools>=0.7
-* python-dev
-* pyyaml
-
-The latter of these are usually available as distro packages. See [installer.sh](https://github.com/keylime/keylime/blob/master/installer.sh) for more information if you want to install them this way.
-You can also let keylime's `setup.py` install them via PyPI.
+Some of them are usually available as distro packages.
+See [installer.sh](https://github.com/keylime/keylime/blob/master/installer.sh)
+ for more information if you want to install them this way.
+You can also install them using pip:
+```bash
+python3 -m pip install -r requirements.txt
+```
 
 #### TPM utility prerequisites
 
@@ -292,7 +290,7 @@ To talk directly to a real TPM: `export TPM2TOOLS_TCTI="device:/dev/tpm0"`
 
 You're finally ready to install keylime!
 ```bash
-sudo python setup.py install
+sudo python3 -m pip install . -r requirements.txt
 ```
 
 #### To run on OSX 10.11+

--- a/auto-ipsec/libreswan/src/local_action_crashsa.py
+++ b/auto-ipsec/libreswan/src/local_action_crashsa.py
@@ -21,7 +21,6 @@ violate any copyrights that exist in this work.
 '''
 
 
-import configparser
 import os
 from M2Crypto import X509
 
@@ -36,8 +35,7 @@ except ImportError:
     raise("Simplejson is mandatory, please install")
 
 # read the config file
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 logger = keylime_logging.init_logging('delete-sa')
 

--- a/auto-ipsec/libreswan/src/local_action_update_crl.py
+++ b/auto-ipsec/libreswan/src/local_action_update_crl.py
@@ -22,7 +22,6 @@ violate any copyrights that exist in this work.
 
 import time
 import os
-import configparser
 
 import keylime.tornado_requests as tornado_requests
 import keylime.ca_util as ca_util
@@ -31,8 +30,7 @@ import keylime.common as common
 import keylime.keylime_logging as keylime_logging
 
 # read the config file
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 logger = keylime_logging.init_logging('update_crl')
 

--- a/auto-ipsec/racoon/src/local_action_deletesa.py
+++ b/auto-ipsec/racoon/src/local_action_deletesa.py
@@ -21,7 +21,6 @@ violate any copyrights that exist in this work.
 '''
 
 
-import configparser
 import os
 from M2Crypto import X509
 
@@ -37,8 +36,7 @@ except ImportError:
     raise("Simplejson is mandatory, please install")
 
 # read the config file
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 logger = keylime_logging.init_logging('delete-sa')
 

--- a/auto-ipsec/racoon/src/local_action_update_crl.py
+++ b/auto-ipsec/racoon/src/local_action_update_crl.py
@@ -22,7 +22,6 @@ violate any copyrights that exist in this work.
 
 import time
 import os
-import configparser
 
 import keylime.tornado_requests as tornado_requests
 import keylime.ca_util as ca_util
@@ -31,8 +30,6 @@ import keylime.common as common
 import keylime.keylime_logging as keylime_logging
 
 # read the config file
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
 
 logger = keylime_logging.init_logging('update_crl')
 

--- a/installer.sh
+++ b/installer.sh
@@ -595,7 +595,7 @@ cd $KEYLIME_DIR
 if [[ "$NEED_PYTHON_DIR" -eq "1" ]] ; then
     mkdir -p /usr/local/lib/python3.6/site-packages/
 fi
-python3 setup.py install
+python3 -m pip install . -r requirements.txt
 
 if [[ -f "/etc/keylime.conf" ]] ; then
     if [[ $(diff -N "/etc/keylime.conf" "keylime.conf") ]] ; then

--- a/keylime/ca_impl_cfssl.py
+++ b/keylime/ca_impl_cfssl.py
@@ -19,7 +19,6 @@ violate any copyrights that exist in this work.
 '''
 
 import base64
-import configparser
 import os
 import subprocess
 import socket
@@ -40,9 +39,7 @@ from M2Crypto import EVP, X509
 
 logger = keylime_logging.init_logging('ca_impl_cfssl')
 
-config = configparser.ConfigParser()
-config.read(common.CONFIG_FILE)
-
+config = common.get_config()
 cfssl_ip = config.get('ca', 'cfssl_ip')
 cfssl_port = config.get('ca', 'cfssl_port')
 

--- a/keylime/ca_impl_openssl.py
+++ b/keylime/ca_impl_openssl.py
@@ -18,15 +18,14 @@ above. Use of this work other than as specifically authorized by the U.S. Govern
 violate any copyrights that exist in this work.
 '''
 
-import configparser
 import time
 
 from M2Crypto import X509, EVP, RSA, ASN1
 from keylime import common
 from keylime import keylime_logging
 
-config = configparser.ConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
+
 
 def mk_cert_valid(cert, days=365):
     """

--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -24,7 +24,6 @@ import sys
 import os
 import base64
 import argparse
-import configparser
 import datetime
 import getpass
 import zipfile
@@ -64,8 +63,8 @@ else:
     raise Exception("Unknown CA implementation: %s"%common.CA_IMPL)
 from M2Crypto import X509, EVP, BIO
 
-config = configparser.ConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
+
 
 """
 Tools for creating a CA cert and signed server certs.

--- a/keylime/cloud_agent.py
+++ b/keylime/cloud_agent.py
@@ -57,8 +57,7 @@ except ImportError:
     raise("Simplejson is mandatory, please install")
 
 # read the config file
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 # get the tpm object
 tpm = tpm_obj.getTPM(need_hw_tpm=True)

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -21,7 +21,6 @@ violate any copyrights that exist in this work.
 '''
 import ast
 from urllib.parse import urlparse
-import configparser
 import base64
 import time
 import os
@@ -46,8 +45,7 @@ from keylime.tpm_abstract import TPM_Utilities, Hash_Algorithms, Encrypt_Algorit
 logger = keylime_logging.init_logging('cloudverifier_common')
 
 # setup config
-config = configparser.ConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 
 class CloudAgent_Operational_State:

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -18,7 +18,7 @@ rights in this work are defined by DFARS 252.227-7013 or DFARS 252.227-7014 as d
 above. Use of this work other than as specifically authorized by the U.S. Government may
 violate any copyrights that exist in this work.
 '''
-import configparser
+
 import traceback
 import os
 import sys
@@ -53,8 +53,7 @@ except ImportError:
 if sys.version_info[0] < 3:
     raise Exception("Python 3 or a more recent version is required.")
 
-config = configparser.ConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 drivername = config.get('cloud_verifier', 'drivername')
 
@@ -651,8 +650,7 @@ def main(argv=sys.argv):
     """Main method of the Cloud Verifier Server.  This method is encapsulated in a function for packaging to allow it to be
     called as a function by an external program."""
 
-    config = configparser.ConfigParser()
-    config.read(common.CONFIG_FILE)
+    config = common.get_config()
     cloudverifier_port = config.get('cloud_verifier', 'cloudverifier_port')
 
     VerfierMain.metadata.create_all(engine, checkfirst=True)

--- a/keylime/common.py
+++ b/keylime/common.py
@@ -173,9 +173,18 @@ print(("Using config file %s"%(CONFIG_FILE,)))
 if WARN:
     print("WARNING: Keylime is using the config file from its installation location. \n\tWe recommend you copy keylime.conf to /etc/ to customize it.")
 
-# read the config file
-config = configparser.RawConfigParser()
-config.read(CONFIG_FILE)
+
+_CURRENT_CONFIG = None
+
+
+def get_config():
+    global _CURRENT_CONFIG
+    if _CURRENT_CONFIG is None:
+        # read the config file
+        _CURRENT_CONFIG = configparser.ConfigParser()
+        _CURRENT_CONFIG.read(CONFIG_FILE)
+    return _CURRENT_CONFIG
+
 
 if not REQUIRE_ROOT:
     WORK_DIR=os.path.abspath(".")
@@ -314,6 +323,6 @@ TPM_DATA_PCR = 16
 BOOTSTRAP_KEY_SIZE=32
 
 # choose between cfssl or openssl for creating CA certificates
-CA_IMPL = config.get('general','ca_implementation')
+CA_IMPL = get_config().get('general', 'ca_implementation')
 
-CRL_PORT=38080
+CRL_PORT = 38080

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -24,16 +24,12 @@ import hashlib
 import struct
 import re
 import os
-import configparser
 
 from keylime import common
 from keylime import keylime_logging
 
 logger = keylime_logging.init_logging('ima')
-
-# setup config
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 #         m = ima_measure_re.match(measure_line)
 #         measure  = m.group('file_hash')

--- a/keylime/provider_platform_init.py
+++ b/keylime/provider_platform_init.py
@@ -20,7 +20,6 @@ violate any copyrights that exist in this work.
 '''
 
 import sys
-import configparser
 import base64
 import os
 import errno
@@ -37,8 +36,8 @@ from keylime.keylime_sqlite import vtpm_manager
 
 logger = keylime_logging.init_logging('provider_platform_init')
 
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
+
 
 def symlink_force(target, link_name):
     try:

--- a/keylime/provider_registrar.py
+++ b/keylime/provider_registrar.py
@@ -20,16 +20,15 @@ above. Use of this work other than as specifically authorized by the U.S. Govern
 violate any copyrights that exist in this work.
 '''
 
-from keylime import common
-from keylime import keylime_logging
-logger = keylime_logging.init_logging('provider-registrar')
-
-from keylime import registrar_common
-import configparser
 import sys
 
-config = configparser.ConfigParser()
-config.read(common.CONFIG_FILE)
+from keylime import common
+from keylime import keylime_logging
+from keylime import registrar_common
+
+logger = keylime_logging.init_logging('provider-registrar')
+config = common.get_config()
+
 
 def main(argv=sys.argv):
     registrar_common.start(config.getint('registrar', 'provider_registrar_tls_port'),config.getint('registrar', 'provider_registrar_port'),config.get('registrar','prov_db_filename'))

--- a/keylime/provider_vtpm_add.py
+++ b/keylime/provider_vtpm_add.py
@@ -21,7 +21,6 @@ violate any copyrights that exist in this work.
 '''
 
 import sys
-import configparser
 import base64
 import yaml
 try:
@@ -35,10 +34,10 @@ from keylime import registrar_client
 from keylime import vtpm_manager
 
 # read the config file
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 logger = keylime_logging.init_logging('platform-init')
+
 
 def add_vtpm(inputfile):
     # read in the file

--- a/keylime/registrar.py
+++ b/keylime/registrar.py
@@ -20,7 +20,6 @@ above. Use of this work other than as specifically authorized by the U.S. Govern
 violate any copyrights that exist in this work.
 '''
 
-import configparser
 import sys
 
 from keylime import registrar_common
@@ -29,8 +28,7 @@ from keylime import keylime_logging
 
 logger = keylime_logging.init_logging('registrar')
 
-config = configparser.ConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 
 def main(argv=sys.argv):

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -21,7 +21,6 @@ import os
 import threading
 import sys
 import base64
-import configparser
 import signal
 import time
 import hashlib
@@ -50,10 +49,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine.url import URL
 
 logger = keylime_logging.init_logging('registrar-common')
-
 # setup config
-config = configparser.ConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 drivername = config.get('registrar', 'drivername')
 
@@ -516,7 +513,7 @@ def start(tlsport, port):
     servers = []
     serveraddr = ('', tlsport)
 
-    config = configparser.ConfigParser()
+    config = common.get_config()
     config.read(common.CONFIG_FILE)
     os.umask(0o077)
     kl_dir = os.path.dirname(os.path.abspath(database))

--- a/keylime/revocation_actions/print_metadata.py
+++ b/keylime/revocation_actions/print_metadata.py
@@ -24,18 +24,16 @@ import asyncio
 
 from keylime import common
 import keylime.keylime_logging as keylime_logging
-import configparser
 
 try:
     import simplejson as json
 except ImportError:
     raise("Simplejson is mandatory, please install")
 
-# read the config file
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 logger = keylime_logging.init_logging('print_metadata')
+
 
 async def execute(revocation):
     print(json.loads(revocation['meta_data']))

--- a/keylime/revocation_actions/update_crl.py
+++ b/keylime/revocation_actions/update_crl.py
@@ -22,7 +22,6 @@ violate any copyrights that exist in this work.
 
 import time
 import os
-import configparser
 
 import keylime.tornado_requests as tornado_requests
 import keylime.ca_util as ca_util
@@ -31,10 +30,9 @@ import keylime.common as common
 import keylime.keylime_logging as keylime_logging
 
 # read the config file
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
-
+config = common.get_config()
 logger = keylime_logging.init_logging('update_crl')
+
 
 def execute(json_revocation):
     if json_revocation['type']!='revocation':

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -18,7 +18,7 @@ above. Use of this work other than as specifically authorized by the U.S. Govern
 violate any copyrights that exist in this work.
 '''
 
-import configparser
+from multiprocessing import Process
 import threading
 import functools
 import time
@@ -31,17 +31,12 @@ try:
 except ImportError:
     raise("Simplejson is mandatory, please install")
 
-from multiprocessing import Process
-
 from keylime import common
 from keylime import keylime_logging
 from keylime import crypto
 
 logger = keylime_logging.init_logging('revocation_notifier')
-
-config = configparser.ConfigParser()
-config.read(common.CONFIG_FILE)
-
+config = common.get_config()
 broker_proc = None
 
 

--- a/keylime/secure_mount.py
+++ b/keylime/secure_mount.py
@@ -19,7 +19,6 @@ violate any copyrights that exist in this work.
 '''
 
 import os
-import configparser
 
 from keylime import cmd_exec
 from keylime import common
@@ -28,8 +27,8 @@ from keylime import keylime_logging
 logger = keylime_logging.init_logging('secure_mount')
 
 # read the config file
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
+
 
 def check_mounted(secdir):
     whatsmounted = cmd_exec.run("mount",lock=False)['retout']

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -18,7 +18,6 @@ violate any copyrights that exist in this work.
 import datetime
 import argparse
 import base64
-import configparser
 import hashlib
 import io
 import logging
@@ -52,9 +51,7 @@ from keylime import cloud_verifier_common
 logger = keylime_logging.init_logging('tenant')
 
 
-# setup config
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 # special exception that suppresses stack traces when it happens
 class UserError(Exception):

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -24,7 +24,6 @@ import base64
 import functools
 import os
 import ssl
-import configparser
 import traceback
 import sys
 try:
@@ -46,10 +45,7 @@ from keylime import common
 from keylime import keylime_logging
 
 logger = keylime_logging.init_logging('tenant_webapp')
-
-config = configparser.ConfigParser()
-config.read(common.CONFIG_FILE)
-
+config = common.get_config()
 tenant_templ = tenant.Tenant()
 
 
@@ -598,8 +594,7 @@ def main(argv=sys.argv):
     """Main method of the Tenant Webapp Server.  This method is encapsulated in a function for packaging to allow it to be
     called as a function by an external program."""
 
-    config = configparser.ConfigParser()
-    config.read(common.CONFIG_FILE)
+    config = common.get_config()
 
     webapp_port = config.getint('webapp', 'webapp_port')
 

--- a/keylime/tpm1.py
+++ b/keylime/tpm1.py
@@ -18,7 +18,6 @@ violate any copyrights that exist in this work.
 '''
 
 import base64
-import configparser
 import hashlib
 import M2Crypto
 import os
@@ -50,8 +49,7 @@ from keylime import tpm_ek_ca
 logger = keylime_logging.init_logging('tpm1')
 
 # read the config file
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 
 class tpm1(tpm_abstract.AbstractTPM):

--- a/keylime/tpm2.py
+++ b/keylime/tpm2.py
@@ -19,7 +19,6 @@ violate any copyrights that exist in this work.
 
 import base64
 import binascii
-import configparser
 import distutils.spawn
 import hashlib
 import os
@@ -55,8 +54,8 @@ from keylime import tpm_ek_ca
 logger = keylime_logging.init_logging('tpm2')
 
 # Read the config file
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
+
 
 class tpm2(tpm_abstract.AbstractTPM):
 

--- a/keylime/tpm2.py
+++ b/keylime/tpm2.py
@@ -854,6 +854,9 @@ class tpm2(tpm_abstract.AbstractTPM):
             trusted_certs = tpm_ek_ca.cert_loader()
             for cert in trusted_certs:
                 signcert = M2Crypto.X509.load_cert_string(cert)
+                if str(ek509.get_issuer()) != str(signcert.get_subject()):
+                    continue
+
                 signkey = signcert.get_pubkey()
                 if ek509.verify(signkey) == 1:
                     logger.debug(f"EK cert matched cert: {cert}")

--- a/keylime/tpm_abstract.py
+++ b/keylime/tpm_abstract.py
@@ -18,7 +18,6 @@ violate any copyrights that exist in this work.
 '''
 import ast
 import base64
-import configparser
 import fcntl
 import hashlib
 import os
@@ -190,8 +189,7 @@ class AbstractTPM(object, metaclass=ABCMeta):
     # constructor
     def __init__(self, need_hw_tpm=True):
         # read the config file
-        self.config = configparser.RawConfigParser()
-        self.config.read(common.CONFIG_FILE)
+        self.config = common.get_config()
         self.need_hw_tpm = need_hw_tpm
         self.global_tpmdata = None
         self.tpmrand_warned = False

--- a/keylime/tpm_ek_ca.py
+++ b/keylime/tpm_ek_ca.py
@@ -18,20 +18,17 @@ above. Use of this work other than as specifically authorized by the U.S. Govern
 violate any copyrights that exist in this work.
 '''
 
-import configparser
 import glob
 import os
+
 from keylime import common
 from keylime import keylime_logging
 
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
-
+config = common.get_config()
 logger = keylime_logging.init_logging('tpm_ek_ca')
-
 trusted_certs = {}
-
 tpm_cert_store = config.get('tenant', 'tpm_cert_store')
+
 
 def check_tpm_cert_store():
     if not os.path.isdir(tpm_cert_store):

--- a/keylime/tpm_obj.py
+++ b/keylime/tpm_obj.py
@@ -18,7 +18,6 @@ above. Use of this work other than as specifically authorized by the U.S. Govern
 violate any copyrights that exist in this work.
 '''
 
-import configparser
 import distutils.spawn
 import os
 
@@ -28,10 +27,7 @@ from keylime import common
 from keylime import keylime_logging
 
 logger = keylime_logging.init_logging('tpmobj')
-
-# read the config file
-config = configparser.RawConfigParser()
-config.read(common.CONFIG_FILE)
+config = common.get_config()
 
 # singleton objects for working with the TPM
 __tpm1 = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+cryptography>=2.1.4 # BSD/Apache-2.0
+tornado>=5.0.2 # Apache-2.0
+m2crypto>=0.21.1 # MIT
+pyzmq>=14.4 # LGPL+BSD
+pyyaml>=3.11 # MIT
+simplejson>=3.8 # MIT
+requests>=2.6 # Apache-2.0
+sqlalchemy>=1.3 # MIT

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,45 @@
+[metadata]
+name = keylime
+summary =
+    TPM-based key bootstrapping and system integrity measurement system for cloud
+description-file =
+    README.md
+author = MIT Lincoln Laboratory
+author-email = nabil@ll.mit.edu
+home-page = https://github.com/keylime/keylime
+python-requires = >=3.6
+classifier =
+    Environment :: Console
+    Intended Audience :: Developers
+    Intended Audience :: Information Technology
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: BSD License
+    Operating System :: POSIX :: Linux
+    Programming Language :: Python
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Topic :: System :: Hardware
+
+[files]
+data_files =
+    etc =
+        keylime.conf
+packages =
+    keylime
+
+[entry_points]
+console_scripts =
+    keylime_verifier = keylime.cloud_verifier_tornado:main
+    keylime_agent = keylime.cloud_agent:main
+    keylime_tenant = keylime.tenant:main
+    keylime_userdata_encrypt = keylime.user_data_encrypt:main
+    keylime_registrar = keylime.registrar:main
+    keylime_provider_registrar = keylime.provider_registrar:main
+    keylime_provider_platform_init = keylime.provider_platform_init:main
+    keylime_provider_vtpm_add = keylime.provider_vtpm_add:main
+    keylime_ca = keylime.ca_util:main
+    keylime_ima_emulator = keylime.ima_emulator_adapter:main
+    keylime_webapp = keylime.tenant_webapp:main

--- a/setup.py
+++ b/setup.py
@@ -1,153 +1,44 @@
-'''
+"""
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.
 
-This material is based upon work supported by the Assistant Secretary of Defense for
-Research and Engineering under Air Force Contract No. FA8721-05-C-0002 and/or
-FA8702-15-D-0001. Any opinions, findings, conclusions or recommendations expressed in this
-material are those of the author(s) and do not necessarily reflect the views of the
-Assistant Secretary of Defense for Research and Engineering.
+This material is based upon work supported by the Assistant Secretary of
+Defense for Research and Engineering under Air Force Contract No.
+FA8721-05-C-0002 and/or FA8702-15-D-0001.
+Any opinions, findings, conclusions or recommendations expressed in this
+material are those of the author(s) and do not necessarily reflect the
+views of the Assistant Secretary of Defense for Research and Engineering.
 
 Copyright 2015 Massachusetts Institute of Technology.
 
 The software/firmware is provided to you on an As-Is basis
 
 Delivered to the US Government with Unlimited Rights, as defined in DFARS Part
-252.227-7013 or 7014 (Feb 2014). Notwithstanding any copyright notice, U.S. Government
-rights in this work are defined by DFARS 252.227-7013 or DFARS 252.227-7014 as detailed
-above. Use of this work other than as specifically authorized by the U.S. Government may
-violate any copyrights that exist in this work.
-'''
+252.227-7013 or 7014 (Feb 2014). Notwithstanding any copyright notice, U.S.
+Government rights in this work are defined by DFARS 252.227-7013 or
+DFARS 252.227-7014 as detailed above.
+Use of this work other than as specifically authorized by the U.S. Government
+may violate any copyrights that exist in this work.
+"""
 
-
-# Always prefer setuptools over distutils
-from setuptools import setup, find_packages, Extension
-# To use a consistent encoding
-from codecs import open
-from os import path
-from os import walk
+import setuptools
+from setuptools import Extension
 import sys
 
-here = path.abspath(path.dirname(__file__))
-
-# Get the long description from the relevant file
-with open(path.join(here, 'DESCRIPTION.md'), encoding='utf-8') as f:
-    long_description = f.read()
-
-# cLime only builds against glibc at the moment. If we ever want to change this
-# it shouldn't be too hard.
 extensions = []
+
 if '--with-clime' in sys.argv:
     if 'linux' in sys.platform:
-        extensions.append(Extension('_cLime',
-                                    define_macros=[('MAJOR_VERSION', '1'),
-                                                   ('MINOR_VERSION', '0')],
-                                    include_dirs=['/usr/local/include'],
-                                    libraries=['tpm', 'keylime'],
-                                    library_dirs=['/usr/local/lib'],
-                                    runtime_library_dirs=['/usr/local/lib'],
-                                    sources=['keylime/_cLime.c']))
+        extensions.append(
+            Extension('_cLime', ['keylime/_cLime.c'],
+                      define_macros=[('MAJOR_VERSION', '1'),
+                                     ('MINOR_VERSION', '0')],
+                      include_dirs=['/usr/local/include'],
+                      libraries=['tpm', 'keylime'],
+                      library_dirs=['/usr/local/lib'],
+                      runtime_library_dirs=['/usr/local/lib']))
     sys.argv.remove('--with-clime')
 
-# enumerate all of the data files we need to package up
-data_files = [('/etc', ['keylime.conf'])]
-
-setup(
-    name='keylime',
-
-    # Versions should comply with PEP440.  For a discussion on single-sourcing
-    # the version across setup.py and the project code, see
-    # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2',
-
-    description='TPM-based key bootstrapping and system integrity measurement system for cloud',
-    long_description=long_description,
-
-    # The project's main homepage.
-    url='https://github.com/keylime/keylime',
-
-    # Author details
-    author='MIT Lincoln Laboratory',
-    author_email='nabil@ll.mit.edu',
-
-    # Choose your license
-    license='BSD-2-Clause',
-
-    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    classifiers=[
-        'Development Status :: 5.3.1 - Beta',
-
-        # Indicate who your project is intended for
-        'Intended Audience :: Developers',
-        'Intended Audience :: System Administrators',
-
-        # where does it run
-        'Environment :: Console',
-        'Operating System :: POSIX',
-        'Operating System :: POSIX :: Linux',
-
-        # Pick your license as you wish (should match "license" above)
-        'License :: OSI Approved :: BSD License',
-
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 3.7',
-    ],
-
-    # What does your project relate to?
-    keywords='tpm cloud cloud-init tls',
-
-    # You can just specify the packages manually here if your project is
-    # simple. Or you can use find_packages().
-    packages=['keylime'],
-    package_data={'keylime': ['static/*/*', 'static/*/*/*']},
-
-    # List run-time dependencies here.  These will be installed by pip when
-    # your project is installed. For an analysis of "install_requires" vs pip's
-    # requirements files see:
-    # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['cryptography>=2.1.4', 'tornado>=5.0.2', 'm2crypto>=0.21.1',
-        'pyzmq>=14.4', 'pyyaml>=3.11', 'simplejson>=3.8', 'requests>=2.6', 'sqlalchemy>=1.3'],
-
-    # test packages required
-    tests_require=['green', 'coverage'],
-
-    # List additional groups of dependencies here (e.g. development
-    # dependencies). You can install these using the following syntax,
-    # for example:
-    # $ pip install -e .[dev,test]
-    # extras_require={
-    #    'dev': ['check-manifest'],
-    #    'test': ['coverage'],
-    # },
-
-    # If there are data files included in your packages that need to be
-    # installed, specify them here.  If using Python 2.6 or less, then these
-    # have to be included in MANIFEST.in as well.
-
-    # Although 'package_data' is the preferred approach, in some case you may
-    # need to place data files outside of your packages. See:
-    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
-    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    data_files=data_files,
-
-    # To provide executable scripts, use entry points in preference to the
-    # "scripts" keyword. Entry points provide cross-platform support and allow
-    # pip to create the appropriate form of executable for the target platform.
-    entry_points={
-        'console_scripts': [
-            'keylime_verifier=keylime.cloud_verifier_tornado:main',
-            'keylime_agent=keylime.cloud_agent:main',
-            'keylime_tenant=keylime.tenant:main',
-            'keylime_userdata_encrypt=keylime.user_data_encrypt:main',
-            'keylime_registrar=keylime.registrar:main',
-            'keylime_provider_registrar=keylime.provider_registrar:main',
-            'keylime_provider_platform_init=keylime.provider_platform_init:main',
-            'keylime_provider_vtpm_add=keylime.provider_vtpm_add:main',
-            'keylime_ca=keylime.ca_util:main',
-            'keylime_ima_emulator=keylime.ima_emulator_adapter:main',
-            'keylime_webapp=keylime.tenant_webapp:main',
-        ],
-    },
-
-    ext_modules=extensions
-)
+setuptools.setup(
+    setup_requires=['pbr'],
+    pbr=True,
+    ext_modules=extensions)

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -187,7 +187,7 @@ echo "==========================================================================
 echo $'\t\t\tInstalling Keylime'
 echo "=================================================================================="
 cd $KEYLIME_DIR
-python3 setup.py install
+python3 -m pip install . -r requirements.txt
 
 # Run the tests as necessary
 if [[ "$COVERAGE" -eq "1" ]] ; then


### PR DESCRIPTION
Moves configuration loading into the common module and make
the config loaded a global instance.

Sticks to ConfigParser instead of mixed usage of ConfigParser and
RawConfigParser.