### PR TITLE
Add Python3.8 as supported

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifier =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Topic :: System :: Hardware
 
 [files]


### PR DESCRIPTION
Python3.8 is starting to come as a standard version now (fed 32)

This change adds it to the supported OS in `setup.cfg`