### PR TITLE
Reverts data_files to former format.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,9 +24,6 @@ classifier =
     Topic :: System :: Hardware
 
 [files]
-data_files =
-    etc =
-        keylime.conf
 packages =
     keylime
 

--- a/setup.py
+++ b/setup.py
@@ -41,4 +41,5 @@ if '--with-clime' in sys.argv:
 setuptools.setup(
     setup_requires=['pbr'],
     pbr=True,
-    ext_modules=extensions)
+    ext_modules=extensions,
+    data_files = [('/etc', ['keylime.conf'])])


### PR DESCRIPTION
Previous data_files syntax was failing to move keylime.conf
into /etc/