### PR TITLE
Fix for registrar and verifier running on different hosts

### DIFF
--- a/keylime/registrar_client.py
+++ b/keylime/registrar_client.py
@@ -121,6 +121,13 @@ def getKeys(registrar_ip,registrar_port,agent_id):
             return None
 
         return response_body["results"]
+
+    except AttributeError as e :
+        if response == 503 :
+            logger.critical("Error: the registrar is not availabled at %s:%s"%(registrar_ip, registrar_port))
+        else :
+            logger.exception(e)
+
     except Exception as e:
         logger.exception(e)
 

--- a/keylime/registrar_client.py
+++ b/keylime/registrar_client.py
@@ -124,7 +124,7 @@ def getKeys(registrar_ip,registrar_port,agent_id):
 
     except AttributeError as e :
         if response == 503 :
-            logger.critical("Error: the registrar is not availabled at %s:%s"%(registrar_ip, registrar_port))
+            logger.critical("Error: the registrar is not available at %s:%s"%(registrar_ip, registrar_port))
         else :
             logger.exception(e)
 

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -387,7 +387,7 @@ class Tenant():
 
     def validate_tpm_quote(self,public_key,quote,tpm_version,hash_alg):
         registrar_client.init_client_tls(config,'tenant')
-        reg_keys = registrar_client.getKeys(self.cloudverifier_ip,self.registrar_port,self.agent_uuid)
+        reg_keys = registrar_client.getKeys(self.registrar_ip,self.registrar_port,self.agent_uuid)
         if reg_keys is None:
             logger.warning("AIK not found in registrar, quote not validated")
             return False


### PR DESCRIPTION
This commit fixes the inability of running `keylime_tenant` in a setup
where Keylime's Registrar and Verifier daemons run on separate hosts.
There is also an attempt at providing a clearer error message when the
registrar cannot be reached at the specified IP address, TCP port.

Resolves: #297