### PR TITLE
Update verifier REST API to return error for invalid exclude list

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -369,3 +369,15 @@ def notify_error(agent, msgtype='revocation'):
     else:
         tosend['signature'] = "none"
     revocation_notifier.notify(tosend)
+
+def validate_agent_data(agent_data):
+    if agent_data is None:
+        return False, None
+
+    # Validate exlude list contains valid regular expressions
+    lists = ast.literal_eval(agent_data['ima_whitelist'])
+    is_valid, _, err_msg = common.valid_exclude_list(lists.get('exclude'))
+    if not is_valid:
+        err_msg += " Exclude list regex is misformatted. Please correct the issue and try again."
+
+    return is_valid, err_msg

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -314,6 +314,12 @@ class AgentsHandler(BaseHandler):
                     agent_data['sign_alg'] = ""
                     agent_data['agent_id'] = agent_id
 
+                    is_valid, err_msg = cloud_verifier_common.validate_agent_data(agent_data)
+                    if not is_valid:
+                        common.echo_json_response(self, 400, err_msg)
+                        logger.warning(err_msg)
+                        return
+
                     try:
                         new_agent_count = session.query(
                             VerfierMain).filter_by(agent_id=agent_id).count()

--- a/keylime/common.py
+++ b/keylime/common.py
@@ -9,6 +9,7 @@ import logging.config
 import sys
 import urllib.parse
 import random
+import re
 import time
 import tornado.web
 from http.server import BaseHTTPRequestHandler
@@ -300,6 +301,28 @@ def get_restful_params(urlstring):
     path_params["api_version"] = api_version
     path_params.update(query_params)
     return path_params
+
+
+def valid_exclude_list(exclude_list):
+    if not exclude_list:
+        return True, None, None
+
+    combined_regex = "(" + ")|(".join(exclude_list) + ")"
+    return valid_regex(combined_regex)
+
+
+def valid_regex(regex):
+    if regex is None:
+        return True, None, None
+
+    try:
+        compiled_regex = re.compile(regex)
+    except re.error as regex_err:
+        err = "Invalid regex: " + regex_err.msg + "."
+        return False, None, err
+
+    return True, compiled_regex, None
+
 
 # this doesn't currently work
 # if LOAD_TEST:

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -125,16 +125,12 @@ def process_measurement_list(lines, lists=None, m2w=None):
     else:
         whitelist = None
 
-    compiled_regex = None
-    if exclude_list != []:
-        combined_regex = "(" + ")|(".join(exclude_list) + ")"
-        try:
-            compiled_regex = re.compile(combined_regex)
-        except re.error as regex_err:
-            msg = "Invalid regular expression '" + regex_err.pattern + "': "
-            msg += regex_err.msg + " at position " + \
-                str(regex_err.pos) + ". Exclude list will be ignored."
-            logger.error(msg)
+    is_valid, compiled_regex, err_msg = common.valid_exclude_list(exclude_list)
+    if not is_valid:
+        # This should not happen as the exclude list has already been validated
+        # by the verifier before acceping it. This is a safety net just in case.
+        err_msg += " Exclude list will be ignored."
+        logger.error(err_msg)
 
     for line in lines:
         line = line.strip()

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -503,10 +503,11 @@ class Tenant():
                 "Agent %s already existed at CV.  Please use delete or update." % self.agent_uuid)
             exit()
         elif response.status != 200:
+            response_json = json.loads(response.read().decode())
             keylime_logging.log_http_response(
-                logger, logging.ERROR, response.read().decode()())
+                logger, logging.ERROR, response_json)
             logger.error(
-                f"POST command response: {response.status} Unexpected response from Cloud Verifier: {response.read().decode()}")
+                f"POST command response: {response.status} Unexpected response from Cloud Verifier: {response_json}")
             exit()
 
     def do_cvstatus(self, listing=False):

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -699,6 +699,40 @@ class TestRestful(unittest.TestCase):
         self.assertIn("port", json_response["results"], "Malformed response body!")
 
 
+    def test_034_cv_agent_post_invalid_exclude_list(self):
+        """Test CV's POST /v2/agents/{UUID} Interface"""
+        self.assertIsNotNone(self.V, "Required value not set.  Previous step may have failed?")
+
+        b64_v = base64.b64encode(self.V)
+        # Set unsupported regex in exclude list
+        ima_whitelist = { 'exclude': ['*'] }
+        data = {
+            'v': b64_v,
+            'cloudagent_ip': tenant_templ.cloudagent_ip,
+            'cloudagent_port': tenant_templ.cloudagent_port,
+            'tpm_policy': json.dumps(self.tpm_policy),
+            'vtpm_policy':json.dumps(self.vtpm_policy),
+            'ima_whitelist':json.dumps(ima_whitelist),
+            'metadata':json.dumps(self.metadata),
+            'revocation_key':self.revocation_key,
+            'accept_tpm_hash_algs': config.get('tenant','accept_tpm_hash_algs').split(','),
+            'accept_tpm_encryption_algs': config.get('tenant','accept_tpm_encryption_algs').split(','),
+            'accept_tpm_signing_algs': config.get('tenant','accept_tpm_signing_algs').split(','),
+        }
+
+        agent_data = json.dumps(data)
+        params = f"/v{self.api_version}/agents/{tenant_templ.agent_uuid}"
+        response = httpclient_requests.request("POST", "%s"%(tenant_templ.cloudverifier_ip),
+                        tenant_templ.cloudverifier_port, params=params,
+                        data=agent_data, context=tenant_templ.context)
+
+        self.assertEqual(response.status, 400, "Successful CV agent Post return code!")
+        json_response = json.loads(response.read().decode())
+
+        # Ensure response is well-formed
+        self.assertIn("results", json_response, "Malformed response body!")
+
+
 
     """Agent Poll Testset"""
 


### PR DESCRIPTION
Fixes #314

Exclude list example:

```shell
[root@keylime keylime-dev]# cat ~/excludes.txt
/root/keylime-dev/.*
*
```

Error from the verifier:
```shell
2020-06-05 20:40:21.875 - keylime.cloudverifier - WARNING - Invalid regex: nothing to repeat. Exclude list regex is misformatted. Please correct the issue and try again.
```

Error from the tenant:
```shell
[root@keylime keylime-dev]# python keylime/cmd/tenant.py -v 127.0.0.1 -t 127.0.0.1 -tp 9002 -f /root/excludes.txt -u D432FBB3-D2F1-4A97-9EF7-75BD81C00000 --whitelist /root/whitelist.txt --exclude /root/excludes.txt -c add
Using config file /root/keylime-dev/keylime.conf
2020-06-05 20:40:20.539 - keylime.tenant - WARNING - CAUTION: using default password for private key, please set private_key_pw to a strong password
2020-06-05 20:40:20.539 - keylime.tenant - INFO - Setting up client TLS in /var/lib/keylime/cv_ca
2020-06-05 20:40:20.546 - keylime.tenant - INFO - TPM PCR Mask from policy is 0x408000
2020-06-05 20:40:20.546 - keylime.tenant - INFO - TPM PCR Mask from policy is 0x808000
2020-06-05 20:40:20.671 - keylime.ima - WARNING - No boot_aggregate value found in whitelist, adding an empty one
2020-06-05 20:40:21.876 - keylime.tenant - ERROR - Response code 400: Invalid regex: nothing to repeat. Exclude list regex is misformatted. Please correct the issue and try again.
2020-06-05 20:40:21.876 - keylime.tenant - ERROR - POST command response: 400 Unexpected response from Cloud Verifier: {'code': 400, 'status': 'Invalid regex: nothing to repeat. Exclude list regex is misformatted. Please correct the issue and try again.', 'results': {}}
```