### PR TITLE
Simplify database configuration

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -166,14 +166,7 @@ registrar_private_key_pw = default
 # Database URL Configuration
 # See document [here] for instructions on using different database configurations
 # The default is sqlite and will be situated at "/var/lib/keylime/cv_data.sqlite"
-drivername = sqlite
-username = ''
-password = ''
-host = ''
-port = ''
-database = cv_data.sqlite
-query = ''
-
+db_connection = sqlite:////var/lib/keylime/cv_data.sqlite
 
 # Number of worker processes to use for the cloud verifier
 # Set to 0 to create one worker per processor
@@ -410,13 +403,7 @@ registrar_private_key_pw = default
 # Database URL Configuration
 # See document [here] for instructions on using different database configurations
 # The default is sqlite and will be situated at "/var/lib/keylime/reg_data.sqlite"
-drivername = sqlite
-username = ''
-password = ''
-host = ''
-port = ''
-database = reg_data.sqlite
-query = ''
+db_connection = sqlite:////var/lib/keylime/reg_data.sqlite
 
 # The file to use for SQLite persistence of provider hypervisor data
 prov_db_filename = provider_reg_data.sqlite

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -37,33 +37,7 @@ if sys.version_info[0] < 3:
 
 config = common.get_config()
 
-drivername = config.get('cloud_verifier', 'drivername')
-
-if drivername == 'sqlite':
-    database = "%s/%s" % (common.WORK_DIR,
-                          config.get('cloud_verifier', 'database'))
-    # Create the path to where the sqlite database will be store with a perm umask of 077
-    os.umask(0o077)
-    kl_dir = os.path.dirname(os.path.abspath(database))
-    if not os.path.exists(kl_dir):
-        os.makedirs(kl_dir, 0o700)
-
-    url = URL(
-        drivername=drivername,
-        username='',
-        password='',
-        host='',
-        database=(database)
-    )
-else:
-    url = URL(
-        drivername=drivername,
-        username=config.get('cloud_verifier', 'username'),
-        password=config.get('cloud_verifier', 'password'),
-        host=config.get('cloud_verifier', 'host'),
-        database=config.get('cloud_verifier', 'database')
-    )
-
+url = config.get('cloud_verifier', 'db_connection')
 
 try:
     engine = create_engine(url,

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -30,33 +30,13 @@ from keylime.db.registrar_db import RegistrarMain
 from keylime.db.keylime_db import SessionManager
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import create_engine
-from sqlalchemy.engine.url import URL
+
 
 logger = keylime_logging.init_logging('registrar-common')
 # setup config
 config = common.get_config()
 
-drivername = config.get('registrar', 'drivername')
-
-
-if drivername == 'sqlite':
-    database = "%s/%s" % (common.WORK_DIR,
-                          config.get('registrar', 'database'))
-    url = URL(
-        drivername=drivername,
-        username='',
-        password='',
-        host='',
-        database=(database)
-    )
-else:
-    url = URL(
-        drivername=drivername,
-        username=config.get('registrar', 'username'),
-        password=config.get('registrar', 'password'),
-        host=config.get('registrar', 'host'),
-        database=config.get('registrar', 'database')
-    )
+url = config.get('registrar', 'db_connection')
 
 try:
     engine = create_engine(url,


### PR DESCRIPTION
Make the URL configurable so that we don't need to set each part.

I didn't see the the TEST_MODE used in CI, so if it's still used by some one locally, it could be easily resolved by changing the db_connection configuration.