### PR TITLE
Fixes large mount returns called from secure_mount

### DIFF
--- a/keylime/secure_mount.py
+++ b/keylime/secure_mount.py
@@ -4,6 +4,7 @@ Copyright 2017 Massachusetts Institute of Technology.
 '''
 
 import os
+import subprocess
 
 from keylime import cmd_exec
 from keylime import common
@@ -16,24 +17,30 @@ config = common.get_config()
 
 
 def check_mounted(secdir):
-    whatsmounted = cmd_exec.run("mount",lock=False)['retout']
+    # We don't use cmd.exec here as on some machines, mount can return more lines then popen can handle.
+    whatsmounted = subprocess.check_output(
+        ['mount']).decode('utf-8').split('\n')
     whatsmounted_converted = common.list_convert(whatsmounted)
     for line in whatsmounted_converted:
         tokens = line.split()
         tmpfs = False
-        if len(tokens)<3:
+        if len(tokens) < 3:
             continue
-        if tokens[0]=='tmpfs':
-            tmpfs=True
-        if tokens[2]==secdir:
+        if tokens[0] == 'tmpfs':
+            tmpfs = True
+        if tokens[2] == secdir:
             if not tmpfs:
-                logger.error("secure storage location %s already mounted on wrong file system type: %s.  Unmount to continue."%(secdir,tokens[0]))
-                raise Exception("secure storage location %s already mounted on wrong file system type: %s.  Unmount to continue."%(secdir,tokens[0]))
+                logger.error("secure storage location %s already mounted on wrong file system type: %s.  Unmount to continue." % (
+                    secdir, tokens[0]))
+                raise Exception("secure storage location %s already mounted on wrong file system type: %s.  Unmount to continue." % (
+                    secdir, tokens[0]))
 
-            logger.debug("secure storage location %s already mounted on tmpfs"%secdir)
+            logger.debug(
+                "secure storage location %s already mounted on tmpfs" % secdir)
             return True
-    logger.debug("secure storage location %s not mounted "%secdir)
+    logger.debug("secure storage location %s not mounted " % secdir)
     return False
+
 
 def mount():
     secdir = common.WORK_DIR+"/secure"
@@ -47,10 +54,11 @@ def mount():
     if not check_mounted(secdir):
         # ok now we know it isn't already mounted, go ahead and create and mount
         if not os.path.exists(secdir):
-            os.makedirs(secdir,0o700)
-        common.chownroot(secdir,logger)
-        size = config.get('cloud_agent','secure_size')
-        logger.info("mounting secure storage location %s on tmpfs"%secdir)
-        cmd_exec.run("mount -t tmpfs -o size=%s,mode=0700 tmpfs %s" %(size,secdir),lock=False)
+            os.makedirs(secdir, 0o700)
+        common.chownroot(secdir, logger)
+        size = config.get('cloud_agent', 'secure_size')
+        logger.info("mounting secure storage location %s on tmpfs" % secdir)
+        cmd_exec.run("mount -t tmpfs -o size=%s,mode=0700 tmpfs %s" %
+                     (size, secdir), lock=False)
 
     return secdir


### PR DESCRIPTION
The current `cmd_exec` implementation will hang when a secure
mount is attempted on a machine with hundreds of mount points.

This is very common on a kubernetes node where there can be lots
of mounts of tmpfs to pods and cgroup mounts on storage overlays

Resolves: #330