### PR TITLE
Fix warning: "is" should not be used with literals

### DIFF
--- a/demo/agent_monitor/tenant_agent_monitor.py
+++ b/demo/agent_monitor/tenant_agent_monitor.py
@@ -124,7 +124,7 @@ class AgentsHandler(BaseHandler):
 
                     # Execute specified script if all is well
                     global initscript
-                    if initscript is not None and initscript is not "":
+                    if initscript is not None and initscript != "":
                         def initthread():
                             import subprocess
                             logger.debug(

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -186,7 +186,7 @@ def process_quote_response(agent, json_response):
         agent['provide_V'] = False
         received_public_key = agent['public_key']
 
-    if agent.get('registrar_keys', "") is "":
+    if agent.get('registrar_keys', "") == "":
         registrar_client.init_client_tls(config, 'cloud_verifier')
         registrar_keys = registrar_client.getKeys(config.get("registrar", "registrar_ip"), config.get(
             "registrar", "registrar_tls_port"), agent['agent_id'])

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -285,7 +285,7 @@ class Handler(BaseHTTPRequestHandler):
 
                 # run an included script if one has been provided
                 initscript = config.get('cloud_agent', 'payload_script')
-                if initscript is not "":
+                if initscript != "":
                     def initthread():
                         import subprocess
                         env = os.environ.copy()

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -427,7 +427,7 @@ class Tenant():
 
         # check all EKs with optional script:
         script = config.get('tenant', 'ek_check_script')
-        if script is not "":
+        if script != "":
             if script[0] != '/':
                 script = "%s/%s" % (common.WORK_DIR, script)
 


### PR DESCRIPTION
Before, it produces warnings like:
    SyntaxWarning: "is not" with a literal. Did you mean "!="?