### PR TITLE
Fixes postgres database configuration

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -170,8 +170,9 @@ registrar_private_key = default
 registrar_private_key_pw = default
 
 # Database URL Configuration
-# See document [here] for instructions on using different database configurations
-# The default is sqlite and will be situated at "/var/lib/keylime/cv_data.sqlite"
+# See document https://keylime-docs.readthedocs.io/en/latest/installation.html#database-support
+# for instructions on using different database configurations
+# The default is sqlite and will be situated at "/var/lib/keylime/reg_data.sqlite"
 drivername = sqlite
 username = ''
 password = ''
@@ -414,7 +415,8 @@ registrar_private_key_pw = default
 
 
 # Database URL Configuration
-# See document [here] for instructions on using different database configurations
+# See document https://keylime-docs.readthedocs.io/en/latest/installation.html#database-support
+# for instructions on using different database configurations
 # The default is sqlite and will be situated at "/var/lib/keylime/reg_data.sqlite"
 drivername = sqlite
 username = ''

--- a/keylime.conf
+++ b/keylime.conf
@@ -17,7 +17,7 @@ ca_implementation = openssl
 [cloud_agent]
 #=============================================================================
 
-# The Agent's IP address and port used to communicate with other services 
+# The Agent's IP address and port used to communicate with other services
 # as well as a bind address for the agent server.
 cloudagent_ip = 127.0.0.1
 cloudagent_port = 9002
@@ -104,8 +104,8 @@ tpm_encryption_alg = rsa
 tpm_signing_alg = rsassa
 
 # If an EK is already present on the TPM (e.g., with "tpm2_createek") and
-# you require keylime to use this EK, change "generate" to the actual EK 
-# handle (e.g. "0x81000000"). The keylime agent will then not attempt to 
+# you require keylime to use this EK, change "generate" to the actual EK
+# handle (e.g. "0x81000000"). The keylime agent will then not attempt to
 # create a new EK upon startup, and neither will it flush the EK upon exit
 ek_handle = generate
 
@@ -172,7 +172,7 @@ registrar_private_key_pw = default
 # Database URL Configuration
 # See document https://keylime-docs.readthedocs.io/en/latest/installation.html#database-support
 # for instructions on using different database configurations
-# The default is sqlite and will be situated at "/var/lib/keylime/reg_data.sqlite"
+# The default is sqlite and will be situated at "/var/lib/keylime/cv_data.sqlite"
 drivername = sqlite
 username = ''
 password = ''
@@ -349,7 +349,7 @@ ek_check_script=
 [registrar]
 #=============================================================================
 
-# The registrar's IP address and port used to communicate with other 
+# The registrar's IP address and port used to communicate with other
 # services as well as a bind address for the registrar server.
 registrar_ip = 127.0.0.1
 registrar_port = 8890
@@ -459,7 +459,7 @@ cert_bits=2048
 # You can then use keylime_ca -c listen -n ca/RevocationNotifier-cert.crt
 cert_crl_dist=http://localhost:38080/crl
 
-# If the provider for certificate generation is CFSSL, then the HTTP-based 
+# If the provider for certificate generation is CFSSL, then the HTTP-based
 # API server will run at this address and port.
 cfssl_ip = 127.0.0.1
 cfssl_port = 8888

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -55,6 +55,12 @@ if drivername == 'sqlite':
         host='',
         database=(database)
     )
+    try:
+        engine = create_engine(url,
+                            connect_args={'check_same_thread': False},)
+    except SQLAlchemyError as e:
+        logger.error(f'Error creating SQL engine: {e}')
+        exit(1)
 else:
     url = URL(
         drivername=drivername,
@@ -63,14 +69,11 @@ else:
         host=config.get('cloud_verifier', 'host'),
         database=config.get('cloud_verifier', 'database')
     )
-
-
-try:
-    engine = create_engine(url,
-                           connect_args={'check_same_thread': False},)
-except SQLAlchemyError as e:
-    logger.error(f'Error creating SQL engine: {e}')
-    exit(1)
+    try:
+        engine = create_engine(url)
+    except SQLAlchemyError as e:
+        logger.error(f'Error creating SQL engine: {e}')
+        exit(1)
 
 
 # The "exclude_db" dict values are removed from the response before adding the dict to the DB

--- a/scripts/postgres_tables/registrarmain.sql
+++ b/scripts/postgres_tables/registrarmain.sql
@@ -1,0 +1,52 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 12.4
+-- Dumped by pg_dump version 12.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: registrarmain; Type: TABLE; Schema: public; Owner: keylime
+--
+
+CREATE TABLE public.registrarmain (
+    agent_id character varying(80) NOT NULL,
+    key character varying,
+    aik character varying,
+    ek character varying,
+    ekcert character varying,
+    virtual integer,
+    active integer,
+    provider_keys text,
+    regcount integer
+);
+
+
+ALTER TABLE public.registrarmain OWNER TO keylime;
+
+--
+-- Name: registrarmain registrarmain_pkey; Type: CONSTRAINT; Schema: public; Owner: keylime
+--
+
+ALTER TABLE ONLY public.registrarmain
+    ADD CONSTRAINT registrarmain_pkey PRIMARY KEY (agent_id);
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/scripts/postgres_tables/verifiermain.sql
+++ b/scripts/postgres_tables/verifiermain.sql
@@ -1,0 +1,61 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 12.4
+-- Dumped by pg_dump version 12.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: verifiermain; Type: TABLE; Schema: public; Owner: keylime
+--
+
+CREATE TABLE public.verifiermain (
+    agent_id character varying(80) NOT NULL,
+    v character varying,
+    ip character varying(15),
+    port integer,
+    operational_state integer,
+    public_key character varying,
+    tpm_policy character varying,
+    vtpm_policy character varying,
+    meta_data character varying,
+    ima_whitelist character varying,
+    revocation_key character varying,
+    tpm_version integer,
+    accept_tpm_hash_algs text,
+    accept_tpm_encryption_algs text,
+    accept_tpm_signing_algs text,
+    hash_alg character varying,
+    enc_alg character varying,
+    sign_alg character varying
+);
+
+
+ALTER TABLE public.verifiermain OWNER TO keylime;
+
+--
+-- Name: verifiermain verifiermain_pkey; Type: CONSTRAINT; Schema: public; Owner: keylime
+--
+
+ALTER TABLE ONLY public.verifiermain
+    ADD CONSTRAINT verifiermain_pkey PRIMARY KEY (agent_id);
+
+--
+-- PostgreSQL database dump complete
+--
+


### PR DESCRIPTION
`check_same_thread` causes an error with postgres and should only
be used with sqlite

Also fixes an issue where the registrar still attempts to create
a sqlite file, even though postgres is configured.

Add missing documentation URL to keylime.conf

Add table creation files for postgres

Resolves: #344