### PR TITLE
create_whitelist: ostree system use /boot/ostree/*/initr*

### DIFF
--- a/scripts/create_whitelist.sh
+++ b/scripts/create_whitelist.sh
@@ -39,6 +39,14 @@ then
     exit $NOARGS;
 fi
 
+# Where to look for initramfs image
+INITRAMFS_LOC="/boot/"
+if [ -d "/ostree" ]; then
+    # If we are on an ostree system change where we look for initramfs image
+    loc=$(grep -E "/ostree/[^/]([^/]*)" -o /proc/cmdline | head -n 1 | cut -d / -f 3)
+    INITRAMFS_LOC="/boot/ostree/${loc}/"
+fi
+
 if [ $# -eq 2 ]
 then
     ALGO=$2
@@ -62,7 +70,7 @@ mkdir -p /tmp/ima
 
 # Iterate through init ram disks and add files to whitelist
 echo "Creating whitelist for init ram disk"
-for i in `ls /boot/initr*`
+for i in `ls ${INITRAMFS_LOC}/initr*`
 do
     echo "extracting $i"
     mkdir -p /tmp/ima/$i-extracted


### PR DESCRIPTION
When /ostree is a directory switch to using the ostree initramfs image location based off what is available in `/proc/cmdline`.

On Fedora CoreOS:

```
  [root@cosa-devsh ~]# ./create_whitelist.sh out
  Writing whitelist to /var/roothome/out with sha1sum...
  Creating whitelist for init ram disk
  extracting /boot/ostree/fedora-coreos-08a921dd4b162a14798a5f8892dd0a41b99dbfafdabfcc40a9f95cd9fe9de506/initramfs-5.7.12-200.fc32.x86_64.img
  [root@cosa-devsh ~]# wc -l out
  61158 out
  [root@cosa-devsh ~]#
```

Also tried the change on RHCOS and it succeeded as well.