### PR TITLE
Allow keylime to use larger whitelists

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -207,6 +207,11 @@ revocation_notifier = True
 revocation_notifier_ip = 127.0.0.1
 revocation_notifier_port = 8992
 
+# The verifier limits the size of upload payloads (whitelists) which defaults to
+# 100MB (104857600 bytes). This setting can be raised (or lowered) based on the
+# size of the actual payloads
+max_upload_size = 104857600
+
 #=============================================================================
 [tenant]
 #=============================================================================

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -374,8 +374,10 @@ def validate_agent_data(agent_data):
     if agent_data is None:
         return False, None
 
+    # validate that the ima_whitelist is proper JSON
+    lists = json.loads(agent_data['ima_whitelist'])
+
     # Validate exlude list contains valid regular expressions
-    lists = ast.literal_eval(agent_data['ima_whitelist'])
     is_valid, _, err_msg = common.valid_exclude_list(lists.get('exclude'))
     if not is_valid:
         err_msg += " Exclude list regex is misformatted. Please correct the issue and try again."

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -666,6 +666,11 @@ def main(argv=sys.argv):
     config = common.get_config()
     cloudverifier_port = config.get('cloud_verifier', 'cloudverifier_port')
 
+    # allow tornado's max upload size to be configurable
+    max_upload_size = None
+    if config.has_option('cloud_verifier', 'max_upload_size'):
+        max_upload_size = config.get('cloud_verifier', 'max_upload_size')
+
     VerfierMain.metadata.create_all(engine, checkfirst=True)
     session = SessionManager().make_session(engine)
     try:
@@ -704,7 +709,7 @@ def main(argv=sys.argv):
     tornado.process.fork_processes(config.getint(
         'cloud_verifier', 'multiprocessing_pool_num_workers'))
     asyncio.set_event_loop(asyncio.new_event_loop())
-    server = tornado.httpserver.HTTPServer(app, ssl_options=context)
+    server = tornado.httpserver.HTTPServer(app, ssl_options=context, max_buffer_size=max_upload_size)
     server.add_sockets(sockets)
 
     try:

--- a/keylime/httpclient_requests.py
+++ b/keylime/httpclient_requests.py
@@ -5,6 +5,11 @@ Copyright 2020 Luke Hinds (lhinds@redhat.com), Red Hat, Inc.
 
 import http.client
 
+from keylime import keylime_logging
+
+# setup logging
+logger = keylime_logging.init_logging('httpclient_requests')
+
 
 def request(method, host, port, params=None, data=None, context=None,
             timeout=5):
@@ -33,12 +38,16 @@ def request(method, host, port, params=None, data=None, context=None,
             timeout=timeout)
 
     try:
+        logger.debug(f"Making HTTP {method} request to {host}:{port}{params}")
         conn.request(method, params, body=data)
     except http.client.HTTPException as e:
+        logger.error(f"HTTPException: {e}")
         return 500, str(e)
-    except ConnectionError:
+    except ConnectionError as e:
+        logger.error(f"ConnectionError: {e}")
         return 503
-    except TimeoutError:
+    except TimeoutError as e:
+        logger.error(f"TimeoutError: {e}")
         return 504
     response = conn.getresponse()
     return response


### PR DESCRIPTION
Before the limit was 100MB set by tornado, but now we're explicitly
setting and controlling it ourselves. If this proves to be too
restrictive, we can look at making it configurable in the future.

Fixes issue #337