### PR TITLE
Minor test running improvements

### DIFF
--- a/.ci/test_wrapper.sh
+++ b/.ci/test_wrapper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-KEYLIME_HOME=/root/keylime
+KEYLIME_HOME="${KEYLIME_HOME=:-/root/keylime}"
 
 # Configure swtpm2
 cd ${KEYLIME_HOME}/scripts

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -7,8 +7,8 @@
 # Set python3 as default
 alias python='/usr/bin/python3'
 
-# Find Keylime directory (we're in test/ directory)
-KEYLIME_DIR=`pwd`/../
+# Find Keylime directory. It's one directory above the location of this script
+KEYLIME_DIR=$(realpath "$(dirname "$(readlink -f "$0")")/../")
 
 # Get list of tests in the test directory
 TEST_LIST=`ls | grep "^test_.*\.py$"`


### PR DESCRIPTION
* Allow test/run_tests.sh to be run from anywhere and it can figure out
  what the KEYLIME_DIR should be
* Allow KEYLIME_HOME in .ci/test_wrapper.sh to be overridden from
  the env in case you want to test out the full CI run locally from a
  modified source