### PR TITLE
Simple fix for ek_check_script support

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -450,7 +450,7 @@ class Tenant():
             if retval != 0:
                 raise UserError("External check script failed to validate EK")
                 while True:
-                    line = proc.stdout.readline()
+                    line = proc.stdout.readline().decode()
                     if line == "":
                         break
                     logger.debug(f"ek_check output: {line.strip()}")
@@ -459,7 +459,7 @@ class Tenant():
                 logger.debug(
                     "External check script successfully to validated EK")
                 while True:
-                    line = proc.stdout.readline()
+                    line = proc.stdout.readline().decode()
                     if line == "":
                         break
                     logger.debug(f"ek_check output: {line.strip()}")


### PR DESCRIPTION
When using `ek_check_script` (defined under `[tenant]` section on
keylime.conf), make sure the script's output is decoded from byte-string
back to string, given the stopping criterion while parsing the output is
a comparison with an empty string.