### PR TITLE
Seperate out revocation receiver IP:PORT

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -1,3 +1,4 @@
+#=============================================================================
 [general]
 #=============================================================================
 
@@ -12,6 +13,12 @@ tls_check_hostnames = False
 # go binary installed in your path or in /usr/local/
 # Revocation list generation is only supported by cfssl
 ca_implementation = openssl
+
+# Revocation IP & Port used by either the cloud_agent or keylime_ca to receive
+# revocation events from the verifier. A wildcard can be used to listen on all
+# interfaces, or likewise a specific IP (e.g 192.168.0.1)
+receive_revocation_ip= *
+receive_revocation_port = 8992
 
 #=============================================================================
 [cloud_agent]

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -35,8 +35,8 @@ def start_broker():
 
         # Socket facing services
         backend = context.socket(zmq.PUB)
-        backend.bind("tcp://*:%s" %
-                     config.getint('cloud_verifier', 'revocation_notifier_port'))
+        backend.bind("tcp://%s:%s" % (config.get('cloud_verifier', 'revocation_notifier_ip'),
+                                      config.getint('cloud_verifier', 'revocation_notifier_port')))
 
         zmq.device(zmq.FORWARDER, frontend, backend)
 
@@ -87,11 +87,11 @@ def await_notifications(callback, revocation_cert_path):
     context = zmq.Context()
     mysock = context.socket(zmq.SUB)
     mysock.setsockopt(zmq.SUBSCRIBE, b'')
-    mysock.connect("tcp://%s:%s" % (config.get('cloud_verifier', 'revocation_notifier_ip'),
-                                    config.getint('cloud_verifier', 'revocation_notifier_port')))
+    mysock.connect("tcp://%s:%s" % (config.get('general', 'receive_revocation_ip'),
+                                    config.getint('general', 'receive_revocation_port')))
 
     logger.info('Waiting for revocation messages on 0mq %s:%s' %
-                (config.get('cloud_verifier', 'revocation_notifier_ip'), config.getint('cloud_verifier', 'revocation_notifier_port')))
+                (config.get('general', 'receive_revocation_ip'), config.getint('general', 'receive_revocation_port')))
 
     while True:
         rawbody = mysock.recv()


### PR DESCRIPTION
This change seeks to clear up potential confusion over what values
are being set and used for the revocation notifier and reciever

We introduce a `receive_revocation_ip` which can be used by either
the agent or keylime_ca

`cloud_verifier, revocation_notifier_ip` remains as it was and is
used by the verifier.

Also remove the hardcoded `*` wildcard for the config value for
`revocation_notifier_ip` which results in listen on all interfaces
Instead use the config value (as a user may wish to listen on
a specfic IP / interface)

Resolves: #378