### PR TITLE
Remove shell=True from exec_cmd

### DIFF
--- a/auto-ipsec/libreswan/src/local_action_crashsa.py
+++ b/auto-ipsec/libreswan/src/local_action_crashsa.py
@@ -35,12 +35,13 @@ async def execute(revocation):
     secdir = secure_mount.mount()
     logger.info(
         "loading updated CRL from %s/unzipped/cacrl.der into NSS" % secdir)
-    cmd_exec.run(
-        "crlutil -I -i %s/unzipped/cacrl.der -d sql:/etc/ipsec.d" % secdir, lock=False)
+    cmd = ('crlutil', '-I', '-i', '%s/unzipped/cacrl.der' % secdir,
+           '-d', 'sql:/etc/ipsec.d')
+    cmd_exec.run(cmd, lock=False)
 
     # need to find any sa's that were established with that cert subject name
-    output = cmd_exec.run("ipsec whack --trafficstatus",
-                          lock=False, raiseOnError=True)['retout']
+    cmd = ('ipsec', 'whack', '--trafficstatus')
+    output = cmd_exec.run(cmd, lock=False, raiseOnError=True)['retout']
     deletelist = set()
     id = ""
     for line in output:
@@ -76,5 +77,5 @@ async def execute(revocation):
 
     for todelete in deletelist:
         logger.info("deleting IPsec sa with %s" % todelete)
-        cmd_exec.run("ipsec whack --crash %s" %
-                     todelete, raiseOnError=False, lock=False)
+        cmd = ('ipsec', 'whack', '--crash', todelete)
+        cmd_exec.run(cmd, raiseOnError=False, lock=False)

--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -265,8 +265,9 @@ def convert_crl_to_pem(derfile, pemfile):
         with open(pemfile, 'w') as f:
             f.write("")
     else:
-        cmd_exec.run("openssl crl -in %s -inform der -out %s" %
-                     (derfile, pemfile), lock=False)
+        cmd = ('openssl', 'crl', '-in', derfile, '-inform', 'der',
+               '-out', pemfile)
+        cmd_exec.run(cmd, lock=False)
 
 
 def get_crl_distpoint(cert_path):
@@ -319,7 +320,7 @@ def cmd_revoke(workingdir, name=None, serial=None):
         write_private(priv)
 
         # write out the CRL to the disk
-        if os.stat('cacrl.der').st_size :
+        if os.stat('cacrl.der').st_size:
             with open('cacrl.der', 'wb') as f:
                 f.write(crl)
             convert_crl_to_pem("cacrl.der", "cacrl.pem")
@@ -379,9 +380,11 @@ def cmd_listen(workingdir, cert_path):
             logger.info("checking CRL for expiration every hour")
             while True:
                 try:
-                    if os.path.exists('cacrl.der') and os.stat('cacrl.der').st_size :
-                        retout = cmd_exec.run(
-                            "openssl crl -inform der -in cacrl.der -text -noout", lock=False)['retout']
+                    if (os.path.exists('cacrl.der') and
+                            os.stat('cacrl.der').st_size):
+                        cmd = ('openssl', 'crl', '-inform', 'der', '-in',
+                               'cacrl.der', '-text', '-noout')
+                        retout = cmd_exec.run(cmd, lock=False)['retout']
                         for line in retout:
                             line = line.strip()
                             if line.startswith(b"Next Update:"):

--- a/keylime/cmd_exec.py
+++ b/keylime/cmd_exec.py
@@ -14,19 +14,29 @@ utilLock = threading.Lock()
 EXIT_SUCESS = 0
 
 
-def run(cmd, expectedcode=EXIT_SUCESS, raiseOnError=True, lock=True, outputpaths=None, env=os.environ):
+def _execute(cmd, env=None, **kwargs):
+    proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, **kwargs)
+    out, err = proc.communicate()
+    code = proc.returncode
+    return out, err, code
+
+
+def run(cmd, expectedcode=EXIT_SUCESS, raiseOnError=True, lock=True,
+        outputpaths=None, env=os.environ, **kwargs):
+    """Execute external command.
+
+    :param cmd: a sequence of command arguments
+    """
     global utilLock
 
     t0 = time.time()
     if lock:
         with utilLock:
-            proc = subprocess.Popen(cmd, env=env, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (retout, reterr) = proc.communicate()
-            code = proc.returncode
+            retout, reterr, code = _execute(cmd, env=env, **kwargs)
     else:
-        proc = subprocess.Popen(cmd, env=env, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        (retout, reterr) = proc.communicate()
-        code = proc.returncode
+        retout, reterr, code = _execute(cmd, env=env, **kwargs)
+
     t1 = time.time()
     timing = {'t1': t1, 't0': t0}
 

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -492,7 +492,8 @@ def main(argv=sys.argv):
         if os.getuid() != 0:
             raise RuntimeError('agent_uuid is configured to use dmidecode, '
                                'but current process is not running as root.')
-        ret = cmd_exec.run('which dmidecode', raiseOnError=False)
+        cmd = ['which', 'dmidecode']
+        ret = cmd_exec.run(cmd, raiseOnError=False)
         if ret['code'] != 0:
             raise RuntimeError('agent_uuid is configured to use dmidecode, '
                                'but it\'s is not found on the system.')
@@ -533,7 +534,8 @@ def main(argv=sys.argv):
     elif agent_uuid == 'generate' or agent_uuid is None:
         agent_uuid = str(uuid.uuid4())
     elif agent_uuid == 'dmidecode':
-        ret = cmd_exec.run('dmidecode -s system-uuid')
+        cmd = ['dmidecode', '-s', 'system-uuid']
+        ret = cmd_exec.run(cmd)
         sys_uuid = ret['retout'].decode('utf-8')
         agent_uuid = sys_uuid.strip()
     if common.STUB_VTPM and common.TPM_CANNED_VALUES is not None:

--- a/keylime/secure_mount.py
+++ b/keylime/secure_mount.py
@@ -55,7 +55,8 @@ def mount():
         common.chownroot(secdir, logger)
         size = config.get('cloud_agent', 'secure_size')
         logger.info("mounting secure storage location %s on tmpfs" % secdir)
-        cmd_exec.run("mount -t tmpfs -o size=%s,mode=0700 tmpfs %s" %
-                     (size, secdir), lock=False)
+        cmd = ('mount', '-t', 'tmpfs', '-o', 'size=%s,mode=0700' % size,
+               'tmpfs', secdir)
+        cmd_exec.run(cmd, lock=False)
 
     return secdir

--- a/keylime/tpm/tpm1.py
+++ b/keylime/tpm/tpm1.py
@@ -127,9 +127,15 @@ class tpm1(tpm_abstract.AbstractTPM):
         while True:
             if lock:
                 with self.tpmutilLock:
-                    retDict = cmd_exec.run(cmd=cmd, expectedcode=expectedcode, raiseOnError=False, lock=lock, outputpaths=outputpaths, env=env)
+                    retDict = cmd_exec.run(
+                        cmd=cmd, expectedcode=expectedcode,
+                        raiseOnError=False, lock=lock,
+                        outputpaths=outputpaths, env=env, shell=True)
             else:
-                retDict = cmd_exec.run(cmd=cmd, expectedcode=expectedcode, raiseOnError=False, lock=lock, outputpaths=outputpaths, env=env)
+                retDict = cmd_exec.run(
+                    cmd=cmd, expectedcode=expectedcode, raiseOnError=False,
+                    lock=lock, outputpaths=outputpaths, env=env, shell=True)
+
             t0 = retDict['timing']['t0']
             t1 = retDict['timing']['t1']
             code = retDict['code']

--- a/keylime/tpm/tpm2.py
+++ b/keylime/tpm/tpm2.py
@@ -254,10 +254,9 @@ class tpm2(tpm_abstract.AbstractTPM):
         while True:
             if lock:
                 with self.tpmutilLock:
-                    retDict = cmd_exec.run(cmd=cmd, expectedcode=expectedcode, raiseOnError=False, lock=lock, outputpaths=outputpaths, env=env)
+                    retDict = cmd_exec.run(cmd=cmd, expectedcode=expectedcode, raiseOnError=False, lock=lock, outputpaths=outputpaths, env=env, shell=True)
             else:
-                retDict = cmd_exec.run(cmd=cmd, expectedcode=expectedcode, raiseOnError=False, lock=lock, outputpaths=outputpaths, env=env)
-
+                retDict = cmd_exec.run(cmd=cmd, expectedcode=expectedcode, raiseOnError=False, lock=lock, outputpaths=outputpaths, env=env, shell=True)
             t0 = retDict['timing']['t0']
             t1 = retDict['timing']['t1']
             code = retDict['code']

--- a/keylime/vtpm_manager.py
+++ b/keylime/vtpm_manager.py
@@ -446,7 +446,7 @@ def tpmconv(inmod):
         inFile.close()
         os.close(infd)
 
-        command = "tpmconv -ik %s -ok %s" % (inFile.name, tmppath)
+        command = ('tpmconv', '-ik', 'inFile.name', '-ok', tmppath)
         tpm.__run(command, lock=False)
 
         # read in the pem


### PR DESCRIPTION
Removed shell=True from exec_cmd, currently in a tradeoff
of converting string argument of tpm.__run to list by split.

Issue #131