### PR TITLE
Restrict verifier and registrar port listening

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -630,6 +630,7 @@ def main(argv=sys.argv):
 
     config = common.get_config()
     cloudverifier_port = config.get('cloud_verifier', 'cloudverifier_port')
+    cloudverifier_host = config.get('cloud_verifier', 'cloudverifier_ip')
 
     # allow tornado's max upload size to be configurable
     max_upload_size = None
@@ -670,7 +671,7 @@ def main(argv=sys.argv):
         revocation_notifier.start_broker()
 
     sockets = tornado.netutil.bind_sockets(
-        int(cloudverifier_port), address='0.0.0.0')
+        int(cloudverifier_port), address=cloudverifier_host)
     tornado.process.fork_processes(config.getint(
         'cloud_verifier', 'multiprocessing_pool_num_workers'))
     asyncio.set_event_loop(asyncio.new_event_loop())

--- a/keylime/cmd/provider_registrar.py
+++ b/keylime/cmd/provider_registrar.py
@@ -16,8 +16,11 @@ config = common.get_config()
 
 
 def main(argv=sys.argv):
-    registrar_common.start(config.getint('registrar', 'provider_registrar_tls_port'), config.getint(
-        'registrar', 'provider_registrar_port'), config.get('registrar', 'prov_db_filename'))
+    registrar_common.start(
+        config.get('registrar', 'provider_registrar_ip'),
+        config.getint('registrar', 'provider_registrar_tls_port'),
+        config.getint('registrar', 'provider_registrar_port'),
+        config.get('registrar', 'prov_db_filename'))
 
 
 if __name__ == "__main__":

--- a/keylime/cmd/registrar.py
+++ b/keylime/cmd/registrar.py
@@ -22,8 +22,10 @@ def main(argv=sys.argv):
     if config.has_option('registrar', 'auto_migrate_db') and config.getboolean('registrar', 'auto_migrate_db'):
         keylime.cmd.migrations_apply.apply('registrar')
 
-    registrar_common.start(config.getint(
-        'registrar', 'registrar_tls_port'), config.getint('registrar', 'registrar_port'))
+    registrar_common.start(
+        config.get('registrar', 'registrar_ip'),
+        config.getint('registrar', 'registrar_tls_port'),
+        config.getint('registrar', 'registrar_port'))
 
 
 if __name__ == "__main__":

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -467,13 +467,13 @@ def do_shutdown(servers):
         server.shutdown()
 
 
-def start(tlsport, port):
+def start(host, tlsport, port):
     """Main method of the Registrar Server.  This method is encapsulated in a function for packaging to allow it to be
     called as a function by an external program."""
 
     threads = []
     servers = []
-    serveraddr = ('', tlsport)
+    serveraddr = (host, tlsport)
 
     RegistrarMain.metadata.create_all(engine, checkfirst=True)
     session = SessionManager().make_session(engine)
@@ -493,7 +493,7 @@ def start(tlsport, port):
     threads.append(thread)
 
     # start up the unprotected registrar server
-    serveraddr2 = ('', port)
+    serveraddr2 = (host, port)
     server2 = UnprotectedRegistrarServer(serveraddr2, UnprotectedHandler)
     thread2 = threading.Thread(target=server2.serve_forever)
     threads.append(thread2)


### PR DESCRIPTION
verifier and registrar is listening 0.0.0.0 address which could expose
services to unwanted networks. Since there are configurations for the
specific addresses to bind to, let's use it instead.

Resolves #389