### PR TITLE
Run code style checks on python files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 dist: bionic
 
 sudo: required
+addons:
+  apt:
+    packages:
+      - pycodestyle
 
 # If the change is a markdown file, don't run CI build. Or at a later point
 # we can set a specific job in here (such as a markdown lint)
@@ -27,6 +31,7 @@ services:
   - docker
 
 before_install:
+  - make check
   - 'docker pull ${tpm12image}:${tpm12tag}'
   - 'docker pull ${tpm20image}:${tpm20tag}'
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+
+.PHONY: check
+check:
+	scripts/check_codestyle.sh

--- a/scripts/check_codestyle.sh
+++ b/scripts/check_codestyle.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+TOOL=$(type -P pycodestyle)
+if [ -z "${TOOL}" ]; then
+	TOOL=$(type -P pep8)
+fi
+if [ -z "${TOOL}" ]; then
+	echo "Either pycodestyle-3 or pep8 is required"
+	exit 1
+fi
+
+${TOOL} *.py
+exit $?

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setuptools.setup(
             'keylime_userdata_encrypt=keylime.cmd.user_data_encrypt:main',
             'keylime_registrar=keylime.cmd.registrar:main',
             'keylime_provider_registrar=keylime.cmd.provider_registrar:main',
-            'keylime_provider_platform_init=keylime.cmd.provider_platform_init:main', # noqa
+            'keylime_provider_platform_init=keylime.cmd.provider_platform_init:main',  # noqa
             'keylime_provider_vtpm_add=keylime.cmd.provider_vtpm_add:main',
             'keylime_ca=keylime.cmd.ca:main',
             'keylime_ima_emulator=keylime.cmd.ima_emulator_adapter:main',


### PR DESCRIPTION
This PR adds a script for launching either pep8 or pycodestyle-3 to check the python code style. Also a Makefile is added with a check target for running the script either on a local machine or by Travis. We now also run it as part of the Travis build.