### PR TITLE
Support using system-uuid from dmidecode as agent uuid

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -62,6 +62,8 @@ extract_payload_zip = True
 # If you set this to "generate", Keylime will create a random UUID.
 # If you set this to "hash_ek", Keylime will set the UUID to the result
 # of 'SHA256(public EK in PEM format)'.
+# If you set this to "dmidecode", Keylime will use the UUID from
+# 'dmidecode -s system-uuid'.
 agent_uuid = D432FBB3-D2F1-4A97-9EF7-75BD81C00000
 
 # Whether to listen for revocation notifications from the verifier or not.


### PR DESCRIPTION
system-uuid from dmidecode can be considered unique and doesn't
change from machine to machine.