### PR TITLE
Enable IMA PCR by adding it to the mask using 'logical or'

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -200,7 +200,7 @@ class Tenant():
 
             # Auto-enable IMA (or-bit mask)
             self.tpm_policy['mask'] = "0x%X" % (
-                int(self.tpm_policy['mask'], 0) + (1 << common.IMA_PCR))
+                int(self.tpm_policy['mask'], 0) | (1 << common.IMA_PCR))
 
             if type(args["allowlist"]) in [str, str]:
                 if args["allowlist"] == "default":


### PR DESCRIPTION
Enable the IMA PCR by adding it to the mask using a 'logical or'
rather than 'adding' it.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.xom>