### PR TITLE
Enable PR assignment automation from actions-automation

### DIFF
--- a/.github/workflows/keylime-bot.yml
+++ b/.github/workflows/keylime-bot.yml
@@ -1,0 +1,57 @@
+name: keylime-bot
+
+on:
+  check_run:
+  check_suite:
+  create:
+  delete:
+  deployment:
+  deployment_status:
+  fork:
+  gollum:
+  issue_comment:
+  issues:
+  label:
+  milestone:
+  page_build:
+  project:
+  project_card:
+  project_column:
+  public:
+  pull_request_target:
+    types:
+      - assigned
+      - unassigned
+      - labeled
+      - unlabeled
+      - opened
+      - edited
+      - closed
+      - reopened
+      - synchronize
+      - ready_for_review
+      - locked
+      - unlocked
+      - review_requested
+      - review_request_removed
+  push:
+  registry_package:
+  release:
+  status:
+  watch:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  pull-request-responsibility:
+    runs-on: ubuntu-latest
+    env:
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+    name: pull-request-responsibility
+    steps:
+      - uses: actions-automation/pull-request-responsibility@main
+        with:
+          LABEL: "keylime-bot for keylime"
+          reviewers: "core"
+          num_to_request: 3


### PR DESCRIPTION
Roughly equivalent to https://github.com/keylime/enhancements/pull/35.

Once merged, pull requests will:
- automatically have reviewers requested (currently pulls from Github's suggested reviewers and the `core` team)
- have their assignees updated based on who is most responsible at any given time

Since bot setup was already done for `enhancements`, this should be good to go as is.