### PR TITLE
Fix typo in Exception type

### DIFF
--- a/keylime/migrations/env.py
+++ b/keylime/migrations/env.py
@@ -126,7 +126,7 @@ def run_migrations_online():
 
         for rec in engines.values():
             rec["transaction"].commit()
-    except Except:
+    except Exception:
         for rec in engines.values():
             rec["transaction"].rollback()
         raise


### PR DESCRIPTION
Hasn't been hit unless there is an error in the migrations which is why
it didn't cause tests to fail