### PR TITLE
codestyle: Transition to pylint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ sudo: required
 addons:
   apt:
     packages:
-      - pycodestyle
+      - python3-pip
+      - python3-setuptools
 
 # If the change is a markdown file, don't run CI build. Or at a later point
 # we can set a specific job in here (such as a markdown lint)
@@ -31,6 +32,7 @@ services:
   - docker
 
 before_install:
+  - sudo pip3 install pylint --upgrade
   - make check
   - 'docker pull ${tpm12image}:${tpm12tag}'
   - 'docker pull ${tpm20image}:${tpm20tag}'

--- a/scripts/check_codestyle.sh
+++ b/scripts/check_codestyle.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 
-TOOL=$(type -P pycodestyle)
-if [ -z "${TOOL}" ]; then
-	TOOL=$(type -P pep8)
-fi
-if [ -z "${TOOL}" ]; then
-	echo "Either pycodestyle-3 or pep8 is required"
+if [ -z "$(type -P pylint)" ]; then
+	echo "pylint is required"
 	exit 1
 fi
 
-${TOOL} --max-line-length=2000 --ignore=E741,W504 *.py $(find ./keylime ./test -name '*.py')
+pylint \
+  --disable C0103,C0115,C0116,C0123,C0200,C0325,C0301,C0302,C0330,C0411,C0412,C0414,C0415,C0114,C0122 \
+  --disable C0111 \
+  --disable W0707,W0201,W0223,W0235,W1201,W1202,W0611,W0603,W0613,W0703,W1309,W0102,W0702,W0622,W0212 \
+  --disable W1505,W0511,W0631,W0632,W0621,W0612,W0105,W0715,W0101,W0221,W0107,W1509,W0614,W0401,W0601 \
+  --disable W1203 \
+  --disable E0401,E0611,E1300,E1101,E0602,E1205,E1120,E1121,E1123,E1111,E1136 \
+  --disable R0801,R0902,R0205,R0903,R0912,R0914,R0915,R1702,R1705,R1711,R1722,R1724,R1720,R0201,R0911 \
+  --disable R1723,R1716,R0913,R1714,R0124,R1710,R0904,R1703,R1725 \
+  *.py $(find ./keylime ./test -name '*.py')
 exit $?


### PR DESCRIPTION
Transition from pep8 to pylint. Suppress many pylint errors/warnings that
we have not cleaned up the code for, yet, since those were not supported
by pep8.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>