### PR TITLE
Fixes an error with `keylime_tenant -c reactivate`

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -420,6 +420,8 @@ class AgentsHandler(BaseHandler):
                 json_response = json.loads(response.body)
 
                 # validate the cloud agent response
+                if 'provide_V' not in agent :
+                    agent['provide_V'] = True
                 if cloud_verifier_common.process_quote_response(agent, json_response['results']):
                     if agent['provide_V']:
                         asyncio.ensure_future(self.process_agent(


### PR DESCRIPTION
Fixes an error where `keylime_tenant -c reactivate` is called, 
and the`verifier` returns an error complaining about the lack of the key
`provide_V` on the "agent" object. With this small change, `reactivate`
can be properly issued, even after a `verifier` restart, and a new U/V
(and pubkey) exchange will be done.