### PR TITLE
Optionally validate client certificate

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -160,6 +160,9 @@ private_key = default
 # generated CA private key.
 private_key_pw = default
 
+# Whether verifier validates client certificate
+check_client_cert = True
+
 # Registrar client TLS options. This allows the CV to authenticate the
 # registar before asking for AIKs.
 # This option sets the directory where the CA certificate for the registrar
@@ -183,6 +186,8 @@ registrar_private_key = default
 # If you are using the auto generated keys from the CV, set the same password
 # here as you did for 'private_key_pw' above.
 registrar_private_key_pw = default
+
+registrar_require_cert = True
 
 # Database URL Configuration
 # See this document https://keylime-docs.readthedocs.io/en/latest/installation.html#database-support
@@ -441,6 +446,8 @@ registrar_private_key = default
 # here as you did for private_key_pw in the [cloud_verifier] section.
 registrar_private_key_pw = default
 
+# Whether registrar validates client certificate
+check_client_cert = True
 
 # Database URL Configuration
 # See this document https://keylime-docs.readthedocs.io/en/latest/installation.html#database-support

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -149,7 +149,8 @@ def init_mtls(section='cloud_verifier', generatedir='cv_ca'):
         context.load_verify_locations(cafile=ca_path)
         context.load_cert_chain(
             certfile=my_cert, keyfile=my_priv_key, password=my_key_pw)
-        context.verify_mode = ssl.CERT_REQUIRED
+        if config.getboolean(section, 'check_client_cert', fallback=True):
+            context.verify_mode = ssl.CERT_REQUIRED
     except ssl.SSLError as exc:
         if exc.reason == 'EE_KEY_TOO_SMALL':
             logger.error('Higher key strength is required for keylime '


### PR DESCRIPTION
Currently it's not configurable, this PR adds two configuration
options named check_client_cert and defaults to true for verifier
and registrar, when set to false will not validate client certificate.