### PR TITLE
Fix `keylime_tenant -c list`.

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -529,7 +529,7 @@ class Tenant():
 
         do_cvstatus = RequestsClient(self.verifier_base_url, self.tls_enabled)
         response = do_cvstatus.get(
-            (f'/agents/{self.agent_uuid}'),
+            (f'/agents/{agent_uuid}'),
             cert=self.cert,
             verify=False
         )


### PR DESCRIPTION
When this command is called, the agent uuid passed to `do_cvstatus` must
be made empty. If not, instead of correctly issuing `GET /agents/`,
returning a list of all agents on a verifier, the aforementioned command
will issue `GET /agents/<default UUID in case one is not specified>`,
resulting in error.