### PR TITLE
Simplify database configuration

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -192,7 +192,16 @@ registrar_private_key_pw = default
 # Database URL Configuration
 # See this document https://keylime-docs.readthedocs.io/en/latest/installation.html#database-support
 # for instructions on using different database configurations.
-# The default is "sqlite" and will be located at "/var/lib/keylime/cv_data.sqlite".
+# Database configuration via drivername, username, password, etc is deprecated
+# and superseded by database_url, when database_url is set, other database
+# fields will be ignored.
+# An example of database_url value for using sqlite:
+#   sqlite:////var/lib/keylime/cv_data.sqlite
+# An example of database_url value for using mysql:
+#   mysql+pymysql://keylime:keylime@keylime_db:[port]/verifier?charset=utf8
+# If database_url is not set, the deprecated default is "sqlite" and will be
+# located at "/var/lib/keylime/cv_data.sqlite".
+database_url =
 drivername = sqlite
 username = ''
 password = ''
@@ -200,6 +209,7 @@ host = ''
 port = ''
 database = cv_data.sqlite
 query = ''
+
 auto_migrate_db = True
 
 
@@ -452,7 +462,16 @@ check_client_cert = True
 # Database URL Configuration
 # See this document https://keylime-docs.readthedocs.io/en/latest/installation.html#database-support
 # for instructions on using different database configurations.
-# The default is "sqlite" and will be located at "/var/lib/keylime/reg_data.sqlite".
+# Database configuration via drivername, username, password, etc is deprecated
+# and superseded by database_url, when database_url is set, other database
+# fields will be ignored.
+# An example of database_url value for using sqlite:
+#   sqlite:////var/lib/keylime/reg_data.sqlite
+# An example of database_url value for using mysql:
+#   mysql+pymysql://keylime:keylime@keylime_db:[port]/registrar?charset=utf8
+# If database_url is not set, the deprecated default is "sqlite" and will be
+# located at "/var/lib/keylime/reg_data.sqlite".
+database_url =
 drivername = sqlite
 username = ''
 password = ''
@@ -460,7 +479,9 @@ host = ''
 port = ''
 database = reg_data.sqlite
 query = ''
+
 auto_migrate_db = True
+
 
 # The file to use for SQLite persistence of provider hypervisor data.
 prov_db_filename = provider_reg_data.sqlite

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -341,8 +341,8 @@ class UnprotectedHandler(BaseHTTPRequestHandler, SessionManager):
                     except SQLAlchemyError as e:
                         logger.error(f'SQLAlchemy Error: {e}')
                 else:
-                    drivername = config.get('registrar', 'drivername')
-                    if drivername == "mysql":
+                    # TODO(kaifeng) Special handling should be removed
+                    if engine.dialect.name == "mysql":
                         agent.key = agent.key.encode('utf-8')
 
                     ex_mac = crypto.do_hmac(agent.key, agent_id)


### PR DESCRIPTION
Currently database configuration is breaked into several options,
we could just pass a connection string to SQLAlchemy instead of
constructing the url.

E.g.:

sqlite:////var/lib/keylime/cv_data.sqlite
mysql+pymysql://keylime:keylime@db_host/verifier