### PR TITLE
Opt repo into "copy-labels-linked" automation action

### DIFF
--- a/.github/workflows/keylime-bot.yml
+++ b/.github/workflows/keylime-bot.yml
@@ -52,5 +52,6 @@ jobs:
     steps:
       - uses: actions-automation/pull-request-responsibility@main
         with:
+          actions: "request,assign,copy-labels-linked"
           reviewers: "core"
           num_to_request: 3


### PR DESCRIPTION
[`pull-request-responsibility`](https://github.com/actions-automation/pull-request-responsibility), the repo providing `keylime` with its PR review cycle automation, is getting some new features!

1) Auto-merge -- if all required merge criteria is met (ex. approval from x reviewers with write access, tests passing, no conflicts), PRs will automatically be merged

2) Copy linked labels -- if you link a PR to an issue, automatically copy any labels on the issue over to the PR. For example, if issue #123 has the label "enhancement" and PR #124 is linked to #123 (by using "Resolves #xyz"), PR #124 will automatically be tagged as "enhancement" as well

~~These new actions will be enabled by default soon. However, if one or both of these aren't appropriate for `keylime`, this patch will opt the repo out of both. Feel free to close if both sound good or merge if there are concerns with the above actions (or request changes if you only want to allow one).~~

I've changed the automation action's behavior from opt-out to opt-in. This PR now opts `keylime` into the new `copy-labels-linked` action as well as existing actions, while not enabling auto-merge (per @mpeters' concerns [here](https://github.com/keylime/rust-keylime/pull/150#issuecomment-739989153)).