### PR TITLE
Support hostname as agent id

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -63,6 +63,8 @@ extract_payload_zip = True
 # of 'SHA256(public EK in PEM format)'.
 # If you set this to "dmidecode", Keylime will use the UUID from
 # 'dmidecode -s system-uuid'.
+# If you set this to "hostname", Keylime will use the full qualified domain
+# name of current host as the agent id.
 agent_uuid = D432FBB3-D2F1-4A97-9EF7-75BD81C00000
 
 # Whether to listen for revocation notifications from the verifier or not.

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -15,6 +15,7 @@ import base64
 import configparser
 import uuid
 import os
+import socket
 import sys
 import time
 import hashlib
@@ -535,6 +536,8 @@ def main(argv=sys.argv):
         ret = cmd_exec.run(cmd)
         sys_uuid = ret['retout'].decode('utf-8')
         agent_uuid = sys_uuid.strip()
+    elif agent_uuid == 'hostname':
+        agent_uuid = socket.getfqdn()
     if common.STUB_VTPM and common.TPM_CANNED_VALUES is not None:
         # Use canned values for stubbing
         jsonIn = common.TPM_CANNED_VALUES


### PR DESCRIPTION
hostname is considered unique and can be used as agent id.
Other forms of identifiers need to be manually retrieved
thus hard to automate.