### PR TITLE
Overhaul container infra to support migrating testing to GH Actions

### DIFF
--- a/.ci/test_wrapper.sh
+++ b/.ci/test_wrapper.sh
@@ -4,33 +4,19 @@ set -x
 KEYLIME_HOME="${KEYLIME_HOME=:-/root/keylime}"
 
 # Configure swtpm2
-cd ${KEYLIME_HOME}/scripts
-chmod +x init_tpm_server
-chmod +x tpm_serverd
-install -c tpm_serverd /usr/local/bin/tpm_serverd
-install -c init_tpm_server /usr/local/bin/init_tpm_server
-# Server needs to be running, or tpm2-abrmd.service will fail.
-/usr/local/bin/tpm_serverd
-
-export TPM2TOOLS_TCTI="tabrmd:bus_name=com.intel.tss2.Tabrmd"
-pkill -HUP dbus-daemon
-
-# Configure tpm2-abrmd systemd
-# systemd-udev-settle is not needed to run tpm2-tools in container
-sed -i 's/^After/#&/' /usr/lib/systemd/system/tpm2-abrmd.service
-sed -i 's/^Requires/#&/' /usr/lib/systemd/system/tpm2-abrmd.service
-# the tpm device is not needed to run tpm2-tools in container with the
-# tpm emulator
-sed -i 's/^ConditionPathExists/#&/' /usr/lib/systemd/system/tpm2-abrmd.service
-sed -i 's/.*ExecStart.*/ExecStart=\/usr\/sbin\/tpm2-abrmd --tcti=mssim/' /usr/lib/systemd/system/tpm2-abrmd.service
-systemctl daemon-reload
-systemctl enable tpm2-abrmd
-systemctl start tpm2-abrmd
-# Check that tpm2-abrmd is actually running as starting it won't report failures
-if ! (systemctl -q is-active tpm2-abrmd); then
-    echo "tpm2-abrmd failed to start, exiting"
-    exit 1
-fi
+mkdir /tmp/tpmdir
+swtpm_setup --tpm2 \
+     --tpmstate /tmp/tpmdir \
+     --createek --allow-signing --decryption --create-ek-cert \
+     --create-platform-cert \
+     --display
+swtpm socket --tpm2 \
+     --tpmstate dir=/tmp/tpmdir \
+     --flags startup-clear \
+     --ctrl type=tcp,port=2322 \
+     --server type=tcp,port=2321 \
+     --daemon
+export TPM2TOOLS_TCTI=swtpm:
 
 # Run tests
 cd ${KEYLIME_HOME}/test

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,11 @@
 ##############################################################################
 # keylime TPM 2.0 Dockerfile
 #
-# This file is for automatic test running of Keylime.
+# This file is for automatic test running of Keylime and rust-keylime.
 # It is not recommended for use beyond testing scenarios.
 ##############################################################################
 
-FROM fedora:31
+FROM fedora:latest
 MAINTAINER Luke Hinds <lhinds@redhat.com>
 LABEL version="1.0.1" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
 
@@ -18,6 +18,8 @@ ENV TPM_HOME ${HOME}/swtpm2
 
 # Packaged dependencies
 ENV PKGS_DEPS="automake \
+cargo \
+clang-devel \
 dbus-devel \
 dnf-plugins-core \
 gcc \
@@ -25,8 +27,10 @@ git \
 glib2-devel \
 glib2-static \
 gnulib \
+kmod \
 libselinux-python3 \
 libtool \
+libtpms \
 make \
 openssl-devel \
 procps \
@@ -35,6 +39,7 @@ python3-dbus \
 python3-devel \
 python3-m2crypto \
 python3-pip \
+python3-requests \
 python3-setuptools \
 python3-sqlalchemy \
 python3-tornado \
@@ -42,9 +47,13 @@ python3-virtualenv \
 python3-yaml \
 python3-zmq \
 redhat-rpm-config \
+rust \
+swtpm \
+swtpm-tools \
 tpm2-abrmd \
 tpm2-tools \
 tpm2-tss \
+tpm2-tss-devel \
 uthash-devel \
 wget \
 which"
@@ -53,29 +62,3 @@ RUN dnf makecache && \
   dnf -y install $PKGS_DEPS && \
   dnf clean all && \
   rm -rf /var/cache/dnf/*
-
-RUN cd "/lib/systemd/system/sysinit.target.wants/"; \
-    for i in *; do [ $i = systemd-tmpfiles-setup.service ] || rm -f "$i"; done
-
-RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
-    /etc/systemd/system/*.wants/* \
-    /lib/systemd/system/local-fs.target.wants/* \
-    /lib/systemd/system/sockets.target.wants/*udev* \
-    /lib/systemd/system/sockets.target.wants/*initctl* \
-    /lib/systemd/system/basic.target.wants/* \
-    /lib/systemd/system/anaconda.target.wants/*
-
-RUN systemctl set-default multi-user.target
-ENV init /lib/systemd/systemd
-
-# Build and install TPM 2.0 simulator
-WORKDIR ${TPM_HOME}
-RUN wget --content-disposition http://sourceforge.net/projects/ibmswtpm2/files/ibmtpm1119.tar.gz/download && \
-  tar -zxvf ibmtpm1119.tar.gz
-WORKDIR ${TPM_HOME}/src
-RUN make && \
-  install -c tpm_server /usr/local/bin/tpm_server
-
-VOLUME [ "/sys/fs/cgroup" ]
-
-ENTRYPOINT ["/lib/systemd/systemd"]


### PR DESCRIPTION
These changes should support running Keylime's TPM 2.0 tests within a container without needing any of the hacks that were present previously.

Tagging @lukehinds and @puiterwijk for review.