### PR TITLE
Remove KEYLIME_HOME in test_wrapper.sh

### DIFF
--- a/.ci/test_wrapper.sh
+++ b/.ci/test_wrapper.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -x
 
-KEYLIME_HOME="${KEYLIME_HOME=:-/root/keylime}"
-
 # Configure swtpm2
 mkdir /tmp/tpmdir
 swtpm_setup --tpm2 \
@@ -19,6 +17,5 @@ swtpm socket --tpm2 \
 export TPM2TOOLS_TCTI=swtpm:
 
 # Run tests
-cd ${KEYLIME_HOME}/test
 chmod +x ./run_tests.sh
 ./run_tests.sh -s openssl


### PR DESCRIPTION
No longer needed on Actions.