### PR TITLE
Run Keylime test suite on Github Actions

### DIFF
--- a/.ci/test_wrapper_gha.sh
+++ b/.ci/test_wrapper_gha.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -x
+
+# Configure swtpm2
+mkdir /tmp/tpmdir
+swtpm_setup --tpm2 \
+     --tpmstate /tmp/tpmdir \
+     --createek --allow-signing --decryption --create-ek-cert \
+     --create-platform-cert \
+     --display
+swtpm socket --tpm2 \
+     --tpmstate dir=/tmp/tpmdir \
+     --flags startup-clear \
+     --ctrl type=tcp,port=2322 \
+     --server type=tcp,port=2321 \
+     --daemon
+export TPM2TOOLS_TCTI=tabrmd:
+
+# Configure dbus
+sudo rm -rf /var/run/dbus
+sudo mkdir /var/run/dbus
+sudo dbus-daemon --system
+
+tpm2-abrmd \
+    --logger=stdout \
+    --tcti=swtpm: \
+    --flush-all \
+    --allow-root &
+
+# Run tests
+chmod +x test/run_tests.sh
+test/run_tests.sh -s openssl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,17 @@
 name: test
 
-on: pull_request
+on: [pull_request, workflow_dispatch]
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    container:
+      image: quay.io/keylime/keylime-ci:latest
+      options: --user root --mount type=tmpfs,destination=/var/lib/keylime/,tmpfs-mode=1770
+      env:
+        KEYLIME_TEST: True
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Run tests
+      run: .ci/test_wrapper_gha.sh


### PR DESCRIPTION
This should run the same test suite currently running on Travis on Github Actions. It should pave the way for Keylime to drop Travis entirely.

Related: https://github.com/keylime/enhancements/issues/18