### PR TITLE
Allow using absolute path of cert for registrar client

### DIFF
--- a/keylime/registrar_client.py
+++ b/keylime/registrar_client.py
@@ -61,8 +61,15 @@ def init_client_tls(section):
     else:
         ca_path = "%s/%s" % (tls_dir, ca_cert)
 
-    tls_cert = "%s/%s" % (tls_dir, my_cert)
-    tls_priv_key = "%s/%s" % (tls_dir, my_priv_key)
+    if os.path.isabs(my_cert):
+        tls_cert = my_cert
+    else:
+        tls_cert = "%s/%s" % (tls_dir, my_cert)
+    if os.path.isabs(my_priv_key):
+        tls_priv_key = my_priv_key
+    else:
+        tls_priv_key = "%s/%s" % (tls_dir, my_priv_key)
+
     tls_cert_info = (tls_cert, tls_priv_key)
 
 


### PR DESCRIPTION
Allow using absolute path of cert files for the registrar client.

Relates-to: #430