### PR TITLE
Add dbus-daemon to container package list

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ ENV PKGS_DEPS="automake \
 cargo \
 clang-devel \
 dbus \
+dbus-daemon \
 dbus-devel \
 dnf-plugins-core \
 gcc \


### PR DESCRIPTION
Necessary to allow Keylime to run on the container.