### PR TITLE
codestyle: Address issues related to W1505

### DIFF
--- a/keylime/ca_impl_cfssl.py
+++ b/keylime/ca_impl_cfssl.py
@@ -124,6 +124,7 @@ def mk_cacert():
 
 
 def mk_signed_cert(cacert, ca_pk, name, serialnum):
+    del cacert, serialnum
     csr = {"request": {
         "CN": name,
         "hosts": [

--- a/keylime/ca_impl_openssl.py
+++ b/keylime/ca_impl_openssl.py
@@ -111,6 +111,7 @@ def mk_signed_cert(cacert, ca_pk, name, serialnum):
 
 
 def gencrl(_, a, b):
+    del a, b
     logger = keylime_logging.init_logging('ca_impl_openssl')
     logger.warning("CRL creation with openssl is not supported")
     return ""

--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -63,9 +63,9 @@ else:
 global_password = None
 
 
-def globalcb(*args):
-    global global_password
-    return global_password.encode()
+# def globalcb(*args):
+#    global global_password
+#    return global_password.encode()
 
 
 def setpassword(pw):

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -615,7 +615,7 @@ def start_tornado(tornado_server, port):
     print("Tornado finished")
 
 
-def main(argv=sys.argv):
+def main():
     """Main method of the Cloud Verifier Server.  This method is encapsulated in a function for packaging to allow it to be
     called as a function by an external program."""
 

--- a/keylime/cmd/ima_emulator_adapter.py
+++ b/keylime/cmd/ima_emulator_adapter.py
@@ -73,7 +73,7 @@ def ml_extend(ml, position, searchHash=None):
     return position
 
 
-def main(argv=sys.argv):
+def main():
     if not tpm.is_emulator():
         raise Exception("This stub should only be used with a TPM emulator")
 

--- a/keylime/cmd/provider_registrar.py
+++ b/keylime/cmd/provider_registrar.py
@@ -5,8 +5,6 @@ SPDX-License-Identifier: Apache-2.0
 Copyright 2017 Massachusetts Institute of Technology.
 '''
 
-import sys
-
 from keylime import config
 from keylime import keylime_logging
 from keylime import registrar_common
@@ -14,7 +12,7 @@ from keylime import registrar_common
 logger = keylime_logging.init_logging('provider-registrar')
 
 
-def main(argv=sys.argv):
+def main():
     registrar_common.start(
         config.get('registrar', 'provider_registrar_ip'),
         config.getint('registrar', 'provider_registrar_tls_port'),

--- a/keylime/cmd/registrar.py
+++ b/keylime/cmd/registrar.py
@@ -5,8 +5,6 @@ SPDX-License-Identifier: Apache-2.0
 Copyright 2017 Massachusetts Institute of Technology.
 '''
 
-import sys
-
 from keylime import registrar_common
 from keylime import config
 from keylime import keylime_logging
@@ -15,7 +13,7 @@ import keylime.cmd.migrations_apply
 logger = keylime_logging.init_logging('registrar')
 
 
-def main(argv=sys.argv):
+def main():
     # if we are configured to auto-migrate the DB, check if there are any migrations to perform
     if config.has_option('registrar', 'auto_migrate_db') and config.getboolean('registrar', 'auto_migrate_db'):
         keylime.cmd.migrations_apply.apply('registrar')

--- a/keylime/cryptodome.py
+++ b/keylime/cryptodome.py
@@ -33,7 +33,7 @@ def rsa_export_privkey(privkey):
 
 
 def rsa_generate(size):
-    return RSA.generate(2048)
+    return RSA.generate(size)
 
 
 def rsa_sign(key, message):

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -5,7 +5,6 @@ Copyright 2017 Massachusetts Institute of Technology.
 
 import ast
 import codecs
-import sys
 import hashlib
 import struct
 import os
@@ -74,7 +73,7 @@ supported_fields = {
 }
 
 
-def read_measurement_list_bin(path, allowlist):
+def read_measurement_list_bin(path):
     raise Exception("not implementated fully yet")
     # pylint: disable=W0101
     f = open(path, 'rb')
@@ -352,8 +351,8 @@ def read_excllist(exclude_path=None):
     return excl_list
 
 
-def main(argv=sys.argv):
-    # read_measurement_list_bin("/sys/kernel/security/ima/binary_runtime_measurements", None)
+def main():
+    # read_measurement_list_bin("/sys/kernel/security/ima/binary_runtime_measurements")
 
     allowlist_path = 'allowlist.txt'
     print("reading allowlist from %s" % allowlist_path)

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -199,10 +199,10 @@ class Handler(BaseHTTPRequestHandler):
             self.server.add_U(decrypted_key)
             self.server.auth_tag = json_body['auth_tag']
             self.server.payload = json_body.get('payload', None)
-            have_derived_key = self.server.attempt_decryption(self)
+            have_derived_key = self.server.attempt_decryption()
         elif rest_params["keys"] == "vkey":
             self.server.add_V(decrypted_key)
-            have_derived_key = self.server.attempt_decryption(self)
+            have_derived_key = self.server.attempt_decryption()
         else:
             logger.warning(
                 'POST returning  response. uri not supported: ' + self.path)
@@ -399,7 +399,7 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
                 logger.debug(F"Adding V: {base64.b64encode(v)}")
             self.v_set.add(v)
 
-    def attempt_decryption(self, handler):
+    def attempt_decryption(self):
         """On reception of a U or V value, this method is called to attempt the decryption of the Cloud Init script
 
         At least one U and V value must be received in order to attempt encryption. Multiple U and V values are stored
@@ -461,7 +461,7 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
         return False
 
 
-def main(argv=sys.argv):
+def main():
     if os.getuid() != 0 and config.REQUIRE_ROOT:
         logger.critical("This process must be run as root.")
         return

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -479,6 +479,7 @@ def start(host, tlsport, port):
         thread.start()
 
     def signal_handler(signum, frame):
+        del signum, frame
         do_shutdown(servers)
         sys.exit(0)
 

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -658,7 +658,7 @@ def get_tls_context():
     return context
 
 
-def main(argv=sys.argv):
+def main():
     """Main method of the Tenant Webapp Server.  This method is encapsulated in a function for packaging to allow it to be
     called as a function by an external program."""
 

--- a/keylime/tpm/tpm2.py
+++ b/keylime/tpm/tpm2.py
@@ -590,7 +590,7 @@ class tpm2(tpm_abstract.AbstractTPM):
 
         self._set_tpm_metadata('aik', pem)
 
-    def __create_aik(self, activate, asym_alg=None, hash_alg=None, sign_alg=None):
+    def __create_aik(self, asym_alg=None, hash_alg=None, sign_alg=None):
         if hash_alg is None:
             hash_alg = self.defaults['hash']
         if asym_alg is None:
@@ -941,7 +941,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         self._set_tpm_metadata('ekcert', ekcert)
 
         # if no AIK created, then create one
-        self.__create_aik(self_activate)
+        self.__create_aik()
 
         return self.get_tpm_metadata('ek'), self.get_tpm_metadata('ekcert'), self.get_tpm_metadata('aik'), self.get_tpm_metadata('ek_tpm'), self.get_tpm_metadata('aik_name')
 

--- a/keylime/vtpm_manager.py
+++ b/keylime/vtpm_manager.py
@@ -391,7 +391,7 @@ def get_group_info(num):
     return {'aikpem': aikpem, 'uuid': uuid}
 
 
-def get_group_symkey(groupnum, aikpem, pubekpem, keyblob):
+def get_group_symkey(groupnum, keyblob):
     logger.info('Keyblob: %r', open(keyblob, 'rb').read())
     return do_group_activate(groupnum, keyblob)
 
@@ -420,7 +420,7 @@ def do_register_test_helper(groupnum=1,
         aikpem, pubekpem, keyblob, goalkey), shell=True)
 
     # Obtain the symkey via group activate
-    symkey_raw = get_group_symkey(groupnum, aikpem, pubekpem, keyblob)
+    symkey_raw = get_group_symkey(groupnum, keyblob)
     with open(symkey, 'wb') as f:
         f.write(symkey_raw)
     logger.info('Wrote %s', symkey)

--- a/scripts/check_codestyle.sh
+++ b/scripts/check_codestyle.sh
@@ -6,7 +6,7 @@ if [ -z "$(type -P pylint)" ]; then
 fi
 
 pylint \
-  --disable C0200,C0411,W0707,W0223,W0613,W1509 \
+  --disable C0200,C0411,W0707,W0223,W1509 \
   --disable C0103,C0115,C0116,C0301,C0302,C0111 \
   --disable W0102,W0511,W0603,W0703,W1201,W1203 \
   --disable E0401,E1101,E1120 \


### PR DESCRIPTION
This patch fixes the following issues detected by pylint:

************* Module keylime.tpm.tpm2
keylime/tpm/tpm2.py:593:27: W0613: Unused argument 'activate' (unused-argument)
************* Module keylime.registrar_common
keylime/registrar_common.py:481:23: W0613: Unused argument 'signum' (unused-argument)
keylime/registrar_common.py:481:31: W0613: Unused argument 'frame' (unused-argument)
************* Module keylime.keylime_agent
keylime/keylime_agent.py:402:33: W0613: Unused argument 'handler' (unused-argument)
keylime/keylime_agent.py:464:9: W0613: Unused argument 'argv' (unused-argument)
************* Module keylime.ca_util
keylime/ca_util.py:66:0: W0613: Unused argument 'args' (unused-argument)
************* Module keylime.vtpm_manager
keylime/vtpm_manager.py:394:31: W0613: Unused argument 'aikpem' (unused-argument)
keylime/vtpm_manager.py:394:39: W0613: Unused argument 'pubekpem' (unused-argument)
************* Module keylime.cloud_verifier_tornado
keylime/cloud_verifier_tornado.py:618:9: W0613: Unused argument 'argv' (unused-argument)
************* Module keylime.cmd.registrar
keylime/cmd/registrar.py:18:9: W0613: Unused argument 'argv' (unused-argument)
************* Module keylime.cmd.ima_emulator_adapter
keylime/cmd/ima_emulator_adapter.py:76:9: W0613: Unused argument 'argv' (unused-argument)
************* Module keylime.cmd.provider_registrar
keylime/cmd/provider_registrar.py:17:9: W0613: Unused argument 'argv' (unused-argument)
************* Module keylime.cryptodome
keylime/cryptodome.py:35:17: W0613: Unused argument 'size' (unused-argument)
************* Module keylime.ima
keylime/ima.py:77:36: W0613: Unused argument 'allowlist' (unused-argument)
keylime/ima.py:355:9: W0613: Unused argument 'argv' (unused-argument)
************* Module keylime.ca_impl_cfssl
keylime/ca_impl_cfssl.py:126:19: W0613: Unused argument 'cacert' (unused-argument)
keylime/ca_impl_cfssl.py:126:40: W0613: Unused argument 'serialnum' (unused-argument)
************* Module keylime.tenant_webapp
keylime/tenant_webapp.py:661:9: W0613: Unused argument 'argv' (unused-argument)
************* Module keylime.ca_impl_openssl
keylime/ca_impl_openssl.py:113:14: W0613: Unused argument 'a' (unused-argument)
keylime/ca_impl_openssl.py:113:17: W0613: Unused argument 'b' (unused-argument)

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>