### PR TITLE
codestyle: Address issues related to C0114

### DIFF
--- a/keylime/migrations/env.py
+++ b/keylime/migrations/env.py
@@ -1,3 +1,9 @@
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2017 Massachusetts Institute of Technology.
+
+Database migration
+'''
 import logging
 import re
 import sys

--- a/keylime/requests_client.py
+++ b/keylime/requests_client.py
@@ -1,3 +1,8 @@
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2017 Massachusetts Institute of Technology.
+'''
+
 import requests
 
 

--- a/scripts/check_codestyle.sh
+++ b/scripts/check_codestyle.sh
@@ -6,7 +6,7 @@ if [ -z "$(type -P pylint)" ]; then
 fi
 
 pylint \
-  --disable C0200,C0411,C0114,W0707,W0223,W0613,W1509 \
+  --disable C0200,C0411,W0707,W0223,W0613,W1509 \
   --disable C0103,C0115,C0116,C0301,C0302,C0111 \
   --disable W0102,W0511,W0603,W0703,W1201,W1203 \
   --disable E0401,E1101,E1120 \


### PR DESCRIPTION
This patch addresses the following issues detected by pylint:

************* Module keylime.migrations.env
keylime/migrations/env.py:1:0: C0114: Missing module docstring (missing-module-docstring)
************* Module keylime.requests_client
keylime/requests_client.py:1:0: C0114: Missing module docstring (missing-module-docstring)

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>