### PR TITLE
Remove lock in the command execution

### DIFF
--- a/auto-ipsec/libreswan/src/local_action_crashsa.py
+++ b/auto-ipsec/libreswan/src/local_action_crashsa.py
@@ -34,11 +34,11 @@ async def execute(revocation):
         "loading updated CRL from %s/unzipped/cacrl.der into NSS" % secdir)
     cmd = ('crlutil', '-I', '-i', '%s/unzipped/cacrl.der' % secdir,
            '-d', 'sql:/etc/ipsec.d')
-    cmd_exec.run(cmd, lock=False)
+    cmd_exec.run(cmd)
 
     # need to find any sa's that were established with that cert subject name
     cmd = ('ipsec', 'whack', '--trafficstatus')
-    output = cmd_exec.run(cmd, lock=False, raiseOnError=True)['retout']
+    output = cmd_exec.run(cmd, raiseOnError=True)['retout']
     deletelist = set()
     id = ""
     for line in output:
@@ -75,4 +75,4 @@ async def execute(revocation):
     for todelete in deletelist:
         logger.info("deleting IPsec sa with %s" % todelete)
         cmd = ('ipsec', 'whack', '--crash', todelete)
-        cmd_exec.run(cmd, raiseOnError=False, lock=False)
+        cmd_exec.run(cmd, raiseOnError=False)

--- a/auto-ipsec/racoon/src/local_action_deletesa.py
+++ b/auto-ipsec/racoon/src/local_action_deletesa.py
@@ -35,13 +35,12 @@ async def execute(revocation):
 
     # need to find any sa's that were established with that cert serial
     cmd = ('racoonctl', 'show-sa', 'ipsec')
-    output = cmd_exec.run(cmd, lock=False, raiseOnError=True)['retout']
+    output = cmd_exec.run(cmd, raiseOnError=True)['retout']
     deletelist = set()
     for line in output:
         if not line.startswith(b"\t"):
             cmd = ('racoonctl', 'get-cert', 'inet', line.strip())
-            certder = cmd_exec.run(cmd, raiseOnError=False,
-                                   lock=False)['retout']
+            certder = cmd_exec.run(cmd, raiseOnError=False)['retout']
             if len(certder) == 0:
                 continue
             certobj = X509.load_cert_der_string(b''.join(certder))
@@ -56,11 +55,11 @@ async def execute(revocation):
     for todelete in deletelist:
         logger.info("deleting IPsec sa between %s" % todelete)
         cmd = ('racoonctl', 'delete-sa', 'isakmp', 'inet', todelete)
-        cmd_exec.run(cmd, lock=False)
+        cmd_exec.run(cmd)
         tokens = todelete.split()
         cmd = ('racoonctl', 'delete-sa', 'isakmp', 'inet', tokens[1],
                tokens[0])
-        cmd_exec.run(cmd, lock=False)
+        cmd_exec.run(cmd)
 
     # for each pair returned that doens't start with whitespace
     # racoonctl get-cert inet 192.168.240.128 192.168.240.254 (the pair from before)

--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -261,7 +261,7 @@ def convert_crl_to_pem(derfile, pemfile):
     else:
         cmd = ('openssl', 'crl', '-in', derfile, '-inform', 'der',
                '-out', pemfile)
-        cmd_exec.run(cmd, lock=False)
+        cmd_exec.run(cmd)
 
 
 def get_crl_distpoint(cert_path):
@@ -378,7 +378,7 @@ def cmd_listen(workingdir, cert_path):
                             os.stat('cacrl.der').st_size):
                         cmd = ('openssl', 'crl', '-inform', 'der', '-in',
                                'cacrl.der', '-text', '-noout')
-                        retout = cmd_exec.run(cmd, lock=False)['retout']
+                        retout = cmd_exec.run(cmd)['retout']
                         for line in retout:
                             line = line.strip()
                             if line.startswith(b"Next Update:"):

--- a/keylime/cmd_exec.py
+++ b/keylime/cmd_exec.py
@@ -5,11 +5,8 @@ Copyright 2017 Massachusetts Institute of Technology.
 
 import os
 import subprocess
-import threading
 import time
 
-# shared lock to serialize access to tools
-utilLock = threading.Lock()
 
 EXIT_SUCESS = 0
 
@@ -22,20 +19,14 @@ def _execute(cmd, env=None, **kwargs):
     return out, err, code
 
 
-def run(cmd, expectedcode=EXIT_SUCESS, raiseOnError=True, lock=True,
-        outputpaths=None, env=os.environ, **kwargs):
+def run(cmd, expectedcode=EXIT_SUCESS, raiseOnError=True, outputpaths=None,
+        env=os.environ, **kwargs):
     """Execute external command.
 
     :param cmd: a sequence of command arguments
     """
-    global utilLock
-
     t0 = time.time()
-    if lock:
-        with utilLock:
-            retout, reterr, code = _execute(cmd, env=env, **kwargs)
-    else:
-        retout, reterr, code = _execute(cmd, env=env, **kwargs)
+    retout, reterr, code = _execute(cmd, env=env, **kwargs)
 
     t1 = time.time()
     timing = {'t1': t1, 't0': t0}

--- a/keylime/secure_mount.py
+++ b/keylime/secure_mount.py
@@ -13,7 +13,7 @@ logger = keylime_logging.init_logging('secure_mount')
 
 
 def check_mounted(secdir):
-    whatsmounted = cmd_exec.run("mount", lock=False)['retout']
+    whatsmounted = cmd_exec.run("mount")['retout']
     whatsmounted_converted = config.list_convert(whatsmounted)
     for line in whatsmounted_converted:
         tokens = line.split()
@@ -54,6 +54,6 @@ def mount():
         logger.info("mounting secure storage location %s on tmpfs" % secdir)
         cmd = ('mount', '-t', 'tmpfs', '-o', 'size=%s,mode=0700' % size,
                'tmpfs', secdir)
-        cmd_exec.run(cmd, lock=False)
+        cmd_exec.run(cmd)
 
     return secdir

--- a/keylime/tpm/tpm1.py
+++ b/keylime/tpm/tpm1.py
@@ -201,13 +201,12 @@ class tpm1(tpm_abstract.AbstractTPM):
             if lock:
                 with self.tpmutilLock:
                     retDict = cmd_exec.run(
-                        cmd=cmd, expectedcode=expectedcode,
-                        raiseOnError=False, lock=lock,
+                        cmd=cmd, expectedcode=expectedcode, raiseOnError=False,
                         outputpaths=outputpaths, env=env, shell=shell)
             else:
                 retDict = cmd_exec.run(
                     cmd=cmd, expectedcode=expectedcode, raiseOnError=False,
-                    lock=lock, outputpaths=outputpaths, env=env, shell=shell)
+                    outputpaths=outputpaths, env=env, shell=shell)
 
             code = retDict['code']
             retout = retDict['retout']

--- a/keylime/tpm/tpm2.py
+++ b/keylime/tpm/tpm2.py
@@ -345,11 +345,11 @@ class tpm2(tpm_abstract.AbstractTPM):
             if lock:
                 with self.tpmutilLock:
                     retDict = cmd_exec.run(cmd=cmd, expectedcode=expectedcode,
-                                           raiseOnError=False, lock=lock,
+                                           raiseOnError=False,
                                            outputpaths=outputpaths, env=env)
             else:
                 retDict = cmd_exec.run(cmd=cmd, expectedcode=expectedcode,
-                                       raiseOnError=False, lock=lock,
+                                       raiseOnError=False,
                                        outputpaths=outputpaths, env=env)
             code = retDict['code']
             retout = retDict['retout']


### PR DESCRIPTION
A lock is aleady held when executing tpm commands, there is no
need to lock in the underlying command, and this is typically not
a good idea.