### PR TITLE
codestyle: Address issue related to W0707

### DIFF
--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -482,8 +482,8 @@ def read_private(warn=False):
         key = crypto.kdf(global_password, toread['salt'])
         try:
             plain = crypto.decrypt(toread['priv'], key)
-        except ValueError:
-            raise Exception("Invalid password for keystore")
+        except ValueError as e:
+            raise Exception("Invalid password for keystore") from e
 
         return yaml.load(plain, Loader=SafeLoader), toread['salt']
 

--- a/scripts/check_codestyle.sh
+++ b/scripts/check_codestyle.sh
@@ -6,7 +6,7 @@ if [ -z "$(type -P pylint)" ]; then
 fi
 
 pylint \
-  --disable C0200,W0707,W0223,W1509 \
+  --disable C0200,W0223,W1509 \
   --disable C0103,C0115,C0116,C0301,C0302,C0111 \
   --disable W0102,W0511,W0603,W0703,W1201,W1203 \
   --disable E0401,E1101,E1120 \


### PR DESCRIPTION
This patch addresses the following issue detected by pylint:

************* Module keylime.ca_util
keylime/ca_util.py:486:12: W0707: Consider explicitly re-raising using the 'from' keyword (raise-missing-from)

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>