### PR TITLE
Move agents handling out of tornado request handler

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -30,8 +30,12 @@ logger = keylime_logging.init_logging('cloudverifier')
 try:
     engine = DBEngineManager().make_engine('cloud_verifier')
 except SQLAlchemyError as e:
-    logger.error(f'Error creating SQL engine: {e}')
+    logger.error(f'Error creating SQL engine or session: {e}')
     sys.exit(1)
+
+
+def get_session():
+    return SessionManager().make_session(engine)
 
 
 # The "exclude_db" dict values are removed from the response before adding the dict to the DB
@@ -63,7 +67,7 @@ def _from_db_obj(agent_db_obj):
     return agent_dict
 
 
-class BaseHandler(tornado.web.RequestHandler, SessionManager):
+class BaseHandler(tornado.web.RequestHandler):
     def prepare(self):  # pylint: disable=W0235
         super().prepare()
 
@@ -132,7 +136,7 @@ class AgentsHandler(BaseHandler):
         was not found, it either completed successfully, or failed.  If found, the agent_id is still polling
         to contact the Cloud Agent.
         """
-        session = self.make_session(engine)
+        session = get_session()
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
             config.echo_json_response(
@@ -171,7 +175,7 @@ class AgentsHandler(BaseHandler):
         Currently, only agents resources are available for DELETEing, i.e. /agents. All other DELETE uri's will return errors.
         agents requests require a single agent_id parameter which identifies the agent to be deleted.
         """
-        session = self.make_session(engine)
+        session = get_session()
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
             config.echo_json_response(
@@ -234,7 +238,7 @@ class AgentsHandler(BaseHandler):
         Currently, only agents resources are available for POSTing, i.e. /agents. All other POST uri's will return errors.
         agents requests require a json block sent in the body
         """
-        session = self.make_session(engine)
+        session = get_session()
         try:
             rest_params = config.get_restful_params(self.request.uri)
             if rest_params is None:
@@ -309,7 +313,7 @@ class AgentsHandler(BaseHandler):
                         for key in list(exclude_db.keys()):
                             agent_data[key] = exclude_db[key]
                         asyncio.ensure_future(
-                            self.process_agent(agent_data, states.GET_QUOTE))
+                            process_agent(agent_data, states.GET_QUOTE))
                         config.echo_json_response(self, 200, "Success")
                         logger.info(
                             'POST returning 200 response for adding agent id: ' + agent_id)
@@ -331,7 +335,7 @@ class AgentsHandler(BaseHandler):
         Currently, only agents resources are available for PUTing, i.e. /agents. All other PUT uri's will return errors.
         agents requests require a json block sent in the body
         """
-        session = self.make_session(engine)
+        session = get_session()
         try:
             rest_params = config.get_restful_params(self.request.uri)
             if rest_params is None:
@@ -365,7 +369,7 @@ class AgentsHandler(BaseHandler):
             if "reactivate" in rest_params:
                 agent.operational_state = states.START
                 asyncio.ensure_future(
-                    self.process_agent(agent, states.GET_QUOTE))
+                    process_agent(agent, states.GET_QUOTE))
                 config.echo_json_response(self, 200, "Success")
                 logger.info(
                     'PUT returning 200 response for agent id: ' + agent_id)
@@ -393,235 +397,227 @@ class AgentsHandler(BaseHandler):
             logger.exception(e)
         self.finish()
 
-    async def invoke_get_quote(self, agent, need_pubkey):
-        if agent is None:
-            raise Exception("agent deleted while being processed")
-        params = cloud_verifier_common.prepare_get_quote(agent)
-
-        partial_req = "1"
-        if need_pubkey:
-            partial_req = "0"
-
-        res = tornado_requests.request("GET",
-                                       "http://%s:%d/quotes/integrity?nonce=%s&mask=%s&vmask=%s&partial=%s" %
-                                       (agent['ip'], agent['port'], params["nonce"], params["mask"], params['vmask'], partial_req), context=None)
-        response = await res
-
-        if response.status_code != 200:
-            # this is a connection error, retry get quote
-            if response.status_code == 599:
-                asyncio.ensure_future(self.process_agent(
-                    agent, states.GET_QUOTE_RETRY))
-            else:
-                # catastrophic error, do not continue
-                error = "Unexpected Get Quote response error for cloud agent " + \
-                    agent['agent_id'] + ", Error: " + str(response.status_code)
-                logger.critical(error)
-                asyncio.ensure_future(self.process_agent(
-                    agent, states.FAILED))
-        else:
-            try:
-                json_response = json.loads(response.body)
-
-                # validate the cloud agent response
-                if 'provide_V' not in agent :
-                    agent['provide_V'] = True
-                if cloud_verifier_common.process_quote_response(agent, json_response['results']):
-                    if agent['provide_V']:
-                        asyncio.ensure_future(
-                            self.process_agent(agent, states.PROVIDE_V))
-                    else:
-                        asyncio.ensure_future(
-                            self.process_agent(agent, states.GET_QUOTE))
-                else:
-                    asyncio.ensure_future(
-                        self.process_agent(agent, states.INVALID_QUOTE))
-
-            except Exception as e:
-                logger.exception(e)
-
-    async def invoke_provide_v(self, agent):
-        if agent is None:
-            raise Exception("Agent deleted while being processed")
-        try:
-            if agent['pending_event'] is not None:
-                agent['pending_event'] = None
-        except KeyError:
-            pass
-        v_json_message = cloud_verifier_common.prepare_v(agent)
-        res = tornado_requests.request(
-            "POST", "http://%s:%d//keys/vkey" % (agent['ip'], agent['port']), data=v_json_message)
-        response = await res
-
-        if response.status_code != 200:
-            if response.status_code == 599:
-                asyncio.ensure_future(
-                    self.process_agent(agent, states.PROVIDE_V_RETRY))
-            else:
-                # catastrophic error, do not continue
-                error = "Unexpected Provide V response error for cloud agent " + \
-                    agent['agent_id'] + ", Error: " + str(response.error)
-                logger.critical(error)
-                asyncio.ensure_future(self.process_agent(agent, states.FAILED))
-        else:
-            asyncio.ensure_future(self.process_agent(agent, states.GET_QUOTE))
-
-    async def process_agent(self, agent, new_operational_state):
-        # Convert to dict if the agent arg is a db object
-        if not isinstance(agent, dict):
-            agent = _from_db_obj(agent)
-
-        session = self.make_session(engine)
-        try:
-            main_agent_operational_state = agent['operational_state']
-            try:
-                stored_agent = session.query(VerfierMain).filter_by(
-                    agent_id=str(agent['agent_id'])).first()
-            except SQLAlchemyError as e:
-                logger.error(f'SQLAlchemy Error: {e}')
-
-            # if the user did terminated this agent
-            if stored_agent.operational_state == states.TERMINATED:
-                logger.warning("agent %s terminated by user." %
-                               agent['agent_id'])
-                if agent['pending_event'] is not None:
-                    tornado.ioloop.IOLoop.current().remove_timeout(
-                        agent['pending_event'])
-                session.query(VerfierMain).filter_by(
-                    agent_id=agent['agent_id']).delete()
-                session.commit()
-                return
-
-            # if the user tells us to stop polling because the tenant quote check failed
-            if stored_agent.operational_state == states.TENANT_FAILED:
-                logger.warning(
-                    "agent %s has failed tenant quote.  stopping polling" % agent['agent_id'])
-                if agent['pending_event'] is not None:
-                    tornado.ioloop.IOLoop.current().remove_timeout(
-                        agent['pending_event'])
-                return
-
-            # If failed during processing, log regardless and drop it on the floor
-            # The administration application (tenant) can GET the status and act accordingly (delete/retry/etc).
-            if new_operational_state in (states.FAILED, states.INVALID_QUOTE):
-                agent['operational_state'] = new_operational_state
-
-                # issue notification for invalid quotes
-                if new_operational_state == states.INVALID_QUOTE:
-                    cloud_verifier_common.notify_error(agent)
-
-                if agent['pending_event'] is not None:
-                    tornado.ioloop.IOLoop.current().remove_timeout(
-                        agent['pending_event'])
-                for key in exclude_db:
-                    if key in agent:
-                        del agent[key]
-                session.query(VerfierMain).filter_by(
-                    agent_id=agent['agent_id']).update(agent)
-                session.commit()
-
-                logger.warning("agent %s failed, stopping polling" %
-                               agent['agent_id'])
-                return
-
-            # propagate all state, but remove none DB keys first (using exclude_db)
-            try:
-                agent_db = dict(agent)
-                for key in exclude_db:
-                    if key in agent_db:
-                        del agent_db[key]
-
-                session.query(VerfierMain).filter_by(
-                    agent_id=agent_db['agent_id']).update(agent_db)
-                session.commit()
-            except SQLAlchemyError as e:
-                logger.error(f'SQLAlchemy Error: {e}')
-
-            # if new, get a quote
-            if (main_agent_operational_state == states.START and
-                    new_operational_state == states.GET_QUOTE):
-                agent['num_retries'] = 0
-                agent['operational_state'] = states.GET_QUOTE
-                await self.invoke_get_quote(agent, True)
-                return
-
-            if (main_agent_operational_state == states.GET_QUOTE and
-                    new_operational_state == states.PROVIDE_V):
-                agent['num_retries'] = 0
-                agent['operational_state'] = states.PROVIDE_V
-                await self.invoke_provide_v(agent)
-                return
-
-            if (main_agent_operational_state in (states.PROVIDE_V, states.GET_QUOTE) and
-                    new_operational_state == states.GET_QUOTE):
-                agent['num_retries'] = 0
-                interval = config.getfloat('cloud_verifier', 'quote_interval')
-                agent['operational_state'] = states.GET_QUOTE
-                if interval == 0:
-                    await self.invoke_get_quote(agent, False)
-                else:
-                    logger.debug(
-                        "Setting up callback to check again in %f seconds" % interval)
-                    # set up a call back to check again
-                    cb = functools.partial(self.invoke_get_quote, agent, False)
-                    pending = tornado.ioloop.IOLoop.current().call_later(interval, cb)
-                    agent['pending_event'] = pending
-                return
-
-            maxr = config.getint('cloud_verifier', 'max_retries')
-            retry = config.getfloat('cloud_verifier', 'retry_interval')
-            if (main_agent_operational_state == states.GET_QUOTE and
-                    new_operational_state == states.GET_QUOTE_RETRY):
-                if agent['num_retries'] >= maxr:
-                    logger.warning("agent %s was not reachable for quote in %d tries, setting state to FAILED" % (
-                        agent['agent_id'], maxr))
-                    if agent['first_verified']:  # only notify on previously good agents
-                        cloud_verifier_common.notify_error(
-                            agent, msgtype='comm_error')
-                    else:
-                        logger.debug(
-                            "Communication error for new agent.  no notification will be sent")
-                    await self.process_agent(agent, states.FAILED)
-                else:
-                    agent['operational_state'] = states.GET_QUOTE
-                    cb = functools.partial(self.invoke_get_quote, agent, True)
-                    agent['num_retries'] += 1
-                    logger.info("connection to %s refused after %d/%d tries, trying again in %f seconds" %
-                                (agent['ip'], agent['num_retries'], maxr, retry))
-                    tornado.ioloop.IOLoop.current().call_later(retry, cb)
-                return
-
-            if (main_agent_operational_state == states.PROVIDE_V and
-                    new_operational_state == states.PROVIDE_V_RETRY):
-                if agent['num_retries'] >= maxr:
-                    logger.warning("agent %s was not reachable to provide v in %d tries, setting state to FAILED" % (
-                        agent['agent_id'], maxr))
-                    cloud_verifier_common.notify_error(
-                        agent, msgtype='comm_error')
-                    await self.process_agent(agent, states.FAILED)
-                else:
-                    agent['operational_state'] = states.PROVIDE_V
-                    cb = functools.partial(self.invoke_provide_v, agent)
-                    agent['num_retries'] += 1
-                    logger.info("connection to %s refused after %d/%d tries, trying again in %f seconds" %
-                                (agent['ip'], agent['num_retries'], maxr, retry))
-                    tornado.ioloop.IOLoop.current().call_later(retry, cb)
-                return
-            raise Exception("nothing should ever fall out of this!")
-
-        except Exception as e:
-            logger.error("Polling thread error: %s" % e)
-            logger.exception(e)
-
     def data_received(self, chunk):
         raise NotImplementedError()
 
 
-def start_tornado(tornado_server, port):
-    tornado_server.listen(port)
-    print("Starting Torando on port " + str(port))
-    tornado.ioloop.IOLoop.instance().start()
-    print("Tornado finished")
+async def invoke_get_quote(agent, need_pubkey):
+    if agent is None:
+        raise Exception("agent deleted while being processed")
+    params = cloud_verifier_common.prepare_get_quote(agent)
+
+    partial_req = "1"
+    if need_pubkey:
+        partial_req = "0"
+
+    res = tornado_requests.request("GET",
+                                   "http://%s:%d/quotes/integrity?nonce=%s&mask=%s&vmask=%s&partial=%s" %
+                                   (agent['ip'], agent['port'], params["nonce"], params["mask"], params['vmask'], partial_req), context=None)
+    response = await res
+
+    if response.status_code != 200:
+        # this is a connection error, retry get quote
+        if response.status_code == 599:
+            asyncio.ensure_future(process_agent(
+                agent, states.GET_QUOTE_RETRY))
+        else:
+            # catastrophic error, do not continue
+            error = "Unexpected Get Quote response error for cloud agent " + \
+                agent['agent_id'] + ", Error: " + str(response.status_code)
+            logger.critical(error)
+            asyncio.ensure_future(process_agent(agent, states.FAILED))
+    else:
+        try:
+            json_response = json.loads(response.body)
+
+            # validate the cloud agent response
+            if 'provide_V' not in agent :
+                agent['provide_V'] = True
+            if cloud_verifier_common.process_quote_response(agent, json_response['results']):
+                if agent['provide_V']:
+                    asyncio.ensure_future(process_agent(agent, states.PROVIDE_V))
+                else:
+                    asyncio.ensure_future(process_agent(agent, states.GET_QUOTE))
+            else:
+                asyncio.ensure_future(process_agent(agent, states.INVALID_QUOTE))
+
+        except Exception as e:
+            logger.exception(e)
+
+
+async def invoke_provide_v(agent):
+    if agent is None:
+        raise Exception("Agent deleted while being processed")
+    try:
+        if agent['pending_event'] is not None:
+            agent['pending_event'] = None
+    except KeyError:
+        pass
+    v_json_message = cloud_verifier_common.prepare_v(agent)
+    res = tornado_requests.request(
+        "POST", "http://%s:%d//keys/vkey" % (agent['ip'], agent['port']), data=v_json_message)
+    response = await res
+
+    if response.status_code != 200:
+        if response.status_code == 599:
+            asyncio.ensure_future(
+                process_agent(agent, states.PROVIDE_V_RETRY))
+        else:
+            # catastrophic error, do not continue
+            error = "Unexpected Provide V response error for cloud agent " + \
+                agent['agent_id'] + ", Error: " + str(response.error)
+            logger.critical(error)
+            asyncio.ensure_future(process_agent(agent, states.FAILED))
+    else:
+        asyncio.ensure_future(process_agent(agent, states.GET_QUOTE))
+
+
+async def process_agent(agent, new_operational_state):
+    # Convert to dict if the agent arg is a db object
+    if not isinstance(agent, dict):
+        agent = _from_db_obj(agent)
+
+    session = get_session()
+    try:
+        main_agent_operational_state = agent['operational_state']
+        try:
+            stored_agent = session.query(VerfierMain).filter_by(
+                agent_id=str(agent['agent_id'])).first()
+        except SQLAlchemyError as e:
+            logger.error(f'SQLAlchemy Error: {e}')
+
+        # if the user did terminated this agent
+        if stored_agent.operational_state == states.TERMINATED:
+            logger.warning("agent %s terminated by user." %
+                           agent['agent_id'])
+            if agent['pending_event'] is not None:
+                tornado.ioloop.IOLoop.current().remove_timeout(
+                    agent['pending_event'])
+            session.query(VerfierMain).filter_by(
+                agent_id=agent['agent_id']).delete()
+            session.commit()
+            return
+
+        # if the user tells us to stop polling because the tenant quote check failed
+        if stored_agent.operational_state == states.TENANT_FAILED:
+            logger.warning(
+                "agent %s has failed tenant quote.  stopping polling" % agent['agent_id'])
+            if agent['pending_event'] is not None:
+                tornado.ioloop.IOLoop.current().remove_timeout(
+                    agent['pending_event'])
+            return
+
+        # If failed during processing, log regardless and drop it on the floor
+        # The administration application (tenant) can GET the status and act accordingly (delete/retry/etc).
+        if new_operational_state in (states.FAILED, states.INVALID_QUOTE):
+            agent['operational_state'] = new_operational_state
+
+            # issue notification for invalid quotes
+            if new_operational_state == states.INVALID_QUOTE:
+                cloud_verifier_common.notify_error(agent)
+
+            if agent['pending_event'] is not None:
+                tornado.ioloop.IOLoop.current().remove_timeout(
+                    agent['pending_event'])
+            for key in exclude_db:
+                if key in agent:
+                    del agent[key]
+            session.query(VerfierMain).filter_by(
+                agent_id=agent['agent_id']).update(agent)
+            session.commit()
+
+            logger.warning("agent %s failed, stopping polling" %
+                           agent['agent_id'])
+            return
+
+        # propagate all state, but remove none DB keys first (using exclude_db)
+        try:
+            agent_db = dict(agent)
+            for key in exclude_db:
+                if key in agent_db:
+                    del agent_db[key]
+
+            session.query(VerfierMain).filter_by(
+                agent_id=agent_db['agent_id']).update(agent_db)
+            session.commit()
+        except SQLAlchemyError as e:
+            logger.error(f'SQLAlchemy Error: {e}')
+
+        # if new, get a quote
+        if (main_agent_operational_state == states.START and
+                new_operational_state == states.GET_QUOTE):
+            agent['num_retries'] = 0
+            agent['operational_state'] = states.GET_QUOTE
+            await invoke_get_quote(agent, True)
+            return
+
+        if (main_agent_operational_state == states.GET_QUOTE and
+                new_operational_state == states.PROVIDE_V):
+            agent['num_retries'] = 0
+            agent['operational_state'] = states.PROVIDE_V
+            await invoke_provide_v(agent)
+            return
+
+        if (main_agent_operational_state in (states.PROVIDE_V, states.GET_QUOTE) and
+                new_operational_state == states.GET_QUOTE):
+            agent['num_retries'] = 0
+            interval = config.getfloat('cloud_verifier', 'quote_interval')
+            agent['operational_state'] = states.GET_QUOTE
+            if interval == 0:
+                await invoke_get_quote(agent, False)
+            else:
+                logger.debug(
+                    "Setting up callback to check again in %f seconds" % interval)
+                # set up a call back to check again
+                cb = functools.partial(invoke_get_quote, agent, False)
+                pending = tornado.ioloop.IOLoop.current().call_later(interval, cb)
+                agent['pending_event'] = pending
+            return
+
+        maxr = config.getint('cloud_verifier', 'max_retries')
+        retry = config.getfloat('cloud_verifier', 'retry_interval')
+        if (main_agent_operational_state == states.GET_QUOTE and
+                new_operational_state == states.GET_QUOTE_RETRY):
+            if agent['num_retries'] >= maxr:
+                logger.warning("agent %s was not reachable for quote in %d tries, setting state to FAILED" % (
+                    agent['agent_id'], maxr))
+                if agent['first_verified']:  # only notify on previously good agents
+                    cloud_verifier_common.notify_error(
+                        agent, msgtype='comm_error')
+                else:
+                    logger.debug(
+                        "Communication error for new agent.  no notification will be sent")
+                await process_agent(agent, states.FAILED)
+            else:
+                agent['operational_state'] = states.GET_QUOTE
+                cb = functools.partial(invoke_get_quote, agent, True)
+                agent['num_retries'] += 1
+                logger.info("connection to %s refused after %d/%d tries, trying again in %f seconds" %
+                            (agent['ip'], agent['num_retries'], maxr, retry))
+                tornado.ioloop.IOLoop.current().call_later(retry, cb)
+            return
+
+        if (main_agent_operational_state == states.PROVIDE_V and
+                new_operational_state == states.PROVIDE_V_RETRY):
+            if agent['num_retries'] >= maxr:
+                logger.warning("agent %s was not reachable to provide v in %d tries, setting state to FAILED" % (
+                    agent['agent_id'], maxr))
+                cloud_verifier_common.notify_error(
+                    agent, msgtype='comm_error')
+                await process_agent(agent, states.FAILED)
+            else:
+                agent['operational_state'] = states.PROVIDE_V
+                cb = functools.partial(invoke_provide_v, agent)
+                agent['num_retries'] += 1
+                logger.info("connection to %s refused after %d/%d tries, trying again in %f seconds" %
+                            (agent['ip'], agent['num_retries'], maxr, retry))
+                tornado.ioloop.IOLoop.current().call_later(retry, cb)
+            return
+        raise Exception("nothing should ever fall out of this!")
+
+    except Exception as e:
+        logger.error("Polling thread error: %s" % e)
+        logger.exception(e)
 
 
 def main():
@@ -637,7 +633,7 @@ def main():
         max_upload_size = int(config.get('cloud_verifier', 'max_upload_size'))
 
     VerfierMain.metadata.create_all(engine, checkfirst=True)
-    session = SessionManager().make_session(engine)
+    session = get_session()
     try:
         query_all = session.query(VerfierMain).all()
     except SQLAlchemyError as e:


### PR DESCRIPTION
It's not necessarily tight with request handler, by moving
it to the outter scope, it is possible to re-trigger agent
processing during verifier startup.

Resolves: #393