### PR TITLE
codestyle: Address issues related to E1101

### DIFF
--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -215,6 +215,10 @@ class AbstractTPM(metaclass=ABCMeta):
     def readPCR(self, pcrval, hash_alg=None):
         pass
 
+    @abstractmethod
+    def _get_tpm_rand_block(self, size=4096):
+        pass
+
     def __check_ima(self, agent_id, pcrval, ima_measurement_list, allowlist):
         logger.info(f"Checking IMA measurement list on agent: {agent_id}")
         if config.STUB_IMA:

--- a/scripts/check_codestyle.sh
+++ b/scripts/check_codestyle.sh
@@ -6,10 +6,12 @@ if [ -z "$(type -P pylint)" ]; then
 fi
 
 pylint \
+  --jobs=0 \
+  --ignored-modules=zmq,alembic.op,alembic.context,M2Crypto.m2 \
   --disable C0200,W0223,W1509 \
   --disable C0103,C0115,C0116,C0301,C0302,C0111 \
   --disable W0102,W0511,W0603,W0703,W1201,W1203 \
-  --disable E0401,E1101,E1120 \
+  --disable E0401,E1120 \
   --disable R0801,R0902,R0903,R0904,R0912,R0913,R0914,R0915,R0201,R0911 \
   *.py $(find ./keylime ./test -name '*.py' ! -name 'oldtest.py')
 exit $?

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -334,6 +334,8 @@ class TestRestful(unittest.TestCase):
     U = None
     V = None
     api_version = config.API_VERSION
+    cloudagent_ip = None
+    cloudagent_port = None
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This patch addresses the following issues detected by pylint:

************* Module keylime.tpm.tpm_abstract
keylime/tpm/tpm_abstract.py:303:20: E1101: Instance of 'AbstractTPM' has no '_get_tpm_rand_block' member (no-member)
************* Module keylime.tpm.tpm1
keylime/tpm/tpm1.py:541:20: E1101: Module 'M2Crypto.m2' has no 'bn_to_mpi' member (no-member)
keylime/tpm/tpm1.py:541:33: E1101: Module 'M2Crypto.m2' has no 'hex_to_bn' member (no-member)
keylime/tpm/tpm1.py:542:20: E1101: Module 'M2Crypto.m2' has no 'bn_to_mpi' member (no-member)
keylime/tpm/tpm1.py:542:33: E1101: Module 'M2Crypto.m2' has no 'hex_to_bn' member (no-member)
************* Module keylime.migrations.versions.eeb702f77d7d_allowlist_rename
keylime/migrations/versions/eeb702f77d7d_allowlist_rename.py:41:4: E1101: Module 'alembic.op' has no 'alter_column' member (no-member)
keylime/migrations/versions/eeb702f77d7d_allowlist_rename.py:47:4: E1101: Module 'alembic.op' has no 'alter_column' member (no-member)
************* Module keylime.migrations.versions.8a44a4364f5a_initial_database_migration
keylime/migrations/versions/8a44a4364f5a_initial_database_migration.py:34:4: E1101: Module 'alembic.op' has no 'create_table' member (no-member)
keylime/migrations/versions/8a44a4364f5a_initial_database_migration.py:50:4: E1101: Module 'alembic.op' has no 'drop_table' member (no-member)
keylime/migrations/versions/8a44a4364f5a_initial_database_migration.py:56:4: E1101: Module 'alembic.op' has no 'create_table' member (no-member)
keylime/migrations/versions/8a44a4364f5a_initial_database_migration.py:81:4: E1101: Module 'alembic.op' has no 'drop_table' member (no-member)
************* Module keylime.migrations.env
keylime/migrations/env.py:17:9: E1101: Module 'alembic.context' has no 'config' member (no-member)
keylime/migrations/env.py:24:11: E1101: Module 'alembic.context' has no 'get_x_argument' member (no-member)
keylime/migrations/env.py:74:12: E1101: Module 'alembic.context' has no 'configure' member (no-member)
keylime/migrations/env.py:82:17: E1101: Module 'alembic.context' has no 'begin_transaction' member (no-member)
keylime/migrations/env.py:83:16: E1101: Module 'alembic.context' has no 'run_migrations' member (no-member)
keylime/migrations/env.py:114:12: E1101: Module 'alembic.context' has no 'configure' member (no-member)
keylime/migrations/env.py:121:12: E1101: Module 'alembic.context' has no 'run_migrations' member (no-member)
keylime/migrations/env.py:138:3: E1101: Module 'alembic.context' has no 'is_offline_mode' member (no-member)
************* Module keylime.config
keylime/config.py:115:21: E1101: Module 'sys' has no '_MEIPASS' member (no-member)
************* Module keylime.revocation_notifier
keylime/revocation_notifier.py:30:34: E1101: Module 'zmq' has no 'SUB' member (no-member)
keylime/revocation_notifier.py:33:28: E1101: Module 'zmq' has no 'SUBSCRIBE' member (no-member)
keylime/revocation_notifier.py:36:33: E1101: Module 'zmq' has no 'PUB' member (no-member)
keylime/revocation_notifier.py:40:8: E1101: Module 'zmq' has no 'device' member (no-member)
keylime/revocation_notifier.py:40:19: E1101: Module 'zmq' has no 'FORWARDER' member (no-member)
keylime/revocation_notifier.py:56:32: E1101: Module 'zmq' has no 'PUB' member (no-member)
keylime/revocation_notifier.py:87:28: E1101: Module 'zmq' has no 'SUB' member (no-member)
keylime/revocation_notifier.py:88:22: E1101: Module 'zmq' has no 'SUBSCRIBE' member (no-member)
************* Module test.test_restful
test/test_restful.py:849:87: E1101: Instance of 'TestRestful' has no 'cloudagent_ip' member (no-member)
test/test_restful.py:849:107: E1101: Instance of 'TestRestful' has no 'cloudagent_port' member (no-member)

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>