### PR TITLE
codestyle: Resolve issues related to E0401

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
     packages:
       - python3-pip
       - python3-setuptools
+      - swig
 
 # If the change is a markdown file, don't run CI build. Or at a later point
 # we can set a specific job in here (such as a markdown lint)
@@ -34,6 +35,7 @@ services:
 before_install:
   - sudo pip3 install pylint --upgrade
   - sudo pip3 install tornado-requests
+  - sudo pip3 install -r requirements.txt
   - make check
   - 'docker pull ${tpm12image}:${tpm12tag}'
   - 'docker pull ${tpm20image}:${tpm20tag}'

--- a/scripts/check_codestyle.sh
+++ b/scripts/check_codestyle.sh
@@ -7,11 +7,11 @@ fi
 
 pylint \
   --jobs=0 \
-  --ignored-modules=zmq,alembic.op,alembic.context,M2Crypto.m2 \
+  --ignored-modules=zmq,alembic.op,alembic.context,M2Crypto.m2,_cLime,Cryptodome,pylab,matplotlib,numpy \
   --disable C0200,W0223,W1509 \
   --disable C0103,C0115,C0116,C0301,C0302,C0111 \
   --disable W0102,W0511,W0603,W0703,W1201,W1203 \
-  --disable E0401,E1120 \
+  --disable E1120 \
   --disable R0801,R0902,R0903,R0904,R0912,R0913,R0914,R0915,R0201,R0911 \
   *.py $(find ./keylime ./test -name '*.py' ! -name 'oldtest.py')
 exit $?


### PR DESCRIPTION
This patch addresses the following issues detected by pylint:

************ Module keylime.tpm.tpm1
keylime/tpm/tpm1.py:759:12: E0401: Unable to import '_cLime' (import-error)
************* Module keylime.cryptodome
keylime/cryptodome.py:10:0: E0401: Unable to import 'Cryptodome.Random' (import-error)
keylime/cryptodome.py:11:0: E0401: Unable to import 'Cryptodome.Hash' (import-error)
keylime/cryptodome.py:12:0: E0401: Unable to import 'Cryptodome.Cipher' (import-error)
keylime/cryptodome.py:13:0: E0401: Unable to import 'Cryptodome.PublicKey' (import-error)
keylime/cryptodome.py:14:0: E0401: Unable to import 'Cryptodome.Cipher' (import-error)
keylime/cryptodome.py:15:0: E0401: Unable to import 'Cryptodome.Protocol' (import-error)
keylime/cryptodome.py:16:0: E0401: Unable to import 'Cryptodome.Signature' (import-error)
************* Module utility_plot_time_series
keylime/benchmark/utility_plot_time_series.py:11:0: E0401: Unable to import 'pylab' (import-error)
keylime/benchmark/utility_plot_time_series.py:12:0: E0401: Unable to import 'matplotlib' (import-error)

Since these modules are likely rarely used we simply add them to the
ignored-modules list.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>