### PR TITLE
codestyle: Address issue related to C0411

### DIFF
--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -10,9 +10,9 @@ import time
 import os
 import sys
 import signal
-import zmq
 
 import simplejson as json
+import zmq
 
 from keylime import config
 from keylime import crypto


### PR DESCRIPTION
I doscovered this problem on an upgraded machine. For some reason this
problem was not found before with pylint 2.6.0.

This patch addresses the following issue detected by pylint

************ Module keylime.revocation_notifier
keylime/revocation_notifier.py:15:0: C0411: third party import "import simplejson as json" should be placed before "import zmq" (wrong-import-order)

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>