### PR TITLE
Fixes #486

### DIFF
--- a/keylime/tpm/tpm2.py
+++ b/keylime/tpm/tpm2.py
@@ -1210,7 +1210,7 @@ class tpm2(tpm_abstract.AbstractTPM):
                 logger.warning("No EK certificate found in TPM NVRAM")
                 return None
 
-            ekcert_size = outjson[0x1c00002]["size"]
+            ekcert_size = str(outjson[0x1c00002]["size"])
 
             # Read the RSA EK cert from NVRAM (DER format)
             if self.tools_version == "3.2":


### PR DESCRIPTION
Just ensures that ekcert_size parameter (the one after the -s in
tpm2_nvread) is passed to self.__run as a string.