### PR TITLE
codestyle: Address issues related to W0223

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -88,6 +88,9 @@ class BaseHandler(tornado.web.RequestHandler, SessionManager):
                 'results': {},
             }))
 
+    def data_received(self, chunk):
+        raise NotImplementedError()
+
 
 class MainHandler(tornado.web.RequestHandler):
 
@@ -110,6 +113,9 @@ class MainHandler(tornado.web.RequestHandler):
     def put(self):
         config.echo_json_response(
             self, 405, "Not Implemented: Use /agents/ interface instead")
+
+    def data_received(self, chunk):
+        raise NotImplementedError()
 
 
 class AgentsHandler(BaseHandler):
@@ -606,6 +612,9 @@ class AgentsHandler(BaseHandler):
         except Exception as e:
             logger.error("Polling thread error: %s" % e)
             logger.exception(e)
+
+    def data_received(self, chunk):
+        raise NotImplementedError()
 
 
 def start_tornado(tornado_server, port):

--- a/keylime/db/registrar_db.py
+++ b/keylime/db/registrar_db.py
@@ -12,7 +12,7 @@ from sqlalchemy import Column, String, Integer, PickleType, Text
 Base = declarative_base()
 
 
-class JSONPickleType(PickleType):
+class JSONPickleType(PickleType):  # pylint: disable=abstract-method
     impl = Text
 
 

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -12,7 +12,7 @@ from sqlalchemy import Column, String, Integer, PickleType, Text
 Base = declarative_base()
 
 
-class JSONPickleType(PickleType):
+class JSONPickleType(PickleType):  # pylint: disable=abstract-method
     impl = Text
 
 

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -63,6 +63,9 @@ class BaseHandler(tornado.web.RequestHandler):
         else:
             config.echo_json_response(self, status_code, self._reason)
 
+    def data_received(self, chunk):
+        raise NotImplementedError()
+
 
 class MainHandler(tornado.web.RequestHandler):
     def head(self):
@@ -84,6 +87,9 @@ class MainHandler(tornado.web.RequestHandler):
     def delete(self):
         config.echo_json_response(
             self, 405, "Not Implemented: Use /webapp/, /agents/ or /logs/  interface instead")
+
+    def data_received(self, chunk):
+        raise NotImplementedError()
 
 
 class WebAppHandler(BaseHandler):
@@ -287,6 +293,9 @@ class WebAppHandler(BaseHandler):
             </html>
             """
         )
+
+    def data_received(self, chunk):
+        raise NotImplementedError()
 
 
 class AgentsHandler(BaseHandler):
@@ -599,6 +608,9 @@ class AgentsHandler(BaseHandler):
         mytenant.do_cvreactivate()
 
         config.echo_json_response(self, 200, "Success")
+
+    def data_received(self, chunk):
+        raise NotImplementedError()
 
 
 def parse_data_uri(data_uri):

--- a/scripts/check_codestyle.sh
+++ b/scripts/check_codestyle.sh
@@ -8,7 +8,7 @@ fi
 pylint \
   --jobs=0 \
   --ignored-modules=zmq,alembic.op,alembic.context,M2Crypto.m2,_cLime,Cryptodome,pylab,matplotlib,numpy \
-  --disable W0223,W1509 \
+  --disable W1509 \
   --disable C0103,C0115,C0116,C0301,C0302,C0111 \
   --disable W0102,W0511,W0603,W0703,W1201,W1203 \
   --disable E1120 \


### PR DESCRIPTION
This patch addresses the following issues detected by pylint:

************ Module keylime.cloud_verifier_tornado
keylime/cloud_verifier_tornado.py:66:0: W0223: Method 'data_received' is abstract in class 'RequestHandler' but is not overridden (abstract-method)
keylime/cloud_verifier_tornado.py:92:0: W0223: Method 'data_received' is abstract in class 'RequestHandler' but is not overridden (abstract-method)
keylime/cloud_verifier_tornado.py:115:0: W0223: Method 'data_received' is abstract in class 'RequestHandler' but is not overridden (abstract-method)
************* Module keylime.db.verifier_db
keylime/db/verifier_db.py:15:0: W0223: Method 'process_bind_param' is abstract in class 'TypeDecorator' but is not overridden (abstract-method)
keylime/db/verifier_db.py:15:0: W0223: Method 'process_literal_param' is abstract in class 'TypeDecorator' but is not overridden (abstract-method)
keylime/db/verifier_db.py:15:0: W0223: Method 'process_result_value' is abstract in class 'TypeDecorator' but is not overridden (abstract-method)
keylime/db/verifier_db.py:15:0: W0223: Method 'python_type' is abstract in class 'TypeEngine' but is not overridden (abstract-method)
************* Module keylime.db.registrar_db
keylime/db/registrar_db.py:15:0: W0223: Method 'process_bind_param' is abstract in class 'TypeDecorator' but is not overridden (abstract-method)
keylime/db/registrar_db.py:15:0: W0223: Method 'process_literal_param' is abstract in class 'TypeDecorator' but is not overridden (abstract-method)
keylime/db/registrar_db.py:15:0: W0223: Method 'process_result_value' is abstract in class 'TypeDecorator' but is not overridden (abstract-method)
keylime/db/registrar_db.py:15:0: W0223: Method 'python_type' is abstract in class 'TypeEngine' but is not overridden (abstract-method)
************* Module keylime.tenant_webapp
keylime/tenant_webapp.py:53:0: W0223: Method 'data_received' is abstract in class 'RequestHandler' but is not overridden (abstract-method)
keylime/tenant_webapp.py:67:0: W0223: Method 'data_received' is abstract in class 'RequestHandler' but is not overridden (abstract-method)
keylime/tenant_webapp.py:89:0: W0223: Method 'data_received' is abstract in class 'RequestHandler' but is not overridden (abstract-method)
keylime/tenant_webapp.py:292:0: W0223: Method 'data_received' is abstract in class 'RequestHandler' but is not overridden (abstract-method)

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>