### PR TITLE
codestyle: Address issues relate to C0200

### DIFF
--- a/keylime/crypto.py
+++ b/keylime/crypto.py
@@ -136,7 +136,7 @@ def strbitxor(a, b):
     a = bytearray(a)
     b = bytearray(b)
     retval = bytearray(len(b))
-    for i in range(len(a)):
+    for i, _ in enumerate(a):
         retval[i] = a[i] ^ b[i]
     return bytes(retval)
 

--- a/keylime/cryptodome.py
+++ b/keylime/cryptodome.py
@@ -72,7 +72,7 @@ def strbitxor(a, b):
     a = bytearray(a)
     b = bytearray(b)
     retval = bytearray(len(b))
-    for i in range(len(a)):
+    for i, _ in enumerate(a):
         retval[i] = a[i] ^ b[i]
     return retval
 

--- a/scripts/check_codestyle.sh
+++ b/scripts/check_codestyle.sh
@@ -8,7 +8,7 @@ fi
 pylint \
   --jobs=0 \
   --ignored-modules=zmq,alembic.op,alembic.context,M2Crypto.m2,_cLime,Cryptodome,pylab,matplotlib,numpy \
-  --disable C0200,W0223,W1509 \
+  --disable W0223,W1509 \
   --disable C0103,C0115,C0116,C0301,C0302,C0111 \
   --disable W0102,W0511,W0603,W0703,W1201,W1203 \
   --disable E1120 \


### PR DESCRIPTION
This patch addresses the following issued detected by pylint:

************* Module keylime.cryptodome
keylime/cryptodome.py:75:4: C0200: Consider using enumerate instead of iterating with range and len (consider-using-enumerate)
************* Module keylime.crypto
keylime/crypto.py:139:4: C0200: Consider using enumerate instead of iterating with range and len (consider-using-enumerate)

The conversion make use of the fact that the following are producing equivalent ouput:

a=bytearray([11,22,55])
for i in range(len(a)):
for i, _ in enumerate(a):
     print(i)

and

a=bytearray([11,22,55])
for i, _ in enumerate(a):
     print(i)

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>