### PR TITLE
Improve tenant cli for status query

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -910,7 +910,7 @@ def main(argv=sys.argv):
     args = parser.parse_args(argv[1:])
     mytenant = Tenant()
 
-    if args.command not in ['list', 'regdelete', 'delete'] and args.agent_ip is None:
+    if args.command not in ['list', 'regdelete', 'delete', 'status'] and args.agent_ip is None:
         raise UserError(
             f"-t/--targethost is required for command {args.command}")
 


### PR DESCRIPTION
status command doesn't need agent address, exclude it
from the argument validation so we don't need to remember
agent addresses when doing status query.