### PR TITLE
Avoid log owner password

### DIFF
--- a/keylime/tpm/tpm1.py
+++ b/keylime/tpm/tpm1.py
@@ -282,7 +282,7 @@ class tpm1(tpm_abstract.AbstractTPM):
                 logger.info("Generating random TPM owner password")
                 owner_pw = tpm_abstract.TPM_Utilities.random_password(20)
             else:
-                logger.info("Taking ownership with config provided TPM owner password: %s" % config_pw)
+                logger.info("Taking ownership with config provided TPM owner password")
                 owner_pw = config_pw
 
             logger.info("Taking ownership of TPM")

--- a/keylime/tpm/tpm2.py
+++ b/keylime/tpm/tpm2.py
@@ -499,7 +499,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             logger.info("Generating random TPM owner password")
             owner_pw = tpm_abstract.TPM_Utilities.random_password(20)
         else:
-            logger.info("Taking ownership with config provided TPM owner password: %s" % config_pw)
+            logger.info("Taking ownership with config provided TPM owner password")
             owner_pw = config_pw
 
         if self.tools_version == "3.2":


### PR DESCRIPTION
We don't log random owner password, so shouldn't log config value
either.