### PR TITLE
Fix ima_whitelist db field type

### DIFF
--- a/keylime/migrations/versions/8a44a4364f5a_initial_database_migration.py
+++ b/keylime/migrations/versions/8a44a4364f5a_initial_database_migration.py
@@ -63,7 +63,7 @@ def upgrade_cloud_verifier():
                     sa.Column('tpm_policy', sa.String(length=1000), nullable=True),
                     sa.Column('vtpm_policy', sa.String(length=1000), nullable=True),
                     sa.Column('meta_data', sa.String(length=200), nullable=True),
-                    sa.Column('ima_whitelist', sa.String(length=429400000), nullable=True),
+                    sa.Column('ima_whitelist', sa.Text(length=429400000), nullable=True),
                     sa.Column('revocation_key', sa.String(length=2800), nullable=True),
                     sa.Column('tpm_version', sa.Integer(), nullable=True),
                     sa.Column('accept_tpm_hash_algs', keylime.db.verifier_db.JSONPickleType(), nullable=True),


### PR DESCRIPTION
During migration there is a warning

2021-01-13 15:29:49.954 - alembic.runtime.migration - INFO - Running upgrade  -> 8a44a4364f5a, Initial database migration
/usr/lib/python3.6/site-packages/pymysql/cursors.py:165: Warning: (1246, "Converting column 'ima_whitelist' from VARCHAR to TEXT")
  result = self._query(query)

The type of ima_whitelist is changed to text from varchar,
set to text initially to avoid this type change.