### PR TITLE
Enable Github plugin for semantic-release

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,1 +1,2 @@
 branches: master
+plugins: ['@semantic-release/github']


### PR DESCRIPTION
A possible fix for the current failure.