### PR TITLE
Extend capacity of verifiermain.ip field

### DIFF
--- a/keylime/migrations/versions/8da20383f6e1_extend_ip_field.py
+++ b/keylime/migrations/versions/8da20383f6e1_extend_ip_field.py
@@ -1,0 +1,42 @@
+"""extend_ip_field
+
+Revision ID: 8da20383f6e1
+Revises: eeb702f77d7d
+Create Date: 2021-01-14 10:50:56.275257
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8da20383f6e1'
+down_revision = 'eeb702f77d7d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+    with op.batch_alter_table('verifiermain') as batch_op:
+        batch_op.alter_column('ip', existing_type=sa.String(length=15),
+                              type_=sa.String(length=255), existing_nullable=True)
+
+
+def downgrade_cloud_verifier():
+    pass


### PR DESCRIPTION
Add migration script to extend the ip field capacity to hold up
to 255 characters.

Resolves: #498