### PR TITLE
Add lint check to "test" workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on: [pull_request, workflow_dispatch]
 
 jobs:
-  test:
+  tpm-tests:
     runs-on: ubuntu-latest
     container:
       image: quay.io/keylime/keylime-ci:latest
@@ -15,3 +15,20 @@ jobs:
       uses: actions/checkout@v2
     - name: Run tests
       run: .ci/test_wrapper_gha.sh
+  lint:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/keylime/keylime-ci:latest
+      options: --user root --mount type=tmpfs,destination=/var/lib/keylime/,tmpfs-mode=1770
+      env:
+        KEYLIME_TEST: True
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Python dependencies
+      run: >
+        python3 -m pip install pylint --upgrade &&
+        python3 -m pip install tornado-requests &&
+        python3 -m pip install -r requirements.txt
+    - name: Run lints
+      run: make check


### PR DESCRIPTION
This replicates the lint step present in the Travis testing config by installing necessary Python dependencies and running `make check`.

Resolves #509 