### PR TITLE
Remove revocation notifier's ZMQ frontend socket file before killing the process

### DIFF
--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -47,6 +47,9 @@ def start_broker():
 def stop_broker():
     global broker_proc
     if broker_proc is not None:
+        # Remove the socket file before  we kill the process
+        if os.path.exists("/tmp/keylime.verifier.ipc"):
+            os.remove("/tmp/keylime.verifier.ipc")
         os.kill(broker_proc.pid, signal.SIGKILL)
 
 


### PR DESCRIPTION
I had initially planned to also close the socket, but it appears that's not necessary, if my understanding of the PyZMQ documentation is correct.

So this patch simply removes the lingering frontend socket file before the revocation notifier process is killed.

Signed-off-by: axelsimon <github@axelsimon.net>