### PR TITLE
Fix brached migration path

### DIFF
--- a/keylime/migrations/versions/a09a40352c32_add_ima_filesigning_keys_column.py
+++ b/keylime/migrations/versions/a09a40352c32_add_ima_filesigning_keys_column.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'a09a40352c32'
-down_revision = 'eeb702f77d7d'
+down_revision = '8da20383f6e1'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
There were two database schema changes merged but not dependent on each
other, so current migration path is branched.

Update dependency according to merge sequence.

Signed-off-by: Kaifeng Wang <kaifeng.w@gmail.com>