### PR TITLE
Revert "Simplify database configuration"

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -198,16 +198,7 @@ registrar_private_key_pw = default
 # Database URL Configuration
 # See this document https://keylime-docs.readthedocs.io/en/latest/installation.html#database-support
 # for instructions on using different database configurations.
-# Database configuration via drivername, username, password, etc is deprecated
-# and superseded by database_url, when database_url is set, other database
-# fields will be ignored.
-# An example of database_url value for using sqlite:
-#   sqlite:////var/lib/keylime/cv_data.sqlite
-# An example of database_url value for using mysql:
-#   mysql+pymysql://keylime:keylime@keylime_db:[port]/verifier?charset=utf8
-# If database_url is not set, the deprecated default is "sqlite" and will be
-# located at "/var/lib/keylime/cv_data.sqlite".
-database_url =
+# The default is "sqlite" and will be located at "/var/lib/keylime/cv_data.sqlite".
 drivername = sqlite
 username = ''
 password = ''
@@ -215,7 +206,6 @@ host = ''
 port = ''
 database = cv_data.sqlite
 query = ''
-
 auto_migrate_db = True
 
 
@@ -476,16 +466,7 @@ check_client_cert = True
 # Database URL Configuration
 # See this document https://keylime-docs.readthedocs.io/en/latest/installation.html#database-support
 # for instructions on using different database configurations.
-# Database configuration via drivername, username, password, etc is deprecated
-# and superseded by database_url, when database_url is set, other database
-# fields will be ignored.
-# An example of database_url value for using sqlite:
-#   sqlite:////var/lib/keylime/reg_data.sqlite
-# An example of database_url value for using mysql:
-#   mysql+pymysql://keylime:keylime@keylime_db:[port]/registrar?charset=utf8
-# If database_url is not set, the deprecated default is "sqlite" and will be
-# located at "/var/lib/keylime/reg_data.sqlite".
-database_url =
+# The default is "sqlite" and will be located at "/var/lib/keylime/reg_data.sqlite".
 drivername = sqlite
 username = ''
 password = ''
@@ -493,9 +474,7 @@ host = ''
 port = ''
 database = reg_data.sqlite
 query = ''
-
 auto_migrate_db = True
-
 
 # The file to use for SQLite persistence of provider hypervisor data.
 prov_db_filename = provider_reg_data.sqlite

--- a/keylime/db/keylime_db.py
+++ b/keylime/db/keylime_db.py
@@ -12,8 +12,6 @@ from sqlalchemy.engine.url import URL
 from keylime import config
 from keylime import keylime_logging
 
-logger = keylime_logging.init_logging('keylime_db')
-
 
 class DBEngineManager:
 
@@ -26,16 +24,8 @@ class DBEngineManager:
         """
         self.service = service
 
-        database_url = config.get(service, 'database_url')
-        if database_url:
-            engine = create_engine(database_url)
-            return engine
-
-        # TODO(kaifeng) Remove following code as well as related configuration
-        # options when the deprecation period is reached.
-        logger.warning('database_url is not set, using deprecated database '
-                       'configuration options')
         drivername = config.get(service, 'drivername')
+
         if drivername == 'sqlite':
             database = "%s/%s" % (config.WORK_DIR,
                                   config.get(service, 'database'))
@@ -79,5 +69,6 @@ class SessionManager:
             Session = scoped_session(sessionmaker())
             Session.configure(bind=self.engine)
         except SQLAlchemyError as e:
+            logger = keylime_logging.init_logging('sql_session_manager')
             logger.error(f'Error creating SQL session manager {e}')
         return Session()

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -349,8 +349,8 @@ class UnprotectedHandler(BaseHTTPRequestHandler, SessionManager):
                         logger.error(f'SQLAlchemy Error: {e}')
                         raise
                 else:
-                    # TODO(kaifeng) Special handling should be removed
-                    if engine.dialect.name == "mysql":
+                    drivername = config.get('registrar', 'drivername')
+                    if drivername == "mysql":
                         agent.key = agent.key.encode('utf-8')
 
                     ex_mac = crypto.do_hmac(agent.key, agent_id)


### PR DESCRIPTION
Reverts keylime/keylime#427


This adds no value at all, its half written with TODOs in it and the previous code was fine. We were using sqlachemy generics to construct the connection url, now all we are doing is have the user hardcode it instead. It does not even update the user docs.

Let's please not deprecate working code unless there is a compelling reason to. I recommend we revert this and think it through and discuss it again properly , what merits such a change as this?  Saying 'simplify' is not saying much.