### PR TITLE
db: Fix DB migrations script revisions

### DIFF
--- a/keylime/migrations/versions/a7a64155ab3a_add_ima_filesigning_keys_column.py
+++ b/keylime/migrations/versions/a7a64155ab3a_add_ima_filesigning_keys_column.py
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = 'a09a40352c32'
-down_revision = 'eeb702f77d7d'
+revision = 'a7a64155ab3a'
+down_revision = '8da20383f6e1'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
The DB migrations script for the IMA keys did not link in properly with
the existing scripts, failing the test cases. This patch fixes this and
the upgrade history is now correct:

$ PYTHONPATH=. alembic -c keylime/migrations/alembic.ini history
8da20383f6e1 -> a7a64155ab3a (head), Add ima_sign_verification_keys column
eeb702f77d7d -> 8da20383f6e1, extend_ip_field
8a44a4364f5a -> eeb702f77d7d, allowlist rename
<base> -> 8a44a4364f5a, Initial database migration

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>