### PR TITLE
ima: Return None in case there was no keyring in the DB

### DIFF
--- a/keylime/ima_file_signatures.py
+++ b/keylime/ima_file_signatures.py
@@ -193,9 +193,13 @@ class ImaKeyring:
 
         default_be = backends.default_backend()
 
+        # An empty Db entry comes as a string '[]'. A valid DB entry as a string
+        # ith escaped quotes and needs to be loaded twice
         obj = json.loads(stringrepr)
         if isinstance(obj, str):
             obj = json.loads(obj)
+        if not isinstance(obj, dict):
+            return None
 
         for der_key in ImaKeyring._base64_to_der_keylist(obj['pubkeys']):
             try:


### PR DESCRIPTION
This patch fixes the following issue on the verifier side when no
string representation of an IMA keyring is found in the DB.

2021-01-20 15:58:55.083 - keylime.tpm2 - INFO - TPM2-TOOLS Version: 5.0
2021-01-20 15:58:55.084 - keylime.cloudverifier - ERROR - list indices must be integers or slices, not str
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/keylime-0.0.0-py3.8.egg/keylime/cloud_verifier_tornado.py", line 437, in invoke_get_quote
    if cloud_verifier_common.process_quote_response(agent, json_response['results']):
  File "/usr/local/lib/python3.8/site-packages/keylime-0.0.0-py3.8.egg/keylime/cloud_verifier_common.py", line 202, in process_quote_response
    ima_keyring = ima_file_signatures.ImaKeyring.from_string(agent['ima_sign_verification_keys'])
  File "/usr/local/lib/python3.8/site-packages/keylime-0.0.0-py3.8.egg/keylime/ima_file_signatures.py", line 200, in from_string
    for der_key in ImaKeyring._base64_to_der_keylist(obj['pubkeys']):
TypeError: list indices must be integers or slices, not str

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>