### PR TITLE
First PR (of a total of 3) to address #491

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -214,7 +214,6 @@ def process_quote_response(agent, json_response):
                                      hash_alg,
                                      ima_keyring,
                                      mb_measurement_list,
-                                     #agent['mb_intended_state'],
                                      {})
     if not validQuote:
         return False

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -133,12 +133,15 @@ def process_quote_response(agent, json_response):
         quote = json_response["quote"]
 
         ima_measurement_list = json_response.get("ima_measurement_list", None)
+        mb_measurement_list = json_response.get("mb_measurement_list", None)
 
         logger.debug("received quote:      %s" % quote)
         logger.debug("for nonce:           %s" % agent['nonce'])
         logger.debug("received public key: %s" % received_public_key)
         logger.debug("received ima_measurement_list    %s" %
                      (ima_measurement_list is not None))
+        logger.debug("received boot log    %s" %
+                     (mb_measurement_list is not None))
     except Exception:
         return None
 
@@ -209,7 +212,10 @@ def process_quote_response(agent, json_response):
                                      ima_measurement_list,
                                      agent['allowlist'],
                                      hash_alg,
-                                     ima_keyring)
+                                     ima_keyring,
+                                     mb_measurement_list,
+                                     #agent['mb_intended_state'],
+                                     {})
     if not validQuote:
         return False
 

--- a/keylime/config.py
+++ b/keylime/config.py
@@ -295,6 +295,10 @@ else:
 
 IMA_PCR = 10
 
+# measured boot addons
+MEASUREDBOOT_PCRS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 14]
+MEASUREDBOOT_ML = '/sys/kernel/security/tpm0/binary_bios_measurements'
+
 # this is where data will be bound to a quote, MUST BE RESETABLE!
 TPM_DATA_PCR = 16
 

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -155,6 +155,19 @@ class Handler(BaseHTTPRequestHandler):
                         ml = f.read()
                     response['ima_measurement_list'] = ml
 
+            # similar to how IMA log retrievals are triggered by IMA_PCR, we trigger boot logs with MEASUREDBOOT_PCRs
+            # other possibilities would include adding additional data to rest_params to trigger boot log retrievals
+            # generally speaking, retrieving the 15Kbytes of a boot log does not seem significant compared to the
+            # potential Mbytes of an IMA measurement list.
+            if TPM_Utilities.check_mask(imaMask, config.MEASUREDBOOT_PCRS[0]):
+                if not os.path.exists(config.MEASUREDBOOT_ML):
+                    logger.warning(
+                        "TPM2 event log not available: %s" % (config.MEASUREDBOOT_ML))
+                else:
+                    with open(config.MEASUREDBOOT_ML, 'rb') as f:
+                        el = base64.b64encode(f.read())
+                    response['mb_measurement_list'] = el
+
             config.echo_json_response(self, 200, "Success", response)
             logger.info('GET %s quote returning 200 response.' %
                         (rest_params["quotes"]))

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -201,6 +201,16 @@ class Tenant():
         al_data = None
         if "allowlist" in args and args["allowlist"] is not None:
 
+            _policy_pcrs = list(self.tpm_policy.keys())
+            _policy_pcrs.remove('mask')
+
+            _protected_pcrs = [ config.IMA_PCR ]
+
+            for _pcr in _policy_pcrs :
+                if int(_pcr) in _protected_pcrs :
+                    logger.error(f"WARNING: PCR {_pcr} is specified in \"tpm_policy\", but will in fact be used by IMA. Please remove it from policy")
+                    sys.exit()
+
             # Auto-enable IMA (or-bit mask)
             self.tpm_policy['mask'] = "0x%X" % (
                 int(self.tpm_policy['mask'], 0) | (1 << config.IMA_PCR))
@@ -234,6 +244,34 @@ class Tenant():
 
             # Process allowlists
             self.allowlist = ima.process_allowlists(al_data, excl_data)
+
+        # Read command-line path string TPM2 event log template
+        if "mb_refstate" in args and args["mb_refstate"] is not None:
+            _policy_pcrs = list(self.tpm_policy.keys())
+            _policy_pcrs.remove('mask')
+            _protected_pcrs = config.MEASUREDBOOT_PCRS
+
+            for _pcr in _policy_pcrs :
+                if int(_pcr) in _protected_pcrs :
+                    logger.error(f"WARNING: PCR {_pcr} is specified in \"tpm_policy\", but will in fact be used by TPM2 measured boot. Please remove it from policy")
+                    sys.exit()
+
+            # Auto-enable TPM2 event log (or-bit mask)
+            for _pcr in config.MEASUREDBOOT_PCRS :
+                self.tpm_policy['mask'] = "0x%X" % (
+                    int(self.tpm_policy['mask'], 0) | (1 << _pcr))
+
+            logger.info(f"TPM PCR Mask automatically modified is {self.tpm_policy['mask']} to include IMA/Event log PCRs")
+
+            if isinstance(args["mb_refstate"], str):
+                if args["mb_refstate"] == "default":
+                    args["mb_refstate"] = config.get('tenant', 'mb_refstate')
+                al_data = 'test'
+#                al_data = mb.read_allowlist(args["allowlist"]) <------ read the actual intended state
+            elif isinstance(args["mb_refstate"], list):
+                al_data = args["mb_refstate"]
+            else:
+                raise UserError("Invalid measured boot reference state (intended state) provided")
 
         # if none
         if (args["file"] is None and args["keyfile"] is None and args["ca_dir"] is None):
@@ -928,6 +966,8 @@ def main(argv=sys.argv):
                         default=None, help="Specify the location of an allowlist")
     parser.add_argument('--sign_verification_key', action='append', dest='ima_sign_verification_keys',
                         default=None, help="Specify an IMA file signature verification key")
+    parser.add_argument('--mb_refstate', action='store', dest='mb_refstate',
+                        default=None, help="Specify the location of a measure boot reference state (intended state)")
     parser.add_argument('--exclude', action='store', dest='ima_exclude',
                         default=None, help="Specify the location of an IMA exclude list")
     parser.add_argument('--tpm_policy', action='store', dest='tpm_policy', default=None,

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -399,7 +399,7 @@ class Tenant():
         for _pcr in policy_pcrs :
             if int(_pcr) in protected_pcrs :
                 logger.error(f"WARNING: PCR {_pcr} is specified in \"tpm_policy\", but will in fact be used by {pcr_use}. Please remove it from policy")
-                sys.exit()
+                sys.exit(1)
 
     def preloop(self):
         """ encrypt the agent UUID as a check for delivering the correct key

--- a/keylime/tpm/tpm2.py
+++ b/keylime/tpm/tpm2.py
@@ -1025,7 +1025,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         retDict = self.__run(command, lock=False)
         return retDict
 
-    def check_quote(self, agent_id, nonce, data, quote, aikFromRegistrar, tpm_policy={}, ima_measurement_list=None, allowlist={}, hash_alg=None, ima_keyring=None):
+    def check_quote(self, agent_id, nonce, data, quote, aikFromRegistrar, tpm_policy={}, ima_measurement_list=None, allowlist={}, hash_alg=None, ima_keyring=None, mb_measurement_list=None, mb_intended_state={}):
         if hash_alg is None:
             hash_alg = self.defaults['hash']
 
@@ -1033,6 +1033,9 @@ class tpm2(tpm_abstract.AbstractTPM):
         aikFile = None
         sigFile = None
         pcrFile = None
+
+        if mb_measurement_list or mb_intended_state :
+            logger.info("Measured boot information received, but for now it will not be processed")
 
         if quote[0] != 'r':
             raise Exception("Invalid quote type %s" % quote[0])
@@ -1115,7 +1118,7 @@ class tpm2(tpm_abstract.AbstractTPM):
         if len(pcrs) == 0:
             pcrs = None
 
-        return self.check_pcrs(agent_id, tpm_policy, pcrs, data, False, ima_measurement_list, allowlist, ima_keyring)
+        return self.check_pcrs(agent_id, tpm_policy, pcrs, data, False, ima_measurement_list, allowlist, ima_keyring, mb_measurement_list, mb_intended_state)
 
     def sim_extend(self, hashval_1, hashval_0=None):
         # simulate extending a PCR value by performing TPM-specific extend procedure

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -238,7 +238,7 @@ class AbstractTPM(metaclass=ABCMeta):
         pcr_allowlist = tpm_policy_.copy()
 
         if mb_measurement_list or mb_intended_state :
-            logger.info("Measured boot information received, but for now it will not be processed")
+            logger.info("Measured boot information received, but for now it will not be processed. A future update will enable the full processing of it.")
 
         if 'mask' in pcr_allowlist:
             del pcr_allowlist['mask']

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -177,7 +177,7 @@ class AbstractTPM(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def check_quote(self, agent_id, nonce, data, quote, aikFromRegistrar, tpm_policy={}, ima_measurement_list=None, allowlist={}, hash_alg=None, ima_keyring=None):
+    def check_quote(self, agent_id, nonce, data, quote, aikFromRegistrar, tpm_policy={}, ima_measurement_list=None, allowlist={}, hash_alg=None, ima_keyring=None, mb_measurement_list=None, mb_intended_state={}):
         pass
 
     def START_HASH(self, algorithm=None):
@@ -230,12 +230,15 @@ class AbstractTPM(metaclass=ABCMeta):
         logger.debug(f"IMA measurement list of agent {agent_id} validated")
         return True
 
-    def check_pcrs(self, agent_id, tpm_policy, pcrs, data, virtual, ima_measurement_list, allowlist, ima_keyring):
+    def check_pcrs(self, agent_id, tpm_policy, pcrs, data, virtual, ima_measurement_list, allowlist, ima_keyring, mb_measurement_list, mb_intended_state):
         try:
             tpm_policy_ = ast.literal_eval(tpm_policy)
         except ValueError:
             tpm_policy_ = {}
         pcr_allowlist = tpm_policy_.copy()
+
+        if mb_measurement_list or mb_intended_state :
+            logger.info("Measured boot information received, but for now it will not be processed")
 
         if 'mask' in pcr_allowlist:
             del pcr_allowlist['mask']
@@ -277,6 +280,11 @@ class AbstractTPM(metaclass=ABCMeta):
                     continue
 
                 return False
+
+            # check whether this is a MB PCR -- do *not* compare measured boot PCRs against a reference state, if one exists
+            if pcrnum in config.MEASUREDBOOT_PCRS and mb_intended_state :
+                pcrsInQuote.add(pcrnum)
+                continue
 
             if pcrnum not in list(pcr_allowlist.keys()):
                 if not config.STUB_TPM and len(list(tpm_policy.keys())) > 0:


### PR DESCRIPTION
* The `agent` will now retrieve TPM 2.0 preboot event log and will ship
it to the `verifier`. The latter will do nothing with it (just receives
and ignores it)
* Adds a new `keylime_tenant` CLI option, `--mb_refstate` (that was a
request from @mpeters) to signal the need for the agent to collect the
the event log. At this point, `keylime_tenant` do not actually process
this option (it shall be processed in a manner similar to IMA in a
future PR), it is simply used to signal the agent that "tpm2 preboot
event log" should be read.
* Hard-coded PCRs [0-9], 14 and path
/sys/kernel/security/tpm0/binary_bios_measurements for the event log
* The `verifier` will output a debug logging message stating that it
received the "tpm2 event log", and will send it down to the `check_pcrs`
method, but there is no actual processing there (it will be done in
subsequent PR)

Signed-off-by: Marcio Silva <marcios@us.ibm.com>