### PR TITLE
Fix evictcontrol for tpm2 tools 3.2

### DIFF
--- a/keylime/tpm/tpm2.py
+++ b/keylime/tpm/tpm2.py
@@ -414,7 +414,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             outjson = config.yaml_to_dict(output)
             if outjson is not None and current_handle in outjson:
                 if self.tools_version == "3.2":
-                    cmd = ["tpm2_evictcontrol", "-A", "o", "-c",
+                    cmd = ["tpm2_evictcontrol", "-A", "o", "-H",
                            hex(current_handle), "-P", owner_pw]
                     retDict = self.__run(cmd, raiseOnError=False)
                 else:
@@ -627,7 +627,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             outjson = config.yaml_to_dict(output)
             if outjson is not None and aik_handle in outjson:
                 if self.tools_version == "3.2":
-                    cmd = ["tpm2_evictcontrol", "-A", "o", "-c", hex(aik_handle), "-P", owner_pw]
+                    cmd = ["tpm2_evictcontrol", "-A", "o", "-H", hex(aik_handle), "-P", owner_pw]
                     retDict = self.__run(cmd, raiseOnError=False)
                 else:
                     cmd = ["tpm2_evictcontrol", "-C", "o", "-c", hex(aik_handle), "-P", owner_pw]
@@ -736,7 +736,7 @@ class tpm2(tpm_abstract.AbstractTPM):
             if str(hex(key)) != self.defaults['ek_handle']:
                 logger.debug("Flushing key handle %s" % hex(key))
                 if self.tools_version == "3.2":
-                    self.__run(["tpm2_evictcontrol", "-A", "o", "-c", hex(key), "-P", owner_pw],
+                    self.__run(["tpm2_evictcontrol", "-A", "o", "-H", hex(key), "-P", owner_pw],
                                raiseOnError=False)
                 else:
                     self.__run(["tpm2_evictcontrol", "-C", "o", "-c", hex(key), "-P", owner_pw],


### PR DESCRIPTION
It appears that for tpm2-tools 3.2 the tpm2_evictcontrol accepts
handle from the -H argument instead of -c.

  # tpm2_evictcontrol -A o -c 0x81010007 -P keylime
  ERROR: Invalid arguments
  ERROR: Unable to run tpm2_evictcontrol

Suddenly hits this issue in a working host.