### PR TITLE
Address some more IMA file signature verification issues

### DIFF
--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -218,7 +218,7 @@ def _extract_from_ima_sig(tokens, template_hash):
 
 
 def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyring=None):
-    errs = [0, 0, 0, 0]
+    errs = [0, 0, 0, 0, 0]
     runninghash = START_HASH
     found_pcr = (pcrval is None)
 
@@ -294,7 +294,7 @@ def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyri
 
             if not ima_keyring.integrity_digsig_verify(signature, filedata_hash, filedata_algo):
                 logger.warning("signature for file %s is not valid" % (path))
-                errs[0] += 1
+                errs[3] += 1
             else:
                 logger.debug("signature for file %s is good" % path)
 
@@ -335,7 +335,7 @@ def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyri
             logger.warning("File %s not evaluated with signature or allowlist" % path)
             errs[1] += 1
 
-        errs[3] += 1
+        errs[4] += 1
 
     # check PCR value has been found
     if not found_pcr:
@@ -343,9 +343,9 @@ def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyri
         return None
 
     # clobber the retval if there were IMA file errors
-    if sum(errs[:3]) > 0:
+    if sum(errs[:4]) > 0:
         logger.error(
-            "IMA ERRORS: template-hash %d fnf %d hash %d good %d" % tuple(errs))
+            "IMA ERRORS: template-hash %d fnf %d hash %d bad-sig %d good %d" % tuple(errs))
         return None
 
     return codecs.encode(runninghash, 'hex').decode('utf-8')

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -299,7 +299,6 @@ def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyri
                 logger.debug("signature for file %s is good" % path)
 
         if allowlist is not None:
-            evaluated = True
             # just skip if it is a weird overwritten path
             if template_hash == FF_HASH:
                 # print "excluding ffhash %s"%path
@@ -312,8 +311,12 @@ def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyri
 
             accept_list = allowlist.get(path, None)
             if accept_list is None:
-                logger.warning("File not found in allowlist: %s" % (path))
-                errs[1] += 1
+                # if it's NOT already evaluated by a file signature then a
+                # missing file entry is an error -- this enforces that every
+                # entry is 'covered' by signature or allowlist
+                if not evaluated:
+                    logger.warning("File not found in allowlist: %s" % (path))
+                    errs[1] += 1
                 continue
 
             # print('codecs.encode', codecs.encode(filedata_hash, 'hex').decode('utf-8'))
@@ -325,6 +328,8 @@ def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyri
                                 accept_list))
                 errs[2] += 1
                 continue
+
+            evaluated = True
 
         if ima_keyring and not evaluated:
             logger.warning("File %s not evaluated with signature or allowlist" % path)

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -296,7 +296,7 @@ def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyri
                 logger.warning("signature for file %s is not valid" % (path))
                 errs[0] += 1
             else:
-                logger.info("signature for file %s is good" % path)
+                logger.debug("signature for file %s is good" % path)
 
         if allowlist is not None:
             evaluated = True

--- a/keylime/ima_file_signatures.py
+++ b/keylime/ima_file_signatures.py
@@ -223,7 +223,7 @@ class ImaKeyring:
         fmt = '>BBBIH'
         hdrlen = struct.calcsize(fmt)
         if len(signature) < hdrlen:
-            logger.error("Signature header is too short")
+            logger.warning("Signature header is too short")
             return False
         _, _, hash_algo, keyidv2, sig_size = struct.unpack(fmt, signature[:hdrlen])
 
@@ -235,12 +235,12 @@ class ImaKeyring:
 
         hashfunc = HASH_FUNCS.get(hash_algo)
         if not hashfunc:
-            logger.error("Unsupported hash algo with id '%d'" % hash_algo)
+            logger.warning("Unsupported hash algo with id '%d'" % hash_algo)
             return False
 
         if filehash_type != hashfunc().name:
-            logger.error("Mismatching filehash type %s and ima signature hash used %s" %
-                         (filehash_type, hashfunc().name))
+            logger.warning("Mismatching filehash type %s and ima signature hash used %s" %
+                           (filehash_type, hashfunc().name))
             return False
 
         pubkey = self.get_pubkey_by_keyidv2(keyidv2)
@@ -250,8 +250,7 @@ class ImaKeyring:
 
         try:
             ImaKeyring._verify(pubkey, signature[hdrlen:], filehash, hashfunc())
-        except InvalidSignature as ex:
-            logger.warning("Invalid signature: %s" % str(ex))
+        except InvalidSignature:
             return False
         return True
 


### PR DESCRIPTION
This PR addresses some more IMA file signature verification 'teething' issues:

- It reduces the logging output on file signatures evaluation. Particularly a log entry indicating a good signature is only shown on logger.debug level
- We now account for bad file signatures in a separate error field and report it
- If an allow list entry is not available then an error is only reported if its signature has not already been evaluated; this allows us to only sign a file and not have an allow list entry on top of it