### PR TITLE
SQLAlchemy database schema fix for the new `ima_sign_verification_keys` column

### DIFF
--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -29,7 +29,7 @@ class VerfierMain(Base):
     vtpm_policy = Column(String(1000))
     meta_data = Column(String(200))
     allowlist = Column(Text(429400000))
-    ima_sign_verification_keys = Column(String(1048576))
+    ima_sign_verification_keys = Column(Text(429400000))
     revocation_key = Column(String(2800))
     tpm_version = Column(Integer)
     accept_tpm_hash_algs = Column(JSONPickleType(pickler=json))


### PR DESCRIPTION
This commit, very similar to #376, fixes the SQLAlchemy problem that
appears when one attempts to create a column of type `String` with a
large value (`1048576`) against a MySQL database. This results in the
error `Column length too big for column 'ima_sign_verification_keys'
(max = 65535); use BLOB or TEXT instead")` and here we just change the
`ima_sign_verification_keys` column to `Text(429400000)`. Tested on both
MySQL 5.7.31 and SQLite.

Signed-off-by: Marcio Silva <marcios@us.ibm.com>