### PR TITLE
Fix an issue that check persistent handles

### DIFF
--- a/keylime/tpm/tpm2.py
+++ b/keylime/tpm/tpm2.py
@@ -412,7 +412,7 @@ class tpm2(tpm_abstract.AbstractTPM):
                 raise Exception("tpm2_getcap failed with code " + str(code) + ": " + str(reterr))
 
             outjson = config.yaml_to_dict(output)
-            if outjson is not None and current_handle in outjson:
+            if outjson is not None and hex(current_handle) in outjson:
                 if self.tools_version == "3.2":
                     cmd = ["tpm2_evictcontrol", "-A", "o", "-H",
                            hex(current_handle), "-P", owner_pw]


### PR DESCRIPTION
This PR is to address following exception:

Traceback (most recent call last):
  File "/usr/bin/keylime_agent", line 11, in <module>
    load_entry_point('keylime==0.0.0', 'console_scripts', 'keylime_agent')()
  File "/usr/lib/python3.6/site-packages/keylime/cmd/agent.py", line 15, in main
    keylime_agent.main()
  File "/usr/lib/python3.6/site-packages/keylime/keylime_agent.py", line 492, in main
    'cloud_agent', 'tpm_ownerpassword'))  # this tells initialize not to self activate the AIK
  File "/usr/lib/python3.6/site-packages/keylime/tpm/tpm2.py", line 935, in tpm_init
    self.__create_ek()
  File "/usr/lib/python3.6/site-packages/keylime/tpm/tpm2.py", line 416, in __create_ek
    if outjson is not None and current_handle in outjson:
TypeError: 'in <string>' requires string as left operand, not int