### PR TITLE
Added developer conveniences to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
 /cloudinit_script_encrypted.txt
+
+# For Python virtual environments
+.venv
+
+# Created automatically by a popular IDE
+.vscode
+
+# Suggested by a popular IDE when it tells me I should save my workspace
+workspace.code-workspace
+
 # Backup files
 *.~
 *~


### PR DESCRIPTION
This PR adds to `.gitignore`:
- `.venv`, a common name for a Python virtual environment;
- `.vscode`, the name for the directory that a popular IDE creates for itself; and
- `workspace.code-workspace`, the name suggested by that IDE when it says I should save my current workspace.
