### PR TITLE
Allow specifying REQUIRE_ROOT, LOG_DIR and WORK_DIR via environment variables

### DIFF
--- a/keylime/config.py
+++ b/keylime/config.py
@@ -3,6 +3,7 @@ SPDX-License-Identifier: Apache-2.0
 Copyright 2017 Massachusetts Institute of Technology.
 '''
 
+import os
 import os.path
 import configparser
 import sys
@@ -33,6 +34,20 @@ def convert(data):
     return data
 
 
+def environ_bool(env_name, default):
+    val = os.getenv(env_name, 'default').lower()
+    if val in ["on", "true", "1"]:
+        return True
+    if val in ["off", "false", "0"]:
+        return False
+    if val == "default":
+        return default
+    raise ValueError(
+        "Environment variable %s set to invalid value "
+        "%s (use either on/true/1 or off/false/0)" %
+        (env_name, val))
+
+
 # Current Keylime API version
 API_VERSION = '2'
 
@@ -56,7 +71,7 @@ TPM_BENCHMARK_PATH = None
 # set to False to enable keylime to run from the CWD and not require
 # root access.  for testing purposes only
 # all processes will log to the CWD in keylime-all.log
-REQUIRE_ROOT = True
+REQUIRE_ROOT = environ_bool('KEYLIME_REQUIRE_ROOT', True)
 
 # enable printing of keys and other info for debug purposes
 INSECURE_DEBUG = False

--- a/keylime/config.py
+++ b/keylime/config.py
@@ -183,9 +183,10 @@ def has_option(section, option):
 
 
 if not REQUIRE_ROOT:
-    WORK_DIR = os.path.abspath(".")
+    DEFAULT_WORK_DIR = os.path.abspath(".")
 else:
-    WORK_DIR = os.getenv('KEYLIME_DIR', '/var/lib/keylime')
+    DEFAULT_WORK_DIR = '/var/lib/keylime'
+WORK_DIR = os.getenv('KEYLIME_DIR', DEFAULT_WORK_DIR)
 
 CA_WORK_DIR = '%s/ca/' % WORK_DIR
 

--- a/keylime/keylime_logging.py
+++ b/keylime/keylime_logging.py
@@ -42,7 +42,7 @@ def log_http_response(logger, loglevel, response_body):
 LOG_TO_FILE = ['registrar', 'provider_registrar', 'cloudverifier']
 # not clear that this works right.  console logging may not work
 LOG_TO_STREAM = ['tenant_webapp']
-LOGDIR = '/var/log/keylime'
+LOGDIR = os.getenv('KEYLIME_LOGDIR', '/var/log/keylime')
 if not config.REQUIRE_ROOT:
     LOGSTREAM = './keylime-stream.log'
 else:


### PR DESCRIPTION
This allows running Keylime registrar and verifier without root and without manually changing code files.

An example executing of the verifier would be: `KEYLIME_CONFIG=`pwd`/keylime.conf KEYLIME_DIR=`pwd`/workdir/work KEYLIME_REQUIRE_ROOT=off KEYLIME_LOGDIR=`pwd`/workdir/logs/ keylime_verifier`