### PR TITLE
Fix missing tpm2 commands

### DIFF
--- a/keylime/cmd/ima_emulator_adapter.py
+++ b/keylime/cmd/ima_emulator_adapter.py
@@ -14,7 +14,6 @@ from keylime.tpm.tpm_abstract import config, hashlib
 from keylime.common import algorithms
 
 # Instaniate tpm
-global tpm_instance
 tpm_instance = tpm(need_hw_tpm=True)
 
 start_hash = ('0000000000000000000000000000000000000000')
@@ -23,6 +22,7 @@ ff_hash = ('ffffffffffffffffffffffffffffffffffffffff')
 
 def ml_extend(ml, position, searchHash=None):
     global start_hash
+    global tpm_instance
     f = open(ml, 'r')
     lines = itertools.islice(f, position, None)
 
@@ -75,6 +75,7 @@ def ml_extend(ml, position, searchHash=None):
 
 
 def main():
+    global tpm_instance
     if not tpm_instance.is_emulator():
         raise Exception("This stub should only be used with a TPM emulator")
 

--- a/keylime/cmd/ima_emulator_adapter.py
+++ b/keylime/cmd/ima_emulator_adapter.py
@@ -13,13 +13,16 @@ from keylime.tpm.tpm_main import tpm
 from keylime.tpm.tpm_abstract import config, hashlib
 from keylime.common import algorithms
 
+# Instaniate tpm
+global tpm_instance
+tpm_instance = tpm(need_hw_tpm=True)
+
 start_hash = ('0000000000000000000000000000000000000000')
 ff_hash = ('ffffffffffffffffffffffffffffffffffffffff')
 
 
 def ml_extend(ml, position, searchHash=None):
     global start_hash
-    tpm_instance = tpm()
     f = open(ml, 'r')
     lines = itertools.islice(f, position, None)
 
@@ -72,7 +75,6 @@ def ml_extend(ml, position, searchHash=None):
 
 
 def main():
-    tpm_instance = tpm()
     if not tpm_instance.is_emulator():
         raise Exception("This stub should only be used with a TPM emulator")
 

--- a/keylime/cmd/ima_emulator_adapter.py
+++ b/keylime/cmd/ima_emulator_adapter.py
@@ -14,6 +14,7 @@ from keylime.tpm.tpm_abstract import config, hashlib
 from keylime.common import algorithms
 
 # Instaniate tpm
+global tpm_instance
 tpm_instance = tpm(need_hw_tpm=True)
 
 start_hash = ('0000000000000000000000000000000000000000')
@@ -22,7 +23,6 @@ ff_hash = ('ffffffffffffffffffffffffffffffffffffffff')
 
 def ml_extend(ml, position, searchHash=None):
     global start_hash
-    global tpm_instance
     f = open(ml, 'r')
     lines = itertools.islice(f, position, None)
 
@@ -75,7 +75,6 @@ def ml_extend(ml, position, searchHash=None):
 
 
 def main():
-    global tpm_instance
     if not tpm_instance.is_emulator():
         raise Exception("This stub should only be used with a TPM emulator")
 

--- a/keylime/cmd/ima_emulator_adapter.py
+++ b/keylime/cmd/ima_emulator_adapter.py
@@ -14,7 +14,6 @@ from keylime.tpm.tpm_abstract import config, hashlib
 from keylime.common import algorithms
 
 # Instaniate tpm
-global tpm_instance
 tpm_instance = tpm(need_hw_tpm=True)
 
 start_hash = ('0000000000000000000000000000000000000000')

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -44,6 +44,7 @@ logger = keylime_logging.init_logging('cloudagent')
 uvLock = threading.Lock()
 
 # Instaniate tpm
+global tpm_instance
 tpm_instance = tpm(need_hw_tpm=True)
 
 
@@ -60,7 +61,7 @@ class Handler(BaseHTTPRequestHandler):
         Only tenant and cloudverifier uri's are supported. Both requests require a nonce parameter.
         The Cloud verifier requires an additional mask paramter.  If the uri or parameters are incorrect, a 400 response is returned.
         """
-        global tpm_instance
+
         logger.info('GET invoked from ' + str(self.client_address) + ' with uri:' + self.path)
         rest_params = config.get_restful_params(self.path)
         if rest_params is None:
@@ -178,7 +179,6 @@ class Handler(BaseHTTPRequestHandler):
         Only tenant and cloudverifier uri's are supported. Both requests require a nonce parameter.
         The Cloud verifier requires an additional mask parameter.  If the uri or parameters are incorrect, a 400 response is returned.
         """
-        global tpm_instance
         rest_params = config.get_restful_params(self.path)
 
         if rest_params is None:
@@ -355,7 +355,6 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
 
     def __init__(self, server_address, RequestHandlerClass, agent_uuid):
         """Constructor overridden to provide ability to pass configuration arguments to the server"""
-        global tpm_instance
         secdir = secure_mount.mount()
         keyname = "%s/%s" % (secdir, config.get('cloud_agent', 'rsa_keyname'))
         # read or generate the key depending on configuration
@@ -484,7 +483,8 @@ def main():
                                'but it\'s is not found on the system.')
 
     # Instanitate TPM class
-    global tpm_instance
+
+    instance_tpm = tpm()
     # get params for initialization
     registrar_ip = config.get('cloud_agent', 'registrar_ip')
     registrar_port = config.get('cloud_agent', 'registrar_port')
@@ -496,7 +496,7 @@ def main():
     config.ch_dir(config.WORK_DIR, logger)
 
     # initialize tpm
-    (ekcert, ek_tpm, aik_tpm) = tpm_instance.tpm_init(self_activate=False, config_pw=config.get(
+    (ekcert, ek_tpm, aik_tpm) = instance_tpm.tpm_init(self_activate=False, config_pw=config.get(
         'cloud_agent', 'tpm_ownerpassword'))  # this tells initialize not to self activate the AIK
     virtual_agent = instance_tpm.is_vtpm()
     # try to get some TPM randomness into the system entropy pool

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -44,7 +44,6 @@ logger = keylime_logging.init_logging('cloudagent')
 uvLock = threading.Lock()
 
 # Instaniate tpm
-global tpm_instance
 tpm_instance = tpm(need_hw_tpm=True)
 
 

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -43,6 +43,10 @@ logger = keylime_logging.init_logging('cloudagent')
 # lock required for multithreaded operation
 uvLock = threading.Lock()
 
+# Instaniate tpm
+global tpm_instance
+tpm_instance = tpm(need_hw_tpm=True)
+
 
 class Handler(BaseHTTPRequestHandler):
     parsed_path = ''
@@ -59,7 +63,6 @@ class Handler(BaseHTTPRequestHandler):
         """
 
         logger.info('GET invoked from ' + str(self.client_address) + ' with uri:' + self.path)
-        tpm_instance = tpm()
         rest_params = config.get_restful_params(self.path)
         if rest_params is None:
             config.echo_json_response(
@@ -176,7 +179,6 @@ class Handler(BaseHTTPRequestHandler):
         Only tenant and cloudverifier uri's are supported. Both requests require a nonce parameter.
         The Cloud verifier requires an additional mask parameter.  If the uri or parameters are incorrect, a 400 response is returned.
         """
-        tpm_instance = tpm()
         rest_params = config.get_restful_params(self.path)
 
         if rest_params is None:
@@ -355,7 +357,6 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
         """Constructor overridden to provide ability to pass configuration arguments to the server"""
         secdir = secure_mount.mount()
         keyname = "%s/%s" % (secdir, config.get('cloud_agent', 'rsa_keyname'))
-        tpm_instance = tpm()
         # read or generate the key depending on configuration
         if os.path.isfile(keyname):
             # read in private key

--- a/keylime/vtpm_manager.py
+++ b/keylime/vtpm_manager.py
@@ -26,7 +26,6 @@ from keylime import keylime_logging
 from keylime.tpm.tpm_main import tpm
 
 # get the tpm object
-global tpm_instance
 tpm_instance = tpm(need_hw_tpm=True)
 
 sys.path.append(os.path.dirname(__file__))

--- a/keylime/vtpm_manager.py
+++ b/keylime/vtpm_manager.py
@@ -26,6 +26,8 @@ from keylime import keylime_logging
 from keylime.tpm.tpm_main import tpm
 
 # get the tpm object
+global tpm_instance
+tpm_instance = tpm(need_hw_tpm=True)
 
 sys.path.append(os.path.dirname(__file__))
 
@@ -436,7 +438,6 @@ def do_register_test():
 def tpmconv(inmod):
     """ convert a raw modulus file into a pem file """
     tmppath = None
-    tpm_instance = tpm()
     try:
         # make a temp file for the output
         tmpfd, tmppath = tempfile.mkstemp()


### PR DESCRIPTION
During the deprecation of tpm1 in 45cb879, the handling of
`need_hw_tpm=True` was removed, which in turn resulted in
no run of `tpm2_startup` and `tpm2_getcap`

Resolves: #556

Signed-off-by: Luke Hinds <lhinds@redhat.com>