### PR TITLE
tpm_main: make activate_identity return the correct thing on error

### DIFF
--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -815,7 +815,7 @@ class tpm(tpm_abstract.AbstractTPM):
         except Exception as e:
             logger.error("Error decrypting AIK: " + str(e))
             logger.exception(e)
-            return False
+            return None
         finally:
             if keyblobFile is not None:
                 os.remove(keyblobFile.name)


### PR DESCRIPTION
Right now, the activate_identity function is returning `False`, while
keylime_agent is checking for `None` to return failure.
This means that the `False` is tried to be encoded as a result if the
credential activation procedure failed, which causes very vague errors.

The resulting error:
TypeError: key: expected bytes or bytearray, but got 'bool'

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>