### PR TITLE
CI: Ensure created EK is valid

### DIFF
--- a/.ci/test_wrapper_gha.sh
+++ b/.ci/test_wrapper_gha.sh
@@ -5,7 +5,7 @@ set -x
 mkdir /tmp/tpmdir
 swtpm_setup --tpm2 \
      --tpmstate /tmp/tpmdir \
-     --createek --allow-signing --decryption --create-ek-cert \
+     --createek --decryption --create-ek-cert \
      --create-platform-cert \
      --display
 swtpm socket --tpm2 \


### PR DESCRIPTION
The tests currently run swtpm_setup with --allow-signing, which results
in an EK that does not match the EK Certificate.
This removes that, since we do not need signing on the EK.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>