### PR TITLE
Second PR (of a total of 4) to address #491

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,7 @@ dbus \
 dbus-daemon \
 dbus-devel \
 dnf-plugins-core \
+efivar-devel \
 gcc \
 git \
 glib2-devel \

--- a/installer.sh
+++ b/installer.sh
@@ -105,7 +105,7 @@ case "$ID" in
         PACKAGE_MGR=$(command -v dnf)
         PYTHON_PREIN="python3 python3-devel python3-setuptools git wget patch"
         PYTHON_DEPS="python3-pip gcc gcc-c++ openssl-devel swig python3-pyyaml python3-m2crypto  python3-zmq python3-cryptography python3-tornado python3-simplejson python3-requests yaml-cpp-devel procps-ng"
-        BUILD_TOOLS="openssl-devel libtool make automake pkg-config m4 libgcrypt-devel autoconf autoconf-archive libcurl-devel libstdc++-devel uriparser-devel dbus-devel gnulib-devel doxygen"
+        BUILD_TOOLS="openssl-devel libtool make automake pkg-config m4 libgcrypt-devel autoconf autoconf-archive libcurl-devel libstdc++-devel uriparser-devel dbus-devel gnulib-devel doxygen efivar-devel"
         GOPKG="golang"
         if [[ ${VERSION_ID} -ge 30 ]] ; then
         # if fedora 30 or greater, then using TPM2 tool packages

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -207,7 +207,6 @@ def process_quote_response(agent, json_response):
         ima_keyring,
         mb_measurement_list,
         {})
-
     if not validQuote:
         return False
 

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -207,6 +207,7 @@ def process_quote_response(agent, json_response):
         ima_keyring,
         mb_measurement_list,
         {})
+
     if not validQuote:
         return False
 

--- a/keylime/common/algorithms.py
+++ b/keylime/common/algorithms.py
@@ -18,7 +18,8 @@ class Hash:
     SHA256 = 'sha256'
     SHA384 = 'sha384'
     SHA512 = 'sha512'
-    supported_algorithms = (SHA1, SHA256, SHA384, SHA512)
+    SM3_256 = 'sm3_256'
+    supported_algorithms = (SHA1, SHA256, SHA384, SHA512, SM3_256)
 
     @staticmethod
     def is_recognized(algorithm):

--- a/keylime/config.py
+++ b/keylime/config.py
@@ -258,9 +258,10 @@ def list_to_dict(alist):
     return params
 
 
-def yaml_to_dict(arry):
+def yaml_to_dict(arry, add_newlines=True):
     arry = convert(arry)
-    return yaml.load("\n".join(arry), Loader=SafeLoader)
+    sep = "\n" if add_newlines else ""
+    return yaml.load(sep.join(arry), Loader=SafeLoader)
 
 
 def get_restful_params(urlstring):
@@ -312,7 +313,7 @@ else:
 IMA_PCR = 10
 
 # measured boot addons
-MEASUREDBOOT_PCRS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 14]
+MEASUREDBOOT_PCRS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15]
 MEASUREDBOOT_ML = '/sys/kernel/security/tpm0/binary_bios_measurements'
 
 # this is where data will be bound to a quote, MUST BE RESETABLE!

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -347,3 +347,7 @@ class AbstractTPM(metaclass=ABCMeta):
     @abstractmethod
     def read_key_nvram(self):
         pass
+
+    @abstractmethod
+    def parse_bootlog(self, log_b64:str) -> dict:
+        raise NotImplementedError

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -21,7 +21,6 @@ import simplejson as json
 
 from keylime import cmd_exec
 from keylime import config
-from keylime import tpm_bootlog_enrich
 from keylime import keylime_logging
 from keylime import secure_mount
 from keylime import tpm_bootlog_enrich

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -21,6 +21,7 @@ import simplejson as json
 
 from keylime import cmd_exec
 from keylime import config
+from keylime import tpm_bootlog_enrich
 from keylime import keylime_logging
 from keylime import secure_mount
 from keylime.tpm import tpm_abstract
@@ -976,7 +977,7 @@ class tpm(tpm_abstract.AbstractTPM):
         retDict = self.__run(command, lock=False)
         return retDict
 
-    def check_quote(self, agent_id, nonce, data, quote, aikTpmFromRegistrar, tpm_policy={}, ima_measurement_list=None, allowlist={}, hash_alg=None, ima_keyring=None, mb_measurement_list=None, mb_intended_state={}):
+    def check_quote(self, agent_id, nonce, data, quote, aikTpmFromRegistrar, tpm_policy={}, ima_measurement_list=None, allowlist={}, hash_alg=None, ima_keyring=None, mb_measurement_list=None, mb_refstate={}):
         if hash_alg is None:
             hash_alg = self.defaults['hash']
 
@@ -991,9 +992,6 @@ class tpm(tpm_abstract.AbstractTPM):
                 crypto_serialization.Encoding.PEM,
                 crypto_serialization.PublicFormat.SubjectPublicKeyInfo,
             )
-
-        if mb_measurement_list or mb_intended_state:
-            logger.info("Measured boot information received, but for now it will not be processed")
 
         if quote[0] != 'r':
             raise Exception("Invalid quote type %s" % quote[0])
@@ -1076,7 +1074,7 @@ class tpm(tpm_abstract.AbstractTPM):
         if len(pcrs) == 0:
             pcrs = None
 
-        return self.check_pcrs(agent_id, tpm_policy, pcrs, data, False, ima_measurement_list, allowlist, ima_keyring, mb_measurement_list, mb_intended_state)
+        return self.check_pcrs(agent_id, tpm_policy, pcrs, data, False, ima_measurement_list, allowlist, ima_keyring, mb_measurement_list, mb_refstate)
 
     def sim_extend(self, hashval_1, hashval_0=None):
         # simulate extending a PCR value by performing TPM-specific extend procedure

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -1218,7 +1218,7 @@ class tpm(tpm_abstract.AbstractTPM):
             return None
         return output
 
-    def stringify_pcrs(self, log: dict) -> None:
+    def __stringify_pcr_keys(self, log: dict) -> None:
         '''Ensure that the PCR indices are strings
 
         The YAML produced by `tpm2_eventlog`, when loaded by the yaml module,
@@ -1253,7 +1253,7 @@ class tpm(tpm_abstract.AbstractTPM):
         log_parsed_strs = retDict['retout']
         log_parsed_data = config.yaml_to_dict(log_parsed_strs, add_newlines=False)
         tpm_bootlog_enrich.enrich(log_parsed_data)
-        self.stringify_pcrs(log_parsed_data)
+        self.__stringify_pcr_keys(log_parsed_data)
         return log_parsed_data
 
     def parse_bootlog(self, log_b64:str) -> dict:

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -21,6 +21,7 @@ import simplejson as json
 
 from keylime import cmd_exec
 from keylime import config
+from keylime import tpm_bootlog_enrich
 from keylime import keylime_logging
 from keylime import secure_mount
 from keylime import tpm_bootlog_enrich

--- a/keylime/tpm_bootlog_enrich.py
+++ b/keylime/tpm_bootlog_enrich.py
@@ -1,0 +1,286 @@
+#!/usr/bin/python3
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2017 Massachusetts Institute of Technology.
+'''
+
+# important notice: this file was temporarly added to keylime in order to cover the gap
+# left by some additiomal features still not available on Intel's tpm2-tools. There is
+# an ongoing effort to add the aforementioned features to their toolkit and when this
+# process is complete this file will become redundant and ready for removal.
+
+import argparse
+import json
+import sys
+import re
+import traceback
+from ctypes import CDLL, create_string_buffer, byref, c_char_p
+
+import yaml
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader
+
+##################################################################################
+#
+# yaml by default outputs numbers in decimal format, and this allows us to
+# represent some numbers in hexadecimal
+#
+##################################################################################
+
+
+class hexint(int):
+    pass
+
+
+def representer(_, data):
+    return yaml.ScalarNode('tag:yaml.org,2002:int', hex(data))
+
+yaml.add_representer(hexint, representer)
+
+##################################################################################
+#
+# These function use efivar C libraries to decode device path and guid
+#
+##################################################################################
+
+efivarlib = "libefivar.so"  # formerly "/usr/lib/x86_64-linux-gnu/libefivar.so"
+
+efivarlib_functions = CDLL(efivarlib)
+
+
+def getDevicePath(b):
+    ret = efivarlib_functions.efidp_format_device_path(0, 0, b, len(b))
+    if ret < 0:
+        raise Exception(
+            f'getDevicePath: efidp_format_device_path({b}) returned {ret}')
+
+    s = create_string_buffer((ret+1))
+
+    ret = efivarlib_functions.efidp_format_device_path(s, ret+1, b, len(b))
+    if ret < 0:
+        raise Exception(
+            f'getDevicePath: efidp_format_device_path({b}) returned {ret}')
+
+    return s.value.decode("utf-8")
+
+
+def getGUID(b):
+    s = c_char_p(None)
+    ret = efivarlib_functions.efi_guid_to_str(b, byref(s))
+    if ret < 0:
+        raise Exception(f'getGUID: efi_guid_to_str({b}) returned {ret}')
+    return s.value.decode("utf-8")
+
+##################################################################################
+#
+# https://uefi.org/sites/default/files/resources/UEFI%20Spec%202.8B%20May%202020.pdf
+# Section 32.4.1
+#
+# Relevant data structures
+#
+#  typedef struct _EFI_SIGNATURE_LIST {
+#       uint8_t SignatureType[16];
+#       uint32_t SignatureListSize;
+#       uint32_t SignatureHeaderSize;
+#       uint32_t SignatureSize;
+#       // uint8_t SignatureHeader[SignatureHeaderSize];
+#       // uint8_t Signatures[][SignatureSize];
+#  } EFI_SIGNATURE_LIST;
+#
+#  typedef struct _EFI_SIGNATURE_DATA {
+#      uint8_t SignatureOwner[16];
+#      uint8_t SignatureData[];
+#  } EFI_SIGNATURE_DATA;
+#
+##################################################################################
+
+##################################################################################
+# Parse EFI_SIGNATURE_DATA
+##################################################################################
+
+
+def getKey(b, start, size):
+    key = {}
+    signatureOwner = getGUID(b[start:start+16])
+    key['SignatureOwner'] = signatureOwner
+
+    signatureData = b[start+16:start+size]
+    key['SignatureData'] = signatureData.hex()
+    return key
+
+
+##################################################################################
+#
+# https://uefi.org/sites/default/files/resources/UEFI%20Spec%202.8B%20May%202020.pdf
+# Section 3.1.3
+#
+# Relevant data structures
+#
+#   typedef struct _EFI_LOAD_OPTION {
+#       UINT32 Attributes;
+#       UINT16 FilePathListLength;
+#       // CHAR16 Description[];
+#       // EFI_DEVICE_PATH_PROTOCOL FilePathList[];
+#       // UINT8 OptionalData[];} EFI_LOAD_OPTION;
+#   } EFI_LOAD_OPTION;
+#
+##################################################################################
+
+##################################################################################
+# Parse additional information about variables BootOrder and Boot####
+##################################################################################
+
+
+def getVar(event, b):
+    if 'UnicodeName' in event:
+        if 'VariableDataLength' in event:
+            varlen = event['VariableDataLength']
+
+            # BootOrder variable
+            if event['UnicodeName'] == 'BootOrder':
+                if varlen % 2 != 0:
+                    raise Exception(
+                        f'getVar: VariableDataLength({varlen}) is not divisible by 2')
+
+                l = int(varlen / 2)
+                r = []
+                for x in range(l):
+                    d = int.from_bytes(b[x*2:x*2+2], byteorder='little')
+                    r.append("Boot%04x" % d)
+                return r
+            # Boot#### variable
+            if re.match('Boot[0-9a-fA-F]{4}', event['UnicodeName']):
+                r = {}
+                i = 0
+                size = 4
+                attributes = b[i:i+size]
+                d = int.from_bytes(attributes, "little") & 1
+                if d == 0:
+                    r['Enabled'] = 'No'
+                else:
+                    r['Enabled'] = 'Yes'
+
+                i += size
+                size = 2
+                filePathListLength = b[i:i+size]
+                d = int.from_bytes(filePathListLength, "little")
+                r['FilePathListLength'] = d
+
+                i += size
+                size = 2
+                description = ''
+                while i < varlen:
+                    w = b[i:i+size]
+                    i += size
+                    if w == b'\x00\x00':
+                        break
+
+                    c = w.decode("utf-16", errors="ignore")
+                    description += c
+                r['Description'] = description
+                devicePath = getDevicePath(b[i:])
+                r['DevicePath'] = devicePath
+                return r
+    return None
+
+
+def enrich_device_path(d: dict) -> None:
+    if 'DevicePath' in d:
+        b = bytes.fromhex(d['DevicePath'])
+        try:
+            p = getDevicePath(b)
+        # Deal with garbage devicePath
+        except Exception:
+            p = f"{d['DevicePath']}"
+        d['DevicePath'] = p
+
+
+def enrich_driver_config(d: dict) -> None:
+    if 'UnicodeName' in d:
+        if d['UnicodeName'] == 'SecureBoot':
+            if 'VariableData' in d:
+                b = bytes.fromhex(d['VariableData'])
+                if len(b) == 0:
+                    d['VariableData'] = {'Enabled': 'No'}
+                elif len(b) > 1:
+                    raise Exception(
+                        f'enrich: SecureBoot data length({len(b)}) > 1')
+                else:
+                    if b == b'\x00':
+                        d['VariableData'] = {
+                            'Enabled': 'No'}
+                    else:
+                        d['VariableData'] = {
+                            'Enabled': 'Yes'}
+
+
+def enrich_variable_authority(d: dict) -> None:
+    if 'VariableData' in d:
+        b = bytes.fromhex(d['VariableData'])
+        l = len(b)
+        k = getKey(b, 0, l)
+        d['VariableData'] = k
+
+
+def enrich_boot_variable(d: dict) -> None:
+    if 'VariableData' in d:
+        b = {}
+        b = bytes.fromhex(d['VariableData'])
+        k = getVar(d, b)
+        if k is not None:
+            d['VariableData'] = k
+
+
+def enrich(log: dict) -> None:
+    '''Make the given BIOS boot log easier to understand and process'''
+    if 'events' in log:
+        events = log['events']
+
+        for event in events:
+            if 'EventType' in event:
+                t = event['EventType']
+                if t in ('EV_EFI_BOOT_SERVICES_APPLICATION',
+                         'EV_EFI_BOOT_SERVICES_DRIVER',
+                         'EV_EFI_RUNTIME_SERVICES_DRIVER'):
+                    if 'Event' in event:
+                        d = event['Event']
+                        enrich_device_path(d)
+                elif t == 'EV_EFI_VARIABLE_DRIVER_CONFIG':
+                    if 'Event' in event:
+                        d = event['Event']
+                        enrich_driver_config(d)
+                elif t == 'EV_EFI_VARIABLE_AUTHORITY':
+                    if 'Event' in event:
+                        d = event['Event']
+                        enrich_variable_authority(d)
+                elif t == 'EV_EFI_VARIABLE_BOOT':
+                    if 'Event' in event:
+                        d = event['Event']
+                        enrich_boot_variable(d)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('infile', nargs='?',
+                        type=argparse.FileType('r'), default=sys.stdin)
+    parser.add_argument(
+        '-o', '--output', choices=('yaml', 'json'), default='yaml')
+    args = parser.parse_args()
+    log = yaml.load(args.infile, Loader=SafeLoader)
+    try:
+        enrich(log)
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(1)
+    if args.output == 'yaml':
+        print(yaml.dump(log, default_flow_style=False, line_break=None))
+    elif args.output == 'json':
+        print(json.dumps(log, sort_keys=True, indent=4))
+    else:
+        raise Exception(f'unexpected output format {args.output!a}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
* The most important change here is the fact that the TPM 2.0 preboot
event log , shipped to the verifier from the agent, will now be
authenticated, by replaying the aforementioned log and comparing it
against the values of PCRs [0-9],14.
* If these do not match, then the node will be considered as failed at
attestation.
* A small utility (tpm_bootlog_enrich.py) is added to perform the log replay.
In the future, it could be replaced by newer versions of tpm2-tools capable
of performing the same activity (several open PRs against the tool with
fixes and improvements)

Signed-off-by: Marcio Silva <marcios@us.ibm.com>