### PR TITLE
Adds sm3_256 to the known hash algorithms

### DIFF
--- a/keylime/common/algorithms.py
+++ b/keylime/common/algorithms.py
@@ -18,7 +18,8 @@ class Hash:
     SHA256 = 'sha256'
     SHA384 = 'sha384'
     SHA512 = 'sha512'
-    supported_algorithms = (SHA1, SHA256, SHA384, SHA512)
+    SM3_256 = 'sm3_256'
+    supported_algorithms = (SHA1, SHA256, SHA384, SHA512, SM3_256)
 
     @staticmethod
     def is_recognized(algorithm):


### PR DESCRIPTION
This algorithm is seen in Nationz chips, and is in the TCG standard.
Adds sm3_256 to known algorithms, otherwise keylime refuses to run
when the tpm_hash_alg is set to sm3_256.