### PR TITLE
Replace simplejson imports

### DIFF
--- a/auto-ipsec/libreswan/src/local_action_crashsa.py
+++ b/auto-ipsec/libreswan/src/local_action_crashsa.py
@@ -13,7 +13,7 @@ import keylime.config as common
 import keylime.keylime_logging as keylime_logging
 import keylime.cmd_exec as cmd_exec
 
-import simplejson as json
+import json
 
 # read the config file
 config = common.get_config()

--- a/auto-ipsec/racoon/src/local_action_deletesa.py
+++ b/auto-ipsec/racoon/src/local_action_deletesa.py
@@ -15,7 +15,7 @@ import keylime.config as common
 import keylime.keylime_logging as keylime_logging
 import keylime.cmd_exec as cmd_exec
 
-import simplejson as json
+import json
 
 # read the config file
 config = common.get_config()

--- a/demo/agent_monitor/tenant_agent_monitor.py
+++ b/demo/agent_monitor/tenant_agent_monitor.py
@@ -28,7 +28,7 @@ sys.path.insert(0, '../../keylime/')
 
 logger = keylime_logging.init_logging('agent_monitor')
 
-import simplejson as json
+import json
 
 initscript = None
 

--- a/keylime/ca_impl_cfssl.py
+++ b/keylime/ca_impl_cfssl.py
@@ -4,6 +4,7 @@ Copyright 2017 Massachusetts Institute of Technology.
 '''
 
 import base64
+import json
 import os
 import subprocess
 import socket
@@ -12,7 +13,6 @@ import shutil
 import sys
 
 import requests
-import simplejson as json
 from M2Crypto import EVP, X509
 
 from keylime import config

--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -19,6 +19,7 @@ protips
 # openssl x509 -in cacert.crt -noout -text
 '''
 
+import json
 import sys
 import os
 import base64
@@ -39,7 +40,6 @@ try:
 except ImportError:
     from yaml import SafeLoader, SafeDumper
 
-import simplejson as json
 from M2Crypto import X509, EVP, BIO
 
 from keylime import cmd_exec

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -10,7 +10,7 @@ import ssl
 import socket
 import time
 
-import simplejson as json
+import json
 
 from keylime import config
 from keylime import keylime_logging

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -9,7 +9,7 @@ import sys
 import functools
 import asyncio
 
-import simplejson as json
+import json
 from sqlalchemy.exc import SQLAlchemyError
 import tornado.ioloop
 import tornado.web

--- a/keylime/config.py
+++ b/keylime/config.py
@@ -3,6 +3,7 @@ SPDX-License-Identifier: Apache-2.0
 Copyright 2017 Massachusetts Institute of Technology.
 '''
 
+import json
 import os
 import os.path
 import configparser
@@ -18,8 +19,6 @@ try:
     from yaml import CSafeLoader as SafeLoader
 except ImportError:
     from yaml import SafeLoader
-
-import simplejson as json
 
 
 def convert(data):

--- a/keylime/db/registrar_db.py
+++ b/keylime/db/registrar_db.py
@@ -3,7 +3,7 @@ SPDX-License-Identifier: Apache-2.0
 Copyright 2020 Luke Hinds (lhinds@redhat.com), Red Hat, Inc.
 '''
 
-import simplejson as json
+import json
 
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, String, Integer, PickleType, Text

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -3,7 +3,7 @@ SPDX-License-Identifier: Apache-2.0
 Copyright 2020 Luke Hinds (lhinds@redhat.com), Red Hat, Inc.
 '''
 
-import simplejson as json
+import json
 
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, String, Integer, PickleType, Text

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -24,7 +24,7 @@ import importlib
 import shutil
 import subprocess
 
-import simplejson as json
+import json
 
 from keylime import config
 from keylime import keylime_logging

--- a/keylime/registrar_client.py
+++ b/keylime/registrar_client.py
@@ -7,7 +7,7 @@ import os
 import logging
 import sys
 
-import simplejson as json
+import json
 
 from keylime import config
 from keylime import crypto

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -4,6 +4,7 @@ Copyright 2017 Massachusetts Institute of Technology.
 '''
 
 import base64
+import json
 import threading
 import sys
 import signal
@@ -16,7 +17,6 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import load_der_x509_certificate
-import simplejson as json
 
 from keylime.db.registrar_db import RegistrarMain
 from keylime.db.keylime_db import DBEngineManager, SessionManager

--- a/keylime/revocation_actions/print_metadata.py
+++ b/keylime/revocation_actions/print_metadata.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 Copyright 2017 Massachusetts Institute of Technology.
 '''
 
-import simplejson as json
+import json
 
 import keylime.keylime_logging as keylime_logging
 

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -11,7 +11,7 @@ import os
 import sys
 import signal
 
-import simplejson as json
+import json
 import zmq
 
 from keylime import config

--- a/keylime/serve_uuid.py
+++ b/keylime/serve_uuid.py
@@ -8,7 +8,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 import sys
 import uuid
 
-import simplejson as json
+import json
 
 
 TESTING_MODE = False

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -8,6 +8,7 @@ Copyright 2017 Massachusetts Institute of Technology.
 import argparse
 import base64
 import hashlib
+import json
 import io
 import logging
 import os
@@ -17,7 +18,6 @@ import time
 import zipfile
 
 from cryptography.hazmat.primitives import serialization as crypto_serialization
-import simplejson as json
 
 from keylime.requests_client import RequestsClient
 from keylime.common import states

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -12,7 +12,7 @@ import ssl
 import traceback
 import sys
 
-import simplejson as json
+import json
 import tornado.ioloop
 import tornado.web
 

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -11,7 +11,7 @@ import os
 import string
 import struct
 
-import simplejson as json
+import json
 import yaml
 try:
     from yaml import CSafeLoader as SafeLoader, CSafeDumper as SafeDumper

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -5,6 +5,7 @@ Copyright 2017 Massachusetts Institute of Technology.
 
 import base64
 import binascii
+import json
 import os
 import re
 import sys
@@ -17,7 +18,6 @@ from distutils.version import StrictVersion
 
 import M2Crypto
 from cryptography.hazmat.primitives import serialization as crypto_serialization
-import simplejson as json
 
 from keylime import cmd_exec
 from keylime import config

--- a/keylime/vtpm_manager.py
+++ b/keylime/vtpm_manager.py
@@ -14,7 +14,7 @@ import time
 import tempfile
 from uuid import UUID
 
-import simplejson as json
+import json
 
 try:
     from yaml import CSafeDumper as SafeDumper

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -28,6 +28,7 @@ For Python Coverage support (pip install coverage), set env COVERAGE_FILE and:
     * coverage run --parallel-mode test_restful.py
 '''
 
+import json
 import sys
 import signal
 import unittest
@@ -41,7 +42,6 @@ import errno
 from pathlib import Path
 
 import dbus
-import simplejson as json
 
 from keylime import config
 from keylime import tornado_requests


### PR DESCRIPTION
During Python2.6 development, the "simplejson" module got pulled into the standard
library as "json".
https://docs.python.org/3/whatsnew/2.6.html#the-json-module-javascript-object-notation

This means that as of Python 2.6, "json" is always available, and is identical
to what previously was called simplejson.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>