### PR TITLE
Use the quay.io version of fedora for CI tests

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@
 # It is not recommended for use beyond testing scenarios.
 ##############################################################################
 
-FROM fedora:latest
+FROM quay.io/fedora/fedora
 MAINTAINER Luke Hinds <lhinds@redhat.com>
 LABEL version="1.0.1" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
 


### PR DESCRIPTION
We hit an error when quay was building a new version of our image:

    Could not pull base image: API error (500): toomanyrequests:
    You have reached your pull rate limit. You may increase the
    limit by authenticating and upgrading:
    https://www.docker.com/increase-rate-limit

So docker hub was throttling quay and killing our build. So switching to
the quay.io version of the same image will keep everything inside of quay
and avoid throttling.