### PR TITLE
Third PR (of a total of 4) to address #491

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -206,7 +206,7 @@ def process_quote_response(agent, json_response):
         hash_alg,
         ima_keyring,
         mb_measurement_list,
-        {})
+        agent['mb_refstate'])
     if not validQuote:
         return False
 
@@ -270,6 +270,17 @@ def process_get_status(agent):
         al_len = len(allowlist['allowlist'])
     else:
         al_len = 0
+
+    try :
+        mb_refstate = ast.literal_eval(agent.mb_refstate)
+    except Exception as e:
+        logger.warning(f'Non-fatal problem ocurred while attempting to evaluate agent attribute "mb_refstate" ({e.args}). Will just consider the value of this attribute to be "None"')
+        mb_refstate = None
+
+    if isinstance(mb_refstate, dict) and 'mb_refstate' in mb_refstate:
+        mb_refstate_len = len(mb_refstate['mb_refstate'])
+    else:
+        mb_refstate_len = 0
     response = {'operational_state': agent.operational_state,
                 'v': agent.v,
                 'ip': agent.ip,
@@ -278,6 +289,7 @@ def process_get_status(agent):
                 'vtpm_policy': agent.vtpm_policy,
                 'meta_data': agent.meta_data,
                 'allowlist_len': al_len,
+                'mb_refstate_len': mb_refstate_len,
                 'accept_tpm_hash_algs': agent.accept_tpm_hash_algs,
                 'accept_tpm_encryption_algs': agent.accept_tpm_encryption_algs,
                 'accept_tpm_signing_algs': agent.accept_tpm_signing_algs,

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -276,6 +276,7 @@ def process_get_status(agent):
     except Exception as e:
         logger.warning(f'Non-fatal problem ocurred while attempting to evaluate agent attribute "mb_refstate" ({e.args}). Will just consider the value of this attribute to be "None"')
         mb_refstate = None
+        logger.debug(f'The contents of the agent attribute "mb_refstate" are {str(agent.mb_refstate)}')
 
     if isinstance(mb_refstate, dict) and 'mb_refstate' in mb_refstate:
         mb_refstate_len = len(mb_refstate['mb_refstate'])

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -52,14 +52,25 @@ exclude_db = {
 
 
 def _from_db_obj(agent_db_obj):
-    fields = ['agent_id', 'v', 'ip', 'port',
-              'operational_state', 'public_key',
-              'tpm_policy', 'vtpm_policy', 'meta_data',
-              'allowlist', 'ima_sign_verification_keys', 'revocation_key',
-              'accept_tpm_hash_algs',
-              'accept_tpm_encryption_algs',
-              'accept_tpm_signing_algs',
-              'hash_alg', 'enc_alg', 'sign_alg']
+    fields = [ 'agent_id', \
+                'v', \
+                'ip', \
+                'port', \
+                'operational_state', \
+                'public_key', \
+                'tpm_policy', \
+                'vtpm_policy', \
+                'meta_data', \
+                'mb_refstate', \
+                'allowlist', \
+                'ima_sign_verification_keys', \
+                'revocation_key', \
+                'accept_tpm_hash_algs', \
+                'accept_tpm_encryption_algs', \
+                'accept_tpm_signing_algs', \
+                'hash_alg', \
+                'enc_alg', \
+                'sign_alg']
     agent_dict = {}
     for field in fields:
         agent_dict[field] = getattr(agent_db_obj, field, None)
@@ -272,6 +283,7 @@ class AgentsHandler(BaseHandler):
                     agent_data['vtpm_policy'] = json_body['vtpm_policy']
                     agent_data['meta_data'] = json_body['metadata']
                     agent_data['allowlist'] = json_body['allowlist']
+                    agent_data['mb_refstate'] = json_body['mb_refstate']
                     agent_data['ima_sign_verification_keys'] = json_body['ima_sign_verification_keys']
                     agent_data['revocation_key'] = json_body['revocation_key']
                     agent_data['accept_tpm_hash_algs'] = json_body['accept_tpm_hash_algs']

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -30,6 +30,7 @@ class VerfierMain(Base):
     meta_data = Column(String(200))
     allowlist = Column(Text(429400000))
     ima_sign_verification_keys = Column(Text(429400000))
+    mb_refstate = Column(Text(429400000))
     revocation_key = Column(String(2800))
     accept_tpm_hash_algs = Column(JSONPickleType(pickler=json))
     accept_tpm_encryption_algs = Column(JSONPickleType(pickler=json))

--- a/keylime/measured_boot.py
+++ b/keylime/measured_boot.py
@@ -1,0 +1,46 @@
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2021 IBM Corp.
+'''
+
+import json
+import sys
+import argparse
+import traceback
+
+from keylime import config
+from keylime import keylime_logging
+
+logger = keylime_logging.init_logging('measured_boot')
+
+def read_mb_refstate(mb_path=None):
+    if mb_path is None:
+        mb_path = config.get('tenant', 'mb_refstate')
+
+    mb_data = None
+    # Purposefully die if path doesn't exist
+    with open(mb_path, 'r') as f:
+        mb_data = json.load(f)
+
+    logger.debug(f"Loaded measured boot reference state from {mb_path}")
+
+    return mb_data
+
+def process_refstate(mb_refstate_data=None) :
+    if isinstance(mb_refstate_data, dict) :
+        return mb_refstate_data
+    return mb_refstate_data
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('infile', default="mbtest.txt")
+    args = parser.parse_args()
+    try:
+        read_mb_refstate(args.infile)
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/keylime/migrations/versions/ae898986c6e9_add_mb_refstate_column.py
+++ b/keylime/migrations/versions/ae898986c6e9_add_mb_refstate_column.py
@@ -1,0 +1,43 @@
+"""add_mb_refstate_column
+
+Revision ID: ae898986c6e9
+Revises: cc2630851a1f
+Create Date: 2021-03-03 11:49:00.860132
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ae898986c6e9'
+down_revision = 'cc2630851a1f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+    op.add_column('verifiermain', sa.Column('mb_refstate', sa.String))
+
+
+def downgrade_cloud_verifier():
+    op.drop_column('verifiermain', 'mb_refstate')

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -222,6 +222,9 @@ class AbstractTPM(metaclass=ABCMeta):
             tpm_policy_ = {}
         pcr_allowlist = tpm_policy_.copy()
 
+        if str(mb_refstate) == "null" :
+            mb_refstate = None
+
         if 'mask' in pcr_allowlist:
             del pcr_allowlist['mask']
         # convert all pcr num keys to integers
@@ -318,7 +321,7 @@ class AbstractTPM(metaclass=ABCMeta):
             logger.error("%sPCRs specified in policy not in quote: %s" % (("", "v")[virtual], missing))
             return False
 
-        if mb_refstate and mb_measurement_list :
+        if mb_refstate :
             missing = list(set(config.MEASUREDBOOT_PCRS).difference(pcrsInQuote))
             if len(missing) > 0:
                 logger.error("%sPCRs specified for measured boot not in quote: %s", ("", "v")[virtual], missing)

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -321,6 +321,7 @@ class TestRestful(unittest.TestCase):
     metadata = {}
     allowlist = {}
     revocation_key = ""
+    mb_refstate = None
     K = None
     U = None
     V = None
@@ -637,6 +638,7 @@ class TestRestful(unittest.TestCase):
             'vtpm_policy': json.dumps(self.vtpm_policy),
             'allowlist': json.dumps(self.allowlist),
             'ima_sign_verification_keys': '',
+            'mb_refstate': None,
             'metadata': json.dumps(self.metadata),
             'revocation_key': self.revocation_key,
             'accept_tpm_hash_algs': config.get('tenant', 'accept_tpm_hash_algs').split(','),


### PR DESCRIPTION
* The "measured boot reference state" (mb_refstate), provided via
  `tenant` CLI with the option `--mb_refstate` is now parsed (JSON) and
stored on the `verifier` database in a new column (as text)
* The supplied mb_refstate is not yet fully used (but the log is
  replayed against and the values of PCRs [0-9][11-15] are checked)

Signed-off-by: Marcio Silva <marcios@us.ibm.com>