### PR TITLE
More specific base docker image tag

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@
 # It is not recommended for use beyond testing scenarios.
 ##############################################################################
 
-FROM quay.io/fedora/fedora
+FROM quay.io/fedora/fedora:33-x86_64
 MAINTAINER Luke Hinds <lhinds@redhat.com>
 LABEL version="1.0.1" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
 


### PR DESCRIPTION
The fedora images in quay dont use generic tags like "latest" or even
"33", so neither should we