### PR TITLE
Fixes #582

### DIFF
--- a/keylime/config.py
+++ b/keylime/config.py
@@ -316,6 +316,8 @@ IMA_PCR = 10
 MEASUREDBOOT_PCRS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15]
 MEASUREDBOOT_ML = '/sys/kernel/security/tpm0/binary_bios_measurements'
 
+LIBEFIVAR="libefivar.so" # formerly "/usr/lib/x86_64-linux-gnu/libefivar.so"
+
 # this is where data will be bound to a quote, MUST BE RESETABLE!
 TPM_DATA_PCR = 16
 

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -232,6 +232,9 @@ class AbstractTPM(metaclass=ABCMeta):
 
         if mb_refstate and mb_measurement_list :
             mb_measurement_data = self.parse_bootlog(mb_measurement_list)
+            if not mb_measurement_data :
+                logger.error("Unable to parse measured boot event log. Check previous messages for a reason for error.")
+                return False
             log_pcrs = mb_measurement_data.get('pcrs')
             if not isinstance(log_pcrs, dict):
                 logger.error("Parse of measured boot event log has unexpected value for .pcrs: %r", log_pcrs)

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -28,9 +28,6 @@ from keylime import tpm_ek_ca
 from keylime.common import algorithms
 from keylime.tpm import tpm2_objects
 
-if os.uname()[4] == 'x86_64' :
-    from keylime import tpm_bootlog_enrich
-
 logger = keylime_logging.init_logging('tpm')
 
 

--- a/keylime/tpm_bootlog_enrich.py
+++ b/keylime/tpm_bootlog_enrich.py
@@ -22,6 +22,7 @@ try:
 except ImportError:
     from yaml import SafeLoader
 
+from keylime import config
 ##################################################################################
 #
 # yaml by default outputs numbers in decimal format, and this allows us to
@@ -37,6 +38,7 @@ class hexint(int):
 def representer(_, data):
     return yaml.ScalarNode('tag:yaml.org,2002:int', hex(data))
 
+
 yaml.add_representer(hexint, representer)
 
 ##################################################################################
@@ -45,10 +47,7 @@ yaml.add_representer(hexint, representer)
 #
 ##################################################################################
 
-efivarlib = "libefivar.so"  # formerly "/usr/lib/x86_64-linux-gnu/libefivar.so"
-
-efivarlib_functions = CDLL(efivarlib)
-
+efivarlib_functions = CDLL(config.LIBEFIVAR)
 
 def getDevicePath(b):
     ret = efivarlib_functions.efidp_format_device_path(0, 0, b, len(b))


### PR DESCRIPTION
Do not import tpm_bootlog_enrich (which depends on libefivar.so),
on non-x86_64 architectures