### PR TITLE
Consistent formatting for logging strings

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -58,17 +58,14 @@ def init_mtls(section='cloud_verifier', generatedir='cv_ca'):
         tls_dir = generatedir
         ca_path = "%s/cacert.crt" % (tls_dir)
         if os.path.exists(ca_path):
-            logger.info(
-                "Existing CA certificate found in %s, not generating a new one" % (tls_dir))
+            logger.info("Existing CA certificate found in %s, not generating a new one", tls_dir)
         else:
-            logger.info(
-                "Generating a new CA in %s and a client certificate for connecting" % tls_dir)
-            logger.info("use keylime_ca -d %s to manage this CA" % tls_dir)
+            logger.info("Generating a new CA in %s and a client certificate for connecting", tls_dir)
+            logger.info("use keylime_ca -d %s to manage this CA", tls_dir)
             if not os.path.exists(tls_dir):
                 os.makedirs(tls_dir, 0o700)
             if my_key_pw == 'default':
-                logger.warning(
-                    "CAUTION: using default password for CA, please set private_key_pw to a strong password")
+                logger.warning("CAUTION: using default password for CA, please set private_key_pw to a strong password")
             ca_util.setpassword(my_key_pw)
             ca_util.cmd_init(tls_dir)
             ca_util.cmd_mkcert(tls_dir, socket.gethostname())
@@ -141,21 +138,18 @@ def process_quote_response(agent, json_response):
         ima_measurement_list = json_response.get("ima_measurement_list", None)
         mb_measurement_list = json_response.get("mb_measurement_list", None)
 
-        logger.debug("received quote:      %s" % quote)
-        logger.debug("for nonce:           %s" % agent['nonce'])
-        logger.debug("received public key: %s" % received_public_key)
-        logger.debug("received ima_measurement_list    %s" %
-                     (ima_measurement_list is not None))
-        logger.debug("received boot log    %s" %
-                     (mb_measurement_list is not None))
+        logger.debug("received quote:      %s", quote)
+        logger.debug("for nonce:           %s", agent['nonce'])
+        logger.debug("received public key: %s", received_public_key)
+        logger.debug("received ima_measurement_list    %s", (ima_measurement_list is not None))
+        logger.debug("received boot log    %s", (mb_measurement_list is not None))
     except Exception:
         return None
 
     # if no public key provided, then ensure we have cached it
     if received_public_key is None:
         if agent.get('public_key', "") == "" or agent.get('b64_encrypted_V', "") == "":
-            logger.error(
-                "agent did not provide public key and no key or encrypted_v was cached at CV")
+            logger.error("agent did not provide public key and no key or encrypted_v was cached at CV")
             return False
         agent['provide_V'] = False
         received_public_key = agent['public_key']
@@ -227,7 +221,7 @@ def process_quote_response(agent, json_response):
 def prepare_v(agent):
     # be very careful printing K, U, or V as they leak in logs stored on unprotected disks
     if config.INSECURE_DEBUG:
-        logger.debug("b64_V (non encrypted): " + agent['v'])
+        logger.debug("b64_V (non encrypted): %s", agent['v'])
 
     if agent.get('b64_encrypted_V', "") != "":
         b64_encrypted_V = agent['b64_encrypted_V']
@@ -274,9 +268,9 @@ def process_get_status(agent):
     try :
         mb_refstate = ast.literal_eval(agent.mb_refstate)
     except Exception as e:
-        logger.warning(f'Non-fatal problem ocurred while attempting to evaluate agent attribute "mb_refstate" ({e.args}). Will just consider the value of this attribute to be "None"')
+        logger.warning('Non-fatal problem ocurred while attempting to evaluate agent attribute "mb_refstate" (%s). Will just consider the value of this attribute to be "None"', e.args)
         mb_refstate = None
-        logger.debug(f'The contents of the agent attribute "mb_refstate" are {str(agent.mb_refstate)}')
+        logger.debug('The contents of the agent attribute "mb_refstate" are %s', agent.mb_refstate)
 
     if isinstance(mb_refstate, dict) and 'mb_refstate' in mb_refstate:
         mb_refstate_len = len(mb_refstate['mb_refstate'])

--- a/keylime/db/keylime_db.py
+++ b/keylime/db/keylime_db.py
@@ -79,5 +79,5 @@ class SessionManager:
             Session = scoped_session(sessionmaker())
             Session.configure(bind=self.engine)
         except SQLAlchemyError as e:
-            logger.error(f'Error creating SQL session manager {e}')
+            logger.error('Error creating SQL session manager %s', e)
         return Session()

--- a/keylime/measured_boot.py
+++ b/keylime/measured_boot.py
@@ -22,7 +22,7 @@ def read_mb_refstate(mb_path=None):
     with open(mb_path, 'r') as f:
         mb_data = json.load(f)
 
-    logger.debug(f"Loaded measured boot reference state from {mb_path}")
+    logger.debug("Loaded measured boot reference state from %s", mb_path)
 
     return mb_data
 

--- a/keylime/registrar_client.py
+++ b/keylime/registrar_client.py
@@ -88,27 +88,23 @@ def getKeys(registrar_ip, registrar_port, agent_id):
         response_body = response.json()
 
         if response.status_code != 200:
-            logger.critical(
-                "Error: unexpected http response code from Registrar Server: %s" % str(response.status_code))
+            logger.critical("Error: unexpected http response code from Registrar Server: %s", response.status_code)
             keylime_logging.log_http_response(logger, logging.CRITICAL, response_body)
             return None
 
         if "results" not in response_body:
-            logger.critical(
-                "Error: unexpected http response body from Registrar Server: %s" % str(response.status_code))
+            logger.critical("Error: unexpected http response body from Registrar Server: %s", response.status_code)
             return None
 
         if "aik_tpm" not in response_body["results"]:
-            logger.critical(
-                "Error: did not receive AIK from Registrar Server: %s" % str(response.status_code))
+            logger.critical("Error: did not receive AIK from Registrar Server: %s", response.status_code)
             return None
 
         return response_body["results"]
 
     except AttributeError as e:
         if response and response.status_code == 503:
-            logger.critical("Error: the registrar is not available at %s:%s" % (
-                registrar_ip, registrar_port))
+            logger.critical("Error: the registrar is not available at %s:%s", registrar_ip, registrar_port)
         else:
             logger.exception(e)
 
@@ -132,28 +128,24 @@ def doRegisterAgent(registrar_ip, registrar_port, agent_id, ek_tpm, ekcert, aik_
         response_body = response.json()
 
         if response.status_code != 200:
-            logger.error(
-                f"Error: unexpected http response code from Registrar Server: {response.status_code}")
+            logger.error("Error: unexpected http response code from Registrar Server: %s", response.status_code)
             keylime_logging.log_http_response(logger, logging.ERROR, response_body)
             return None
 
-        logger.info(f"Agent registration requested for {agent_id}")
+        logger.info("Agent registration requested for %s", agent_id)
 
         if "results" not in response_body:
-            logger.critical(
-                f"Error: unexpected http response body from Registrar Server: {response.status_code}")
+            logger.critical("Error: unexpected http response body from Registrar Server: %s", response.status_code)
             return None
 
         if "blob" not in response_body["results"]:
-            logger.critical(
-                f"Error: did not receive blob from Registrar Server: {response.status_code}")
+            logger.critical("Error: did not receive blob from Registrar Server: %s", response.status_code)
             return None
 
         return response_body["results"]["blob"]
     except Exception as e:
         if response and response.status_code == 503:
-            logger.error(
-                f"Agent cannot establish connection to registrar at {registrar_ip}:{registrar_port}")
+            logger.error("Agent cannot establish connection to registrar at %s:%s", registrar_ip, registrar_port)
             sys.exit()
         else:
             logger.exception(e)
@@ -170,7 +162,7 @@ def doActivateAgent(registrar_ip, registrar_port, agent_id, key):
     response_body = response.json()
 
     if response.status_code == 200:
-        logger.info("Registration activated for agent %s." % agent_id)
+        logger.info("Registration activated for agent %s.", agent_id)
         return True
 
     logger.error(
@@ -187,8 +179,7 @@ def doRegistrarDelete(registrar_ip, registrar_port, agent_id):
     if response.status_code == 200:
         logger.debug("Registrar deleted.")
     else:
-        logger.warning("Status command response: " +
-                       str(response.status_code) + " Unexpected response from registrar.")
+        logger.warning("Status command response: %s Unexpected response from registrar.", response.status_code)
         keylime_logging.log_http_response(logger, logging.WARNING, response_body)
 
 
@@ -198,8 +189,7 @@ def doRegistrarList(registrar_ip, registrar_port):
     response_body = response.json()
 
     if response.status_code != 200:
-        logger.warning("Registrar returned: " +
-                       str(response.status_code) + " Unexpected response from registrar.")
+        logger.warning("Registrar returned: %s Unexpected response from registrar.", response.status_code)
         keylime_logging.log_http_response(logger, logging.WARNING, response_body)
         return None
 

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -313,26 +313,24 @@ class AgentsHandler(BaseHandler):
             )
 
         except Exception as e:
-            logger.error("Status command response: %s:%s Unexpected response from Cloud Verifier." % (
-                tenant_templ.cloudverifier_ip, tenant_templ.cloudverifier_port))
+            logger.error("Status command response: %s:%s Unexpected response from Cloud Verifier.",
+                tenant_templ.cloudverifier_ip, tenant_templ.cloudverifier_port)
             logger.exception(e)
             config.echo_json_response(
                 self, 500, "Unexpected response from Cloud Verifier", str(e))
-            logger.error("Unexpected response from Cloud Verifier: %s" % str(e))
+            logger.error("Unexpected response from Cloud Verifier: %s", e)
             return
 
         inst_response_body = response.json()
 
         if response.status_code != 200 and response.status_code != 404:
-            logger.error(
-                "Status command response: %d Unexpected response from Cloud Verifier." % response.status_code)
+            logger.error("Status command response: %d Unexpected response from Cloud Verifier.", response.status_code)
             keylime_logging.log_http_response(
                 logger, logging.ERROR, inst_response_body)
             return None
 
         if "results" not in inst_response_body:
-            logger.critical("Error: unexpected http response body from Cloud Verifier: %s" % str(
-                response.status_code))
+            logger.critical("Error: unexpected http response body from Cloud Verifier: %s", response.status_code)
             return None
 
         # Agent not added to CV (but still registered)
@@ -367,8 +365,7 @@ class AgentsHandler(BaseHandler):
         if "agents" not in rest_params:
             # otherwise they must be looking for agent info
             config.echo_json_response(self, 400, "uri not supported")
-            logger.warning(
-                'GET returning 400 response. uri not supported: ' + self.request.path)
+            logger.warning('GET returning 400 response. uri not supported: %s', self.request.path)
             return
 
         agent_id = rest_params["agents"]
@@ -390,8 +387,8 @@ class AgentsHandler(BaseHandler):
             )
 
         except Exception as e:
-            logger.error("Status command response: %s:%s Unexpected response from Registrar." % (
-                tenant_templ.registrar_ip, tenant_templ.registrar_port))
+            logger.error("Status command response: %s:%s Unexpected response from Registrar.",
+                tenant_templ.registrar_ip, tenant_templ.registrar_port)
             logger.exception(e)
             config.echo_json_response(
                 self, 500, "Unexpected response from Registrar", str(e))
@@ -400,15 +397,13 @@ class AgentsHandler(BaseHandler):
         response_body = response.json()
 
         if response.status_code != 200:
-            logger.error(
-                "Status command response: %d Unexpected response from Registrar." % response.status_code)
+            logger.error("Status command response: %d Unexpected response from Registrar.", response.status_code)
             keylime_logging.log_http_response(
                 logger, logging.ERROR, response_body)
             return None
 
         if ("results" not in response_body) or ("uuids" not in response_body["results"]):
-            logger.critical("Error: unexpected http response body from Registrar: %s" % str(
-                response.status_code))
+            logger.critical("Error: unexpected http response body from Registrar: %s", response.status_code)
             return None
 
         agent_list = response_body["results"]["uuids"]
@@ -455,8 +450,7 @@ class AgentsHandler(BaseHandler):
 
         if "agents" not in rest_params:
             config.echo_json_response(self, 400, "uri not supported")
-            logger.warning(
-                'DELETE returning 400 response. uri not supported: ' + self.request.path)
+            logger.warning('DELETE returning 400 response. uri not supported: %s', self.request.path)
             return
 
         agent_id = rest_params["agents"]
@@ -483,8 +477,7 @@ class AgentsHandler(BaseHandler):
 
         if "agents" not in rest_params:
             config.echo_json_response(self, 400, "uri not supported")
-            logger.warning(
-                'POST returning 400 response. uri not supported: ' + self.request.path)
+            logger.warning('POST returning 400 response. uri not supported: %s', self.request.path)
             return
 
         agent_id = rest_params["agents"]
@@ -575,8 +568,7 @@ class AgentsHandler(BaseHandler):
             mytenant.do_quote()
         except Exception as e:
             logger.exception(e)
-            logger.warning(
-                'POST returning 500 response. Tenant error: %s' % str(e))
+            logger.warning('POST returning 500 response. Tenant error: %s', e)
             config.echo_json_response(self, 500, "Request failure", str(e))
             return
 
@@ -596,8 +588,7 @@ class AgentsHandler(BaseHandler):
 
         if "agents" not in rest_params:
             config.echo_json_response(self, 400, "uri not supported")
-            logger.warning(
-                'PUT returning 400 response. uri not supported: ' + self.request.path)
+            logger.warning('PUT returning 400 response. uri not supported: %s', self.request.path)
             return
 
         agent_id = rest_params["agents"]
@@ -636,7 +627,7 @@ def parse_data_uri(data_uri):
 
 def start_tornado(tornado_server, port):
     tornado_server.listen(port)
-    logger.info("Starting Torando on port " + str(port))
+    logger.info("Starting Torando on port %s", port)
     tornado.ioloop.IOLoop.instance().start()
     logger.info("Tornado finished")
 
@@ -654,7 +645,7 @@ def get_tls_context():
     if tls_dir[0] != '/':
         tls_dir = os.path.abspath('%s/%s' % (config.WORK_DIR, tls_dir))
 
-    logger.info(f"Setting up client TLS in {tls_dir}")
+    logger.info("Setting up client TLS in %s", tls_dir)
 
     ca_path = "%s/%s" % (tls_dir, ca_cert)
     my_tls_cert = "%s/%s" % (tls_dir, my_cert)
@@ -678,10 +669,9 @@ def main():
 
     if not config.REQUIRE_ROOT and webapp_port < 1024:
         webapp_port += 2000
-        logger.warning("Running without root, changing port to %d" % webapp_port)
+        logger.warning("Running without root, changing port to %d", webapp_port)
 
-    logger.info(
-        'Starting Tenant WebApp (tornado) on port %d use <Ctrl-C> to stop' % webapp_port)
+    logger.info('Starting Tenant WebApp (tornado) on port %d use <Ctrl-C> to stop', webapp_port)
 
     # Figure out where our static files are located
     if getattr(sys, 'frozen', False):

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -135,7 +135,7 @@ class AbstractTPM(metaclass=ABCMeta):
     def __write_tpm_data(self):
         os.umask(0o077)
         if os.geteuid() != 0 and config.REQUIRE_ROOT:
-            logger.warning("Creating tpm metadata file without root.  Sensitive trust roots may be at risk!")
+            logger.warning("Creating tpm metadata file without root. Sensitive trust roots may be at risk!")
         with open('tpmdata.yml', 'w') as f:
             yaml.dump(self.global_tpmdata, f, Dumper=SafeDumper)
 
@@ -205,14 +205,14 @@ class AbstractTPM(metaclass=ABCMeta):
         pass
 
     def __check_ima(self, agent_id, pcrval, ima_measurement_list, allowlist, ima_keyring):
-        logger.info(f"Checking IMA measurement list on agent: {agent_id}")
+        logger.info("Checking IMA measurement list on agent: %s", agent_id)
         if config.STUB_IMA:
             pcrval = None
         ex_value = ima.process_measurement_list(ima_measurement_list.split('\n'), allowlist, pcrval=pcrval, ima_keyring=ima_keyring)
         if ex_value is None:
             return False
 
-        logger.debug(f"IMA measurement list of agent {agent_id} validated")
+        logger.debug("IMA measurement list of agent %s validated", agent_id)
         return True
 
     def check_pcrs(self, agent_id, tpm_policy, pcrs, data, virtual, ima_measurement_list, allowlist, ima_keyring, mb_measurement_list, mb_refstate):
@@ -248,7 +248,7 @@ class AbstractTPM(metaclass=ABCMeta):
         for line in pcrs:
             tokens = line.split()
             if len(tokens) < 3:
-                logger.error("Invalid %sPCR in quote: %s" % (("", "v")[virtual], pcrs))
+                logger.error("Invalid %sPCR in quote: %s", ("", "v")[virtual], pcrs)
                 continue
 
             # always lower case
@@ -257,12 +257,12 @@ class AbstractTPM(metaclass=ABCMeta):
             try:
                 pcrnum = int(tokens[1])
             except Exception:
-                logger.error("Invalid PCR number %s" % tokens[1])
+                logger.error("Invalid PCR number %s", tokens[1])
 
             if pcrnum == config.TPM_DATA_PCR and data is not None:
                 expectedval = self.sim_extend(data)
                 if expectedval != pcrval and not config.STUB_TPM:
-                    logger.error("%sPCR #%s: invalid bind data %s from quote does not match expected value %s" % (("", "v")[virtual], pcrnum, pcrval, expectedval))
+                    logger.error("%sPCR #%s: invalid bind data %s from quote does not match expected value %s", ("", "v")[virtual], pcrnum, pcrval, expectedval)
                     return False
                 validatedBindPCR = True
                 continue
@@ -301,10 +301,10 @@ class AbstractTPM(metaclass=ABCMeta):
 
             if pcrnum not in list(pcr_allowlist.keys()):
                 if not config.STUB_TPM and len(list(tpm_policy.keys())) > 0:
-                    logger.warning("%sPCR #%s in quote not found in %stpm_policy, skipping." % (("", "v")[virtual], pcrnum, ("", "v")[virtual]))
+                    logger.warning("%sPCR #%s in quote not found in %stpm_policy, skipping.", ("", "v")[virtual], pcrnum, ("", "v")[virtual])
                 continue
             if pcrval not in pcr_allowlist[pcrnum] and not config.STUB_TPM:
-                logger.error("%sPCR #%s: %s from quote does not match expected value %s" % (("", "v")[virtual], pcrnum, pcrval, pcr_allowlist[pcrnum]))
+                logger.error("%sPCR #%s: %s from quote does not match expected value %s", ("", "v")[virtual], pcrnum, pcrval, pcr_allowlist[pcrnum])
                 return False
 
             pcrsInQuote.add(pcrnum)
@@ -313,12 +313,12 @@ class AbstractTPM(metaclass=ABCMeta):
             return True
 
         if not validatedBindPCR:
-            logger.error("Binding %sPCR #%s was not included in the quote, but is required" % (("", "v")[virtual], config.TPM_DATA_PCR))
+            logger.error("Binding %sPCR #%s was not included in the quote, but is required", ("", "v")[virtual], config.TPM_DATA_PCR)
             return False
 
         missing = list(set(list(pcr_allowlist.keys())).difference(pcrsInQuote))
         if len(missing) > 0:
-            logger.error("%sPCRs specified in policy not in quote: %s" % (("", "v")[virtual], missing))
+            logger.error("%sPCRs specified in policy not in quote: %s", ("", "v")[virtual], missing)
             return False
 
         if mb_refstate :
@@ -340,7 +340,7 @@ class AbstractTPM(metaclass=ABCMeta):
                     # as fp has a method fileno(), you can pass it to ioctl
                     fcntl.ioctl(fp, RNDADDENTROPY, t)
             except Exception as e:
-                logger.warning("TPM randomness not added to system entropy pool: %s" % e)
+                logger.warning("TPM randomness not added to system entropy pool: %s", e)
 
     # tpm_nvram
     @abstractmethod

--- a/keylime/tpm_ek_ca.py
+++ b/keylime/tpm_ek_ca.py
@@ -17,15 +17,14 @@ tpm_cert_store = config.get('tenant', 'tpm_cert_store')
 
 def check_tpm_cert_store():
     if not os.path.isdir(tpm_cert_store):
-        logger.error(f"The directory {tpm_cert_store} does not exist.")
+        logger.error("The directory %s does not exist.", tpm_cert_store)
         sys.exit()
     else:
         for fname in os.listdir(tpm_cert_store):
             if fname.endswith('.pem'):
                 break
         else:
-            logger.error(
-                f"The directory {tpm_cert_store} does not contain any .pem files.")
+            logger.error("The directory %s does not contain any .pem files.", tpm_cert_store)
             sys.exit()
 
 


### PR DESCRIPTION
Use standard python logging format where args are passed to the logging
functions (info(), error(), etc). Not only is this more consistent,
but it's better performant as interpolation doesn't happen until/if the
logs are written.

Before we were all over the place with fstrings, string concat, format
strings (but interpolation done before the function call).