### PR TITLE
Add pylint version to check_codestyle output

### DIFF
--- a/scripts/check_codestyle.sh
+++ b/scripts/check_codestyle.sh
@@ -5,6 +5,8 @@ if [ -z "$(type -P pylint)" ]; then
 	exit 1
 fi
 
+pylint --version
+
 pylint \
   --jobs=0 \
   --ignored-modules=zmq,alembic.op,alembic.context,M2Crypto.m2,_cLime,Cryptodome,pylab,matplotlib,numpy \


### PR DESCRIPTION
This can help when tracking down differences between different runs,
say one in CI and the other in local dev