### PR TITLE
agent: Fix the checking for a specific error returned by tpm2_quote

### DIFF
--- a/keylime/cmd_exec.py
+++ b/keylime/cmd_exec.py
@@ -57,3 +57,12 @@ def run(cmd, expectedcode=EXIT_SUCESS, raiseOnError=True, outputpaths=None,
         'timing': timing,
     }
     return returnDict
+
+
+# list_contains_substring checks whether a substring is contained in the given
+# list. The list may be the reterr from 'run' and contains bytes-like objects.
+def list_contains_substring(lst, substring):
+    for s in lst:
+        if substring in str(s):
+            return True
+    return False

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -357,7 +357,7 @@ class tpm(tpm_abstract.AbstractTPM):
             reterr = retDict['reterr']
 
             # keep trying to get quote if a PCR race condition occurred in deluxe quote
-            if fprt == "tpm2_quote" and "Error validating calculated PCR composite with quote" in reterr:
+            if fprt == "tpm2_quote" and cmd_exec.list_contains_substring(reterr, "Error validating calculated PCR composite with quote"):
                 numtries += 1
                 maxr = config.getint('cloud_agent', 'max_retries')
                 if numtries >= maxr:


### PR DESCRIPTION
cmd_exec.run returns a list of byte-like objects containing the error strings
that a command may have returned. The current check must have assumed that a
simple string was returned. Fix this by implementing array_contains_substring
that checks whether any byte-like object or string in an array contains a given
substring.

This fixes issue #585.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>