### PR TITLE
ima_emulator_adapater: Remove unnecessary global statement

### DIFF
--- a/keylime/cmd/ima_emulator_adapter.py
+++ b/keylime/cmd/ima_emulator_adapter.py
@@ -21,7 +21,6 @@ ff_hash = ('ffffffffffffffffffffffffffffffffffffffff')
 
 
 def ml_extend(ml, position, searchHash=None):
-    global start_hash
     f = open(ml, 'r')
     lines = itertools.islice(f, position, None)
 


### PR DESCRIPTION
Remove an unnecessary global statement for start_hash since this
variable is accessed read-only. After replaying the log we end up
with the same result in PCR 10 as before this patch.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>