### PR TITLE
config: Document the measured boot PCRs and what is using them

### DIFF
--- a/keylime/config.py
+++ b/keylime/config.py
@@ -313,6 +313,9 @@ else:
 IMA_PCR = 10
 
 # measured boot addons
+# PCRs 0-7: BIOS & UEFI
+# PCRs 8-9: bootloader (grub)
+# PCR 14: MokList, MokListX, and MokSBState
 MEASUREDBOOT_PCRS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15]
 MEASUREDBOOT_ML = '/sys/kernel/security/tpm0/binary_bios_measurements'
 MEASUREDBOOT_IMPORTS = get_config().get('cloud_verifier', 'measured_boot_imports', fallback='').split(',')


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>