### PR TITLE
Addresses #436

### DIFF
--- a/agent_non_root_condition.sh
+++ b/agent_non_root_condition.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+KEYLIME_GROUP=tss
+KEYLIME_USER=keylime
+
+# creating group if it isn't already there
+if ! getent group $KEYLIME_GROUP >/dev/null; then
+    addgroup --system $KEYLIME_GROUP
+fi
+
+# creating keylime user if he isn't already there
+if ! getent passwd keylime >/dev/null; then
+    adduser --system --ingroup tss --shell /bin/false \
+    --home /var/lib/keylime --no-create-home \
+    --gecos "Keylime remote attestation" \
+    keylime
+fi
+
+# Create keylime operational directory
+if [ ! -d /var/lib/keylime ]; then mkdir -p /var/lib/keylime/secure
+fi
+
+# Only root can mount tmpfs with `-o`
+if ! grep -qs '/var/lib/keylime/secure ' /proc/mounts ; then mount -t tmpfs -o size=1m,mode=0700 tmpfs /var/lib/keylime/secure
+fi
+
+# Setting ownership for keylime operational directory
+if [ -d /var/lib/keylime ] && getent passwd $KEYLIME_USER >/dev/null; then
+chown -R $KEYLIME_USER:$KEYLIME_GROUP /var/lib/keylime
+fi
+
+# Setting ownership for /sys/kernel/security/<x>, giving keylime agent access to it
+chown -R $KEYLIME_USER:$KEYLIME_GROUP /sys/kernel/security/tpm0
+chown -R $KEYLIME_USER:$KEYLIME_GROUP /sys/kernel/security/ima

--- a/agent_non_root_condition.sh
+++ b/agent_non_root_condition.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-KEYLIME_GROUP=tss
-KEYLIME_USER=keylime
+KEYLIME_GROUP=${KEYLIME_GROUP:-tss}
+KEYLIME_USER=${KEYLIME_USER:-keylime}
 
 # creating group if it isn't already there
 if ! getent group $KEYLIME_GROUP >/dev/null; then
@@ -10,10 +10,10 @@ fi
 
 # creating keylime user if he isn't already there
 if ! getent passwd keylime >/dev/null; then
-    adduser --system --ingroup tss --shell /bin/false \
+    adduser --system --ingroup $KEYLIME_GROUP --shell /bin/false \
     --home /var/lib/keylime --no-create-home \
     --gecos "Keylime remote attestation" \
-    keylime
+    $KEYLIME_USER
 fi
 
 # Create keylime operational directory

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -450,7 +450,7 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
 
 
 def main():
-    for ML in [ config.MEASUREDBOOT_ML, config.IMA_ML ] : 
+    for ML in [ config.MEASUREDBOOT_ML, config.IMA_ML ] :
         if not os.access(ML, os.F_OK) :
             logger.warning("Measurement list path %s not accessible by agent. Any attempt to instruct it to access this path - via \"keylime_tenant\" CLI - will result in agent process dying", ML)
 

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -450,10 +450,6 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
 
 
 def main():
-    if os.getuid() != 0 and config.REQUIRE_ROOT:
-        logger.critical("This process must be run as root.")
-        return
-
     if config.get('cloud_agent', 'agent_uuid') == 'dmidecode':
         if os.getuid() != 0:
             raise RuntimeError('agent_uuid is configured to use dmidecode, '

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -450,6 +450,10 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
 
 
 def main():
+    for ML in [ config.MEASUREDBOOT_ML, config.IMA_ML ] : 
+        if not os.access(ML, os.F_OK) :
+            logger.warning("Measurement list path %s not accessible by agent. Any attempt to instruct it to access this path - via \"keylime_tenant\" CLI - will result in agent process dying", ML)
+
     if config.get('cloud_agent', 'agent_uuid') == 'dmidecode':
         if os.getuid() != 0:
             raise RuntimeError('agent_uuid is configured to use dmidecode, '


### PR DESCRIPTION
There is still a bit of extra setup work to be done in order to run the
`agent` as non-root, but imo, those should be done outside of the main
keylime code (it is a "packaging" issue, not code issue).

1) It is assumed that the non-root user which is running keylime has the
   ability to read the TPM device.

2) We need to mount `/var/lib/keylime/secure/` as root, since the mount
   command uses `--options`. The solution is to run it as root, and
   chown it to correct non-root user.

3) We need to make sure that the non-root user which is running keylime
   can read `/sys/kernel/security/ima/ascii_runtime_measurements` and
   `/sys/kernel/security/tpm0/binary_bios_measurements`. This could be
   done as simple `chown` or as an udev rule.

Signed-off-by: Marcio Silva <marcios@us.ibm.com>