### PR TITLE
WIP: Some cleanups

### DIFF
--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -63,11 +63,6 @@ else:
 global_password = None
 
 
-# def globalcb(*args):
-#    global global_password
-#    return global_password.encode()
-
-
 def setpassword(pw):
     global global_password
     if len(pw) == 0:

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -80,45 +80,6 @@ supported_fields = {
 }
 
 
-def read_measurement_list_bin(path):
-    raise Exception("not implementated fully yet")
-    # pylint: disable=W0101
-    f = open(path, 'rb')
-
-    while True:
-        template = {}
-        (template['pcr'], template['digest'],
-         template['name_len']) = read_unpack(f, "<I20sI")
-
-        if template['name_len'] > TCG_EVENT_NAME_LEN_MAX:
-            raise Exception("Error event name too long: %d" %
-                            template['name_len'])
-
-        name = read_unpack(f, "<%ds" % template['name_len'])[0]
-
-        is_ima_template = name == 'ima'
-        if not is_ima_template:
-            template['data_len'] = read_unpack(f, "<I")[0]
-            print("reading ima len %d" % template['data_len'])
-        else:
-            template['data_len'] = SHA_DIGEST_LEN + TCG_EVENT_NAME_LEN_MAX + 1
-
-        template['data'] = read_unpack(f, "<%ds" % template['data_len'])[0]
-
-        if is_ima_template:
-            field_len = read_unpack(f, "<I")[0]
-            extra_data = read_unpack(f, "<%ds" % field_len)[0]
-            template['data'] += extra_data
-
-        print("record %s" % template)
-
-        if template['name'] not in list(defined_templates.keys()):
-            template['name'] = 'ima'
-        template['desc-fmt'] = defined_templates[template['name']]
-
-        # tokens = template['desc-fmt'].split('|')
-
-
 def _extract_from_ima(tokens, template_hash):
     """ Extract filedata_hash & path form 'ima' entry; return 1 in case error occurred """
     filedata_hash = codecs.decode(tokens[3], "hex")
@@ -502,8 +463,6 @@ def read_excllist(exclude_path=None):
 
 
 def main():
-    # read_measurement_list_bin("/sys/kernel/security/ima/binary_runtime_measurements")
-
     allowlist_path = 'allowlist.txt'
     print("reading allowlist from %s" % allowlist_path)
 

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -379,7 +379,7 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
             self.u_set.add(u)
 
     def add_V(self, v):
-        """Threadsafe method for adding a U value received from the Cloud Verifier
+        """Threadsafe method for adding a V value received from the Cloud Verifier
         Do not modify u_set of v_set directly.
         """
         with uvLock:

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -60,7 +60,7 @@ class TPM_Utilities:
             if int(key) == config.IMA_PCR:
                 raise Exception("Invalid allowlist PCR number %s, this PCR is used for IMA." % key)
 
-            mask = mask + (1 << int(key))
+            mask = mask | (1 << int(key))
 
             # wrap it in a list if it is a singleton
             if isinstance(policy[key], str):

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -418,7 +418,7 @@ class tpm(tpm_abstract.AbstractTPM):
                     cmd = ["tpm2_evictcontrol", "-A", "o", "-H",
                            hex(current_handle), "-P", owner_pw]
                     retDict = self.__run(cmd, raiseOnError=False)
-                else:
+                elif self.tools_version in ["4.0", "4.2"]:
                     cmd = ["tpm2_evictcontrol", "-C", "o", "-c",
                            hex(current_handle), "-P", owner_pw]
                     retDict = self.__run(cmd, raiseOnError=False)
@@ -460,7 +460,7 @@ class tpm(tpm_abstract.AbstractTPM):
 
             if self.tools_version == "3.2":
                 handle = int(0x81010007)
-            else:
+            elif self.tools_version in ["4.0", "4.2"]:
                 handle = None
                 retyaml = config.yaml_to_dict(output)
                 if "persistent-handle" in retyaml:
@@ -482,7 +482,7 @@ class tpm(tpm_abstract.AbstractTPM):
                 cmd = ["tpm2_readpublic", "-H", hex(ek_handle),
                        "-o", tmppath.name, "-f", "tss"]
                 retDict = self.__run(cmd, raiseOnError=False, outputpaths=tmppath.name)
-            else:
+            elif self.tools_version in ["4.0", "4.2"]:
                 cmd = ["tpm2_readpublic", "-c", hex(ek_handle),
                        "-o", tmppath.name, "-f", "tss"]
                 retDict = self.__run(cmd, raiseOnError=False, outputpaths=tmppath.name)
@@ -547,7 +547,7 @@ class tpm(tpm_abstract.AbstractTPM):
             if self.tools_version == "3.2":
                 cmd = ["tpm2_readpublic", "-H", hex(handle), "-o", tmppath.name]
                 retDict = self.__run(cmd, raiseOnError=False, outputpaths=tmppath.name)
-            else:
+            elif self.tools_version in ["4.0", "4.2"]:
                 cmd = ["tpm2_readpublic", "-c", hex(handle), "-o", tmppath.name]
                 retDict = self.__run(cmd, raiseOnError=False, outputpaths=tmppath.name)
 
@@ -598,7 +598,7 @@ class tpm(tpm_abstract.AbstractTPM):
                 if self.tools_version == "3.2":
                     cmd = ["tpm2_evictcontrol", "-A", "o", "-H", hex(aik_handle), "-P", owner_pw]
                     retDict = self.__run(cmd, raiseOnError=False)
-                else:
+                elif self.tools_version in ["4.0", "4.2"]:
                     cmd = ["tpm2_evictcontrol", "-C", "o", "-c", hex(aik_handle), "-P", owner_pw]
                     retDict = self.__run(cmd, raiseOnError=False)
 
@@ -663,7 +663,7 @@ class tpm(tpm_abstract.AbstractTPM):
 
             # get and persist the pem (not returned by tpm2_getpubak)
             self._set_tpm_metadata('aik_handle', handle)
-        else:
+        elif self.tools_version in ["4.0", "4.2"]:
             if 'loaded-key' not in jsonout:
                 raise Exception("tpm2_createak failed to create aik: return " + str(reterr))
 
@@ -703,7 +703,7 @@ class tpm(tpm_abstract.AbstractTPM):
                 if self.tools_version == "3.2":
                     self.__run(["tpm2_evictcontrol", "-A", "o", "-H", hex(key), "-P", owner_pw],
                                raiseOnError=False)
-                else:
+                elif self.tools_version in ["4.0", "4.2"]:
                     self.__run(["tpm2_evictcontrol", "-C", "o", "-c", hex(key), "-P", owner_pw],
                                raiseOnError=False)
 
@@ -796,7 +796,7 @@ class tpm(tpm_abstract.AbstractTPM):
                            "-k", hex(ek_keyhandle), "-f", keyblobFile.name,
                            "-o", secpath, "-P", apw, "-e", owner_pw]
                 retDict = self.__run(command, outputpaths=secpath)
-            else:
+            elif self.tools_version in ["4.0", "4.2"]:
                 self.__run(["tpm2_startauthsession", "--policy-session", "-S", sesspath])
                 self.__run(["tpm2_policysecret", "-S", sesspath, "-c", "0x4000000B", owner_pw])
                 command = ["tpm2_activatecredential", "-c", aik_keyhandle, "-C", hex(ek_keyhandle),
@@ -946,7 +946,7 @@ class tpm(tpm_abstract.AbstractTPM):
                 nonce = bytes(nonce, encoding="utf8").hex()
                 if self.tools_version == "3.2":
                     command = ["tpm2_quote", "-k", hex(keyhandle), "-L", "%s:%s" % (hash_alg, pcrlist), "-q", nonce, "-m", quotepath.name, "-s", sigpath.name, "-p", pcrpath.name, "-G", hash_alg, "-P", aik_pw]
-                else:
+                elif self.tools_version in ["4.0", "4.2"]:
                     command = ["tpm2_quote", "-c", keyhandle, "-l", "%s:%s" % (hash_alg, pcrlist), "-q", nonce, "-m", quotepath.name, "-s", sigpath.name, "-o", pcrpath.name, "-g", hash_alg, "-p", aik_pw]
                 retDict = self.__run(command, lock=False, outputpaths=[quotepath.name, sigpath.name, pcrpath.name])
                 quoteraw = retDict['fileouts'][quotepath.name]
@@ -971,7 +971,7 @@ class tpm(tpm_abstract.AbstractTPM):
         nonce = bytes(nonce, encoding="utf8").hex()
         if self.tools_version == "3.2":
             command = ["tpm2_checkquote", "-c", pubaik, "-m", quoteFile, "-s", sigFile, "-p", pcrFile, "-G", hash_alg, "-q", nonce]
-        else:
+        elif self.tools_version in ["4.0", "4.2"]:
             command = ["tpm2_checkquote", "-u", pubaik, "-m", quoteFile, "-s", sigFile, "-f", pcrFile, "-g", hash_alg, "-q", nonce]
         retDict = self.__run(command, lock=False)
         return retDict
@@ -1139,7 +1139,7 @@ class tpm(tpm_abstract.AbstractTPM):
             if self.tools_version == "3.2":
                 self.__run(["tpm2_nvdefine", "-x", "0x1500018", "-a", "0x40000001", "-s", str(config.BOOTSTRAP_KEY_SIZE), "-t", '"%s"' % attrs, "-I", owner_pw, "-P", owner_pw], raiseOnError=False)
                 self.__run(["tpm2_nvwrite", "-x", "0x1500018", "-a", "0x40000001", "-P", owner_pw, keyFile.name], raiseOnError=False)
-            else:
+            elif self.tools_version in ["4.0", "4.2"]:
                 self.__run(["tpm2_nvdefine", "0x1500018", "-C", "0x40000001", "-s", str(config.BOOTSTRAP_KEY_SIZE), "-a", '"%s"' % attrs, "-p", owner_pw, "-P", owner_pw], raiseOnError=False)
                 self.__run(["tpm2_nvwrite", "0x1500018", "-C", "0x40000001", "-P", owner_pw, "-i", keyFile.name], raiseOnError=False)
 
@@ -1192,7 +1192,7 @@ class tpm(tpm_abstract.AbstractTPM):
         owner_pw = self.get_tpm_metadata('owner_pw')
         if self.tools_version == "3.2":
             retDict = self.__run(["tpm2_nvread", "-x", "0x1500018", "-a", "0x40000001", "-s", str(config.BOOTSTRAP_KEY_SIZE), "-P", owner_pw], raiseOnError=False)
-        else:
+        elif self.tools_version in ["4.0", "4.2"]:
             retDict = self.__run(["tpm2_nvread", "0x1500018", "-C", "0x40000001", "-s", str(config.BOOTSTRAP_KEY_SIZE), "-P", owner_pw], raiseOnError=False)
 
         output = retDict['retout']

--- a/test/oldtest.py
+++ b/test/oldtest.py
@@ -357,7 +357,7 @@ class Test(unittest.TestCase):
                     mask = 0
                     for key in list(tmpp_policy.keys()):
                         if key.isdigit():
-                            mask = mask + (1 << int(key))
+                            mask = mask | (1 << int(key))
 
                     mask_str = "0x%X" % (mask)
                     tmpp_policy['mask'] = mask_str


### PR DESCRIPTION
This patch fixes some nits:
- use '|' rather than '+' to build a mask of bits (assuming sanity that if bit n is set twice it is not supposed to lead to bit n+1 to be set as was the case with the '+') 
- explicitly test for tpm2_tools version 4.0 and 4.2 in else branches to be consistent with other cases where the same testing is done in many places in tpm_main.py already. This may be the pessimistic approach that future versions of the tpm2_tools may again be incompatible and need another else branch. The optimistic approach would be to adjust the other cases where we explicitly test for 4.0 and 4.2 and use a simple else instead.
- removes the unused read_measurement_list_bin function attempting to parse the binary measurement list. Is someone persuing parsing the binary measurement list or can we stick with the existing ascii list? If nobody is persuing this then let's remove it and in the worst case we can find it in the history later on.
