### PR TITLE
Flush tpm keys upon registration failure - Fixes #620

### DIFF
--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -526,12 +526,14 @@ def main():
         registrar_ip, registrar_port, agent_uuid, ek_tpm, ekcert, aik_tpm)
 
     if keyblob is None:
+        instance_tpm.flush_keys()
         raise Exception("Registration failed")
 
     # get the ephemeral registrar key
     key = instance_tpm.activate_identity(keyblob)
 
     if key is None:
+        instance_tpm.flush_keys()
         raise Exception("Activation failed")
 
     # tell the registrar server we know the key
@@ -540,6 +542,7 @@ def main():
         registrar_ip, registrar_port, agent_uuid, key)
 
     if not retval:
+        instance_tpm.flush_keys()
         raise Exception("Registration failed on activate")
 
     serveraddr = (config.get('cloud_agent', 'cloudagent_ip'),


### PR DESCRIPTION
The simplest fix is to just call instance_tpm.flush_keys() whenever the
agent fails during the initial setup

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>