### PR TITLE
tpm_main: Invoke tpm2_evictcontrol for 4.0 and 4.2 tools if aik_handl…

### DIFF
--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -594,13 +594,18 @@ class tpm(tpm_abstract.AbstractTPM):
                 output = [output]
 
             outjson = config.yaml_to_dict(output)
-            if outjson is not None and aik_handle in outjson:
+            if self.tools_version == "3.2":
+                evict_it = outjson is not None and aik_handle in outjson
+            elif self.tools_version in ["4.0", "4.2"]:
+                evict_it = os.path.exists(aik_handle)
+            if evict_it:
                 if self.tools_version == "3.2":
                     cmd = ["tpm2_evictcontrol", "-A", "o", "-H", hex(aik_handle), "-P", owner_pw]
                     retDict = self.__run(cmd, raiseOnError=False)
                 elif self.tools_version in ["4.0", "4.2"]:
-                    cmd = ["tpm2_evictcontrol", "-C", "o", "-c", hex(aik_handle), "-P", owner_pw]
+                    cmd = ["tpm2_evictcontrol", "-C", "o", "-c", aik_handle, "-P", owner_pw]
                     retDict = self.__run(cmd, raiseOnError=False)
+                    os.remove(aik_handle)
 
                 output = retDict['retout']
                 reterr = retDict['reterr']


### PR DESCRIPTION
…e exists

tpm2_evictcontrol was not invoked for tpm2_tools 4.0 or 4.2 since aik_handle
is not a hex number but a filename and that filename could not be found in
the 'outjson' since there we only find hex numbers. So, adjust the test for
4.0 and 4.2 tools to check whether the aik_handle file exists and invoke
tpm2_evictcontrol if it is there.

Also remove the old aik_handle file after running tpm2_evictcontrol. This
ensures that only one file in /var/lib/keylime/secure is an aik_handle. This
now resolves issue #584 for me but the mystery remains why multiple files in
that directory would have caused an issue for running tpm2_policysecret
while removing them, as pointed out in issue #584, resolved the issue.
Fact is that the following command now runs for hours:

while :; do timeout -s SIGINT 60 keylime_agent ; done

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>