### PR TITLE
Fixes #629: Allow reglist to run without a -t argument

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -1020,7 +1020,7 @@ def main(argv=sys.argv):
 
     mytenant = Tenant()
 
-    if args.command not in ['list', 'regdelete', 'delete', 'status',
+    if args.command not in ['list', 'regdelete', 'reglist', 'delete', 'status',
                             'addallowlist', 'deleteallowlist',
                             'showallowlist'] and args.agent_ip is None:
         raise UserError(


### PR DESCRIPTION
This is a one liner. Not much to comment.