### PR TITLE
Move measured boot related code into functions to make check_pcrs readable

### DIFF
--- a/keylime/measured_boot.py
+++ b/keylime/measured_boot.py
@@ -31,6 +31,39 @@ def process_refstate(mb_refstate_data=None) :
         return mb_refstate_data
     return mb_refstate_data
 
+def get_policy(mb_refstate_str):
+    """ Convert the mb_refstate_str to JSON and get the measured boot policy.
+    :param mb_refstate_str: String representation of measured boot reference state
+    :returns: Returns the JSON object of the measured boot reference state and the measured boot policy;
+              both can be None if mb_refstate_str was empty
+    """
+
+    if mb_refstate_str:
+        mb_refstate_data = json.loads(mb_refstate_str)
+    else:
+        mb_refstate_data = None
+
+    if mb_refstate_data:
+        mb_policy_name = config.MEASUREDBOOT_POLICYNAME
+        #pylint: disable=import-outside-toplevel
+        from keylime.elchecking import policies as eventlog_policies
+        #pylint: enable=import-outside-toplevel
+        mb_policy = eventlog_policies.get_policy(mb_policy_name)
+        if mb_policy is None:
+            logger.warning(
+                "Invalid measured boot policy name %s -- using accept-all instead.", mb_policy_name)
+            mb_policy = eventlog_policies.AcceptAll()
+
+        mb_pcrs_config = frozenset(config.MEASUREDBOOT_PCRS)
+        mb_pcrs_policy = mb_policy.get_relevant_pcrs()
+        if not mb_pcrs_policy <= mb_pcrs_config:
+            logger.error("Measured boot policy considers PCRs %s, which are not among the configured set %s",
+                        set(mb_pcrs_policy - mb_pcrs_config), set(mb_pcrs_config))
+    else:
+        mb_policy = None
+
+    return mb_refstate_data, mb_policy
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('infile', default="mbtest.txt")

--- a/keylime/measured_boot.py
+++ b/keylime/measured_boot.py
@@ -64,6 +64,23 @@ def get_policy(mb_refstate_str):
 
     return mb_refstate_data, mb_policy
 
+def evaluate_policy(mb_policy, mb_refstate_data, mb_measurement_data, pcrsInQuote, pcrPrefix, agent_id):
+    missing = list(set(config.MEASUREDBOOT_PCRS).difference(pcrsInQuote))
+    if len(missing) > 0:
+        logger.error("%sPCRs specified for measured boot not in quote: %s", pcrPrefix, missing)
+        return False
+    try:
+        reason = mb_policy.evaluate(mb_refstate_data, mb_measurement_data)
+    except Exception as exn:
+        logger.error("Boot attestation for agent %s, configured policy %s, refstate=%s, raised Exception %s",
+            agent_id, config.MEASUREDBOOT_POLICYNAME, json.dumps(mb_refstate_data), str(exn))
+        reason = ''
+    if reason:
+        logger.error("Boot attestation failed for agent %s, configured policy %s, refstate=%s, reason=%s",
+            agent_id, config.MEASUREDBOOT_POLICYNAME, json.dumps(mb_refstate_data), reason)
+        return False
+    return True
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('infile', default="mbtest.txt")

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -311,20 +311,10 @@ class AbstractTPM(metaclass=ABCMeta):
             logger.error("%sPCRs specified in policy not in quote: %s", ("", "v")[virtual], missing)
             return False
 
-        if mb_refstate_data :
-            missing = list(set(config.MEASUREDBOOT_PCRS).difference(pcrsInQuote))
-            if len(missing) > 0:
-                logger.error("%sPCRs specified for measured boot not in quote: %s", ("", "v")[virtual], missing)
-                return False
-            try:
-                reason = mb_policy.evaluate(mb_refstate_data, mb_measurement_data)
-            except Exception as exn:
-                logger.error("Boot attestation for agent %s, configured policy %s, refstate=%s, raised Exception %s",
-                    agent_id, config.MEASUREDBOOT_POLICYNAME, json.dumps(mb_refstate_data), str(exn))
-                reason = ''
-            if reason:
-                logger.error("Boot attestation failed for agent %s, configured policy %s, refstate=%s, reason=%s",
-                    agent_id, config.MEASUREDBOOT_POLICYNAME, json.dumps(mb_refstate_data), reason)
+        if mb_refstate_data:
+            success = measured_boot.evaluate_policy(mb_policy, mb_refstate_data, mb_measurement_data,
+                                                    pcrsInQuote, ("", "v")[virtual], agent_id)
+            if not success:
                 return False
 
         return True

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -216,31 +216,6 @@ class AbstractTPM(metaclass=ABCMeta):
         logger.debug("IMA measurement list of agent %s validated", agent_id)
         return True
 
-
-    def parse_mb_bootlog(self, mb_measurement_list):
-        """ Parse the measured boot log and return its object and the state of the SHA256 PCRs
-        :param mb_measurement_list: The measured boot measurement list
-        :returns: Returns a map of the state of the SHA256 PCRs, measured boot data object and True for success
-                  and False in case an error occurred
-        """
-        if mb_measurement_list:
-            mb_measurement_data = self.parse_bootlog(mb_measurement_list)
-            if not mb_measurement_data:
-                logger.error("Unable to parse measured boot event log. Check previous messages for a reason for error.")
-                return {}, {}, False
-            log_pcrs = mb_measurement_data.get('pcrs')
-            if not isinstance(log_pcrs, dict):
-                logger.error("Parse of measured boot event log has unexpected value for .pcrs: %r", log_pcrs)
-                return {}, {}, False
-            pcrs_sha256 = log_pcrs.get('sha256')
-            if (not isinstance(pcrs_sha256, dict)) or not pcrs_sha256:
-                logger.error("Parse of measured boot event log has unexpected value for .pcrs.sha256: %r", pcrs_sha256)
-                return {}, {}, False
-
-            return pcrs_sha256, mb_measurement_data, True
-
-        return {}, {}, True
-
     def check_pcrs(self, agent_id, tpm_policy, pcrs, data, virtual, ima_measurement_list, allowlist, ima_keyring, mb_measurement_list, mb_refstate_str):
         try:
             tpm_policy_ = ast.literal_eval(tpm_policy)
@@ -377,5 +352,5 @@ class AbstractTPM(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def parse_bootlog(self, log_b64:str) -> dict:
+    def parse_mb_bootlog(self, mb_measurement_list:str) -> dict:
         raise NotImplementedError

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -271,11 +271,10 @@ class AbstractTPM(metaclass=ABCMeta):
 
             # PCRs set by measured boot get their own special handling
 
-            if pcrnum in config.MEASUREDBOOT_PCRS :
+            if pcrnum in config.MEASUREDBOOT_PCRS:
 
-                if mb_refstate_data :
-
-                    if not mb_measurement_list :
+                if mb_refstate_data:
+                    if not mb_measurement_list:
                         logger.error("Measured Boot PCR %d in policy, but no measurement list provided", pcrnum)
                         return False
 


### PR DESCRIPTION
This PR moves measured boot related code into their own functions since check_pcrs is so long now. This makes the code easier to read.