### PR TITLE
codestyle: Ignore R1732 implemented by pylint >=2.8.0

### DIFF
--- a/scripts/check_codestyle.sh
+++ b/scripts/check_codestyle.sh
@@ -20,6 +20,6 @@ ${PYLINT} \
   --disable C0103,C0115,C0116,C0301,C0302,C0111 \
   --disable W0102,W0511,W0603,W0703,W1201,W1203 \
   --disable E1120 \
-  --disable R0801,R0902,R0903,R0904,R0912,R0913,R0914,R0915,R0201,R0911,R1729 \
+  --disable R0801,R0902,R0903,R0904,R0912,R0913,R0914,R0915,R0201,R0911,R1729,R1732 \
   *.py $(find ./keylime ./test -name '*.py' ! -name 'oldtest.py')
 exit $?


### PR DESCRIPTION
pylint 2.8.0 and later implement R1732 which raises the following types
of linter issues:

keylime/ima.py:481:4: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)

Ignore them for now.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>