### PR TITLE
Cleanup and fix error case in encryptAIK

### DIFF
--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -760,7 +760,7 @@ class tpm(tpm_abstract.AbstractTPM):
         except Exception as e:
             logger.error("Error encrypting AIK: " + str(e))
             logger.exception(e)
-            return None
+            raise
         finally:
             for fd in [efd, keyfd, blobfd]:
                 if fd >= 0:


### PR DESCRIPTION
This function cleans up encryptAIK and fixes the error case where we were not returning enough parameters to the caller. The latter would cause an unpack error on the caller's side in case encryptAIK failed.