### PR TITLE
installer.sh: Do not delete the local copy of the certificates.

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -605,7 +605,7 @@ echo "==========================================================================
 if [ ! -d "/var/lib/keylime/tpm_cert_store" ]; then
   echo "Creating new tpm_cert_store"
   mkdir -p /var/lib/keylime
-  mv $KEYLIME_DIR/tpm_cert_store /var/lib/keylime/tpm_cert_store
+  cp $KEYLIME_DIR/tpm_cert_store /var/lib/keylime/tpm_cert_store
 else
   echo "Updating existing cert store"
   cp -n $KEYLIME_DIR/tpm_cert_store/* /var/lib/keylime/tpm_cert_store/


### PR DESCRIPTION
Copy, rather than move, the certificates to
/var/lib/keylime/tpm_cert_store/.  This way, git status
does not show that all the certificates have been deleted.

Signed-off-by: Ken Goldman <kgold@linux.ibm.com>