### PR TITLE
ima_file_signatures: Extract keyidv2 from x509 certs

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -162,11 +162,11 @@ class Tenant():
             # Add all IMA file signing verification keys to a keyring
             ima_keyring = ima_file_signatures.ImaKeyring()
             for filename in args["ima_sign_verification_keys"]:
-                pubkey = ima_file_signatures.get_pubkey_from_file(filename)
+                pubkey, keyidv2 = ima_file_signatures.get_pubkey_from_file(filename)
                 if not pubkey:
                     raise UserError(
                         "File '%s' is not a file with a key" % filename)
-                ima_keyring.add_pubkey(pubkey)
+                ima_keyring.add_pubkey(pubkey, keyidv2)
             self.ima_sign_verification_keys = ima_keyring.to_string()
 
         # Read command-line path string allowlist

--- a/test/test_ima_verification.py
+++ b/test/test_ima_verification.py
@@ -67,15 +67,15 @@ class TestIMAVerification(unittest.TestCase):
 
         # add key for 1st entry; 1st entry must be verifiable
         rsakeyfile = os.path.join(keydir, "rsa2048pub.pem")
-        pubkey = ima_file_signatures.get_pubkey_from_file(rsakeyfile)
-        keyring.add_pubkey(pubkey)
+        pubkey, keyidv2 = ima_file_signatures.get_pubkey_from_file(rsakeyfile)
+        keyring.add_pubkey(pubkey, keyidv2)
         self.assertTrue(ima.process_measurement_list(lines[0:1], ima_keyring=keyring) is not None)
         self.assertTrue(ima.process_measurement_list(lines[1:2], ima_keyring=keyring) is None)
 
         # add key for 2nd entry; 1st & 2nd entries must be verifiable
         eckeyfile = os.path.join(keydir, "secp256k1.pem")
-        pubkey = ima_file_signatures.get_pubkey_from_file(eckeyfile)
-        keyring.add_pubkey(pubkey)
+        pubkey, keyidv2 = ima_file_signatures.get_pubkey_from_file(eckeyfile)
+        keyring.add_pubkey(pubkey, keyidv2)
         self.assertTrue(ima.process_measurement_list(lines[0:2], ima_keyring=keyring) is not None)
 
     def test_mixed_verfication(self):
@@ -91,12 +91,12 @@ class TestIMAVerification(unittest.TestCase):
         keyring = ima_file_signatures.ImaKeyring()
 
         rsakeyfile = os.path.join(keydir, "rsa2048pub.pem")
-        pubkey = ima_file_signatures.get_pubkey_from_file(rsakeyfile)
-        keyring.add_pubkey(pubkey)
+        pubkey, keyidv2 = ima_file_signatures.get_pubkey_from_file(rsakeyfile)
+        keyring.add_pubkey(pubkey, keyidv2)
 
         eckeyfile = os.path.join(keydir, "secp256k1.pem")
-        pubkey = ima_file_signatures.get_pubkey_from_file(eckeyfile)
-        keyring.add_pubkey(pubkey)
+        pubkey, keyidv2 = ima_file_signatures.get_pubkey_from_file(eckeyfile)
+        keyring.add_pubkey(pubkey, keyidv2)
 
         # entries are not covered by a exclude list -> this should fail
         self.assertTrue(ima.process_measurement_list(COMBINED.splitlines(), ima_keyring=keyring) is None)


### PR DESCRIPTION
When an x509 certificate is given, attempt to extract the keyidv2 from the
certificate's subject key identifier digest's last 4 bytes. This is safer
than recalculating it with the sha1 hash since other methods may exist.
For public and public keys extracted from private keys we have to use the
sha1 method.

Also adjust how we store the state of the keys into the database. We now
also store an array of the keyidv2's of all keys.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>