### PR TITLE
 installer: Fix back level Intel TSS configure issues for Ubuntu groovy

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -605,7 +605,7 @@ echo "==========================================================================
 if [ ! -d "/var/lib/keylime/tpm_cert_store" ]; then
   echo "Creating new tpm_cert_store"
   mkdir -p /var/lib/keylime
-  mv $KEYLIME_DIR/tpm_cert_store /var/lib/keylime/tpm_cert_store
+  cp $KEYLIME_DIR/tpm_cert_store /var/lib/keylime/tpm_cert_store
 else
   echo "Updating existing cert store"
   cp -n $KEYLIME_DIR/tpm_cert_store/* /var/lib/keylime/tpm_cert_store/

--- a/installer.sh
+++ b/installer.sh
@@ -14,7 +14,7 @@ TPM2SIM_SRC=http://sourceforge.net/projects/ibmswtpm2/files/ibmtpm1119.tar.gz/do
 KEYLIME_VER="master"
 TPM4720_VER="master"
 GOLANG_VER="1.13.1"
-TPM2TSS_VER="2.0.x"
+TPM2TSS_VER="2.4.x"
 TPM2TOOLS_VER="3.X"
 
 # Minimum version requirements
@@ -469,7 +469,7 @@ elif [[ "$TPM_VERSION" -eq "2" ]] ; then
         if [[ -n $CENTOS7_TSS_FLAGS ]] ; then
             export PKG_CONFIG_PATH=/usr/lib/pkgconfig/
         fi
-        ./configure --prefix=/usr $CENTOS7_TSS_FLAGS
+        ./configure --disable-doxygen-doc --prefix=/usr $CENTOS7_TSS_FLAGS
         make
         make install
         ldconfig


### PR DESCRIPTION
The first configure issue was reported here.  The recommendation
was to try 2.4.x, as 2.0.x is no longer supported.  This should
be tested against keylime 'next' builds for compatibility.

https://github.com/tpm2-software/tpm2-tss#2066

The second configure issue was reported here.  The recommendation was
to disable building of the man pages, because 2.4.x expects an older
version of doxygen.

https://github.com/tpm2-software/tpm2-tss#2067
