### PR TITLE
Remove adding entropy to system rng

### DIFF
--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -481,8 +481,6 @@ def main():
     (ekcert, ek_tpm, aik_tpm) = instance_tpm.tpm_init(self_activate=False, config_pw=config.get(
         'cloud_agent', 'tpm_ownerpassword'))  # this tells initialize not to self activate the AIK
     virtual_agent = instance_tpm.is_vtpm()
-    # try to get some TPM randomness into the system entropy pool
-    instance_tpm.init_system_rand()
 
     if ekcert is None:
         if virtual_agent:

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -5,11 +5,9 @@ Copyright 2017 Massachusetts Institute of Technology.
 
 from abc import ABCMeta, abstractmethod
 import ast
-import fcntl
 import hashlib
 import os
 import string
-import struct
 
 import simplejson as json
 import yaml
@@ -317,19 +315,6 @@ class AbstractTPM(metaclass=ABCMeta):
                 return False
 
         return True
-
-    # tpm_random
-    def init_system_rand(self):
-        rand_data = self._get_tpm_rand_block()
-        if config.REQUIRE_ROOT and rand_data is not None:
-            try:
-                t = struct.pack("ii%ds" % len(rand_data), 8 * len(rand_data), len(rand_data), rand_data)
-                with open("/dev/random", mode='wb') as fp:
-                    RNDADDENTROPY = 0x80085203
-                    # as fp has a method fileno(), you can pass it to ioctl
-                    fcntl.ioctl(fp, RNDADDENTROPY, t)
-            except Exception as e:
-                logger.warning("TPM randomness not added to system entropy pool: %s", e)
 
     # tpm_nvram
     @abstractmethod

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -376,10 +376,6 @@ class TestRestful(unittest.TestCase):
                                                            config_pw=config.get('cloud_agent', 'tpm_ownerpassword'))
         vtpm = tpm_instance.is_vtpm()
 
-        # Seed RNG (root only)
-        if config.REQUIRE_ROOT:
-            tpm_instance.init_system_rand()
-
         # Handle virtualized and emulated TPMs
         if ekcert is None:
             if vtpm:


### PR DESCRIPTION
Trust the Linux kernel that it gets entropy from various sources.

Recent Fedora kernels for example are compiled with CONFIG_HW_RANDOM_TPM
that add the TPM as an entropy provider:

https://elixir.bootlin.com/linux/v5.12/source/drivers/char/tpm/Kconfig#L30

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>