### PR TITLE
Fixes and improvements for database configuration

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -198,23 +198,25 @@ registrar_private_key_pw = default
 # Database URL Configuration
 # See this document https://keylime-docs.readthedocs.io/en/latest/installation.html#database-support
 # for instructions on using different database configurations.
-# Database configuration via drivername, username, password, etc is deprecated
-# and superseded by database_url, when database_url is set, other database
-# fields will be ignored.
+# There are two options for the specification of the database connection configuration.
+# 1) A tuple of parameters (e.g., database_drivername, database_username, database_password)
+# 2) A single string in database_url. This, when set, takes precedence over the previous option.
 # An example of database_url value for using sqlite:
 #   sqlite:////var/lib/keylime/cv_data.sqlite
 # An example of database_url value for using mysql:
 #   mysql+pymysql://keylime:keylime@keylime_db:[port]/verifier?charset=utf8
-# If database_url is not set, the deprecated default is "sqlite" and will be
+# If database_url is not set, the default is "sqlite", using method 1, and will be
 # located at "/var/lib/keylime/cv_data.sqlite".
 database_url =
-drivername = sqlite
-username = ''
-password = ''
-host = ''
-port = ''
-database = cv_data.sqlite
-query = ''
+database_drivername = sqlite
+database_username = ''
+database_password = ''
+database_host = ''
+database_port = ''
+database_name = cv_data.sqlite
+database_query = ''
+# Limits for DB connection pool size in sqlalchemy (https://docs.sqlalchemy.org/en/14/core/pooling.html#api-documentation-available-pool-implementations)
+database_pool_sz_ovfl=5,10
 
 auto_migrate_db = True
 
@@ -476,23 +478,25 @@ check_client_cert = True
 # Database URL Configuration
 # See this document https://keylime-docs.readthedocs.io/en/latest/installation.html#database-support
 # for instructions on using different database configurations.
-# Database configuration via drivername, username, password, etc is deprecated
-# and superseded by database_url, when database_url is set, other database
-# fields will be ignored.
+# There are two options for the specification of the database connection configuration.
+# 1) A tuple of parameters (e.g., database_drivername, database_username, database_password)
+# 2) A single string in database_url. This, when set, takes precedence over the previous option.
 # An example of database_url value for using sqlite:
-#   sqlite:////var/lib/keylime/reg_data.sqlite
+#   sqlite:////var/lib/keylime/cv_data.sqlite
 # An example of database_url value for using mysql:
-#   mysql+pymysql://keylime:keylime@keylime_db:[port]/registrar?charset=utf8
-# If database_url is not set, the deprecated default is "sqlite" and will be
-# located at "/var/lib/keylime/reg_data.sqlite".
+#   mysql+pymysql://keylime:keylime@keylime_db:[port]/verifier?charset=utf8
+# If database_url is not set, the default is "sqlite", using method 1, and will be
+# located at "/var/lib/keylime/cv_data.sqlite".
 database_url =
-drivername = sqlite
-username = ''
-password = ''
-host = ''
-port = ''
-database = reg_data.sqlite
-query = ''
+database_drivername = sqlite
+database_username = ''
+database_password = ''
+database_host = ''
+database_port = ''
+database_name = cv_data.sqlite
+database_query = ''
+# Limits for DB connection pool size in sqlalchemy (https://docs.sqlalchemy.org/en/14/core/pooling.html#api-documentation-available-pool-implementations)
+database_pool_sz_ovfl=5,10
 
 auto_migrate_db = True
 

--- a/keylime.conf
+++ b/keylime.conf
@@ -212,7 +212,6 @@ database_drivername = sqlite
 database_username = ''
 database_password = ''
 database_host = ''
-database_port = ''
 database_name = cv_data.sqlite
 database_query = ''
 # Limits for DB connection pool size in sqlalchemy (https://docs.sqlalchemy.org/en/14/core/pooling.html#api-documentation-available-pool-implementations)
@@ -482,7 +481,7 @@ check_client_cert = True
 # 1) A tuple of parameters (e.g., database_drivername, database_username, database_password)
 # 2) A single string in database_url. This, when set, takes precedence over the previous option.
 # An example of database_url value for using sqlite:
-#   sqlite:////var/lib/keylime/cv_data.sqlite
+#   sqlite:////var/lib/keylime/reg_data.sqlite
 # An example of database_url value for using mysql:
 #   mysql+pymysql://keylime:keylime@keylime_db:[port]/verifier?charset=utf8
 # If database_url is not set, the default is "sqlite", using method 1, and will be
@@ -492,8 +491,7 @@ database_drivername = sqlite
 database_username = ''
 database_password = ''
 database_host = ''
-database_port = ''
-database_name = cv_data.sqlite
+database_name = reg_data.sqlite
 database_query = ''
 # Limits for DB connection pool size in sqlalchemy (https://docs.sqlalchemy.org/en/14/core/pooling.html#api-documentation-available-pool-implementations)
 database_pool_sz_ovfl=5,10

--- a/keylime/db/keylime_db.py
+++ b/keylime/db/keylime_db.py
@@ -68,7 +68,7 @@ class DBEngineManager:
                 engine_args['max_overflow'] = int(m_ovfl)
 
         engine = create_engine(url, **engine_args)
-        
+
         return engine
 
 class SessionManager:

--- a/keylime/db/keylime_db.py
+++ b/keylime/db/keylime_db.py
@@ -47,16 +47,17 @@ class DBEngineManager:
 
             # This code shall be removed once we fully deprecate the old format
             try :
-                drivername = config.get(service, "drivername")
+                drivername = config.get(service, 'drivername')
+                database = config.get(service, 'database')
                 logger.warning('Deprecation reminder: please add the suffix "database_" to all database-related parameters on your keylime.conf.')
                 p_n_prefix = ''
             except NoOptionError :
                 drivername = config.get(service, 'database_drivername')
                 p_n_prefix = "database_"
+                database = config.get(service, p_n_prefix + 'name')
 
             if drivername == 'sqlite':
-                database = "%s/%s" % (config.WORK_DIR,
-                                    config.get(service, p_n_prefix + 'name'))
+                database = "%s/%s" % (config.WORK_DIR, database)
                 # Create the path to where the sqlite database will be store with a perm umask of 077
                 os.umask(0o077)
                 kl_dir = os.path.dirname(os.path.abspath(database))
@@ -78,7 +79,7 @@ class DBEngineManager:
                     username=config.get(service, p_n_prefix + 'username'),
                     password=config.get(service, p_n_prefix + 'password'),
                     host=config.get(service, p_n_prefix + 'host'),
-                    database=config.get(service, p_n_prefix + 'name')
+                    database=database
                 )
                 engine_args['pool_size'] = int(p_sz)
                 engine_args['max_overflow'] = int(m_ovfl)

--- a/keylime/db/keylime_db.py
+++ b/keylime/db/keylime_db.py
@@ -38,7 +38,7 @@ class DBEngineManager:
 
         url = config.get(service, 'database_url')
         if url:
-            logger.info('database_url is set, using it for establishing database connection')
+            logger.info('database_url is set, using it to establish database connection')
             engine_args['pool_size'] = int(p_sz)
             engine_args['max_overflow'] = int(m_ovfl)
 
@@ -49,7 +49,7 @@ class DBEngineManager:
             try :
                 drivername = config.get(service, 'drivername')
                 database = config.get(service, 'database')
-                logger.warning('Deprecation reminder: please add the suffix "database_" to all database-related parameters on your keylime.conf.')
+                logger.warning('Deprecation reminder: please add the suffix "database_" to all database-related parameters in your keylime.conf.')
                 p_n_prefix = ''
             except NoOptionError :
                 drivername = config.get(service, 'database_drivername')
@@ -57,7 +57,7 @@ class DBEngineManager:
                 database = config.get(service, p_n_prefix + 'name')
 
             if drivername == 'sqlite':
-                database = "%s/%s" % (config.WORK_DIR, database)
+                database_file = "%s/%s" % (config.WORK_DIR, database)
                 # Create the path to where the sqlite database will be store with a perm umask of 077
                 os.umask(0o077)
                 kl_dir = os.path.dirname(os.path.abspath(database))
@@ -69,7 +69,7 @@ class DBEngineManager:
                     username=None,
                     password=None,
                     host=None,
-                    database=(database)
+                    database=(database_file)
                 )
                 engine_args['connect_args'] = {'check_same_thread': False}
 


### PR DESCRIPTION
- Implements all the changes and improvements discussed at length during
  PR 514, making it obsolete.
- Add the option to specify, via `keylime.conf`, limits for database
  connection pool size. Absolutely required for large-scale deployments.