### PR TITLE
webapp: fix tls certs paths

### DIFF
--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -648,9 +648,9 @@ def get_tls_context():
 
     logger.info("Setting up client TLS in %s", tls_dir)
 
-    ca_path = "%s/%s" % (tls_dir, ca_cert)
-    my_tls_cert = "%s/%s" % (tls_dir, my_tenant_cert)
-    my_tls_priv_key = "%s/%s" % (tls_dir, my_tenant_priv_key)
+    ca_path = os.path.join(tls_dir, ca_cert)
+    my_tls_cert = os.path.join(tls_dir, my_cert)
+    my_tls_priv_key = os.path.join(tls_dir, my_priv_key)
 
     context = ssl.create_default_context()
     context.load_verify_locations(cafile=ca_path)

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -631,15 +631,11 @@ def start_tornado(tornado_server, port):
 
 def get_tls_context():
     ca_cert = config.get('tenant', 'ca_cert')
-    my_tenant_cert = config.get('tenant', 'my_cert')
-    my_tenant_priv_key = config.get('tenant', 'private_key')
 
     tls_dir = config.get('tenant', 'tls_dir')
 
     if tls_dir == 'default':
         ca_cert = 'cacert.crt'
-        my_tenant_cert = 'client-cert.crt'
-        my_tenant_priv_key = 'client-private.pem'
         tls_dir = 'cv_ca'
 
     # this is relative path, convert to absolute in WORK_DIR


### PR DESCRIPTION
`get_tls_context` search for the TLS certificates and TLS private key.
To do that uses a simple "%s/%s" to build the full path.

The problem is that if the certificates contains already the full path,
the final path will be incorrect.

This patch replace it with `os.path.join`, that respect the full path to
generate the final path.

Signed-off-by: Alberto Planas <aplanas@suse.com>