### PR TITLE
ima: Return 'None' when ImaKeyring.from_string() called with emtpy st…

### DIFF
--- a/keylime/ima_file_signatures.py
+++ b/keylime/ima_file_signatures.py
@@ -179,6 +179,9 @@ class ImaKeyring:
     @staticmethod
     def from_string(stringrepr):
         """ Convert a string-encoded ImaKeyring to an ImaKeyring object """
+        if not stringrepr:
+            return None
+
         ima_keyring = ImaKeyring()
 
         default_be = backends.default_backend()


### PR DESCRIPTION
…ring

When ImaKeyring.from_string() is called with an empty string, return None.
This fixes the following issue as encountered by the local tests:

2021-05-10 15:19:19.774 - keylime.cloudverifier - ERROR - Expecting value: line 1 column 1 (char 0)
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/keylime/cloud_verifier_tornado.py", line 591, in invoke_get_quote
    if cloud_verifier_common.process_quote_response(agent, json_response['results']):
  File "/usr/local/lib/python3.7/site-packages/keylime/cloud_verifier_common.py", line 190, in process_quote_response
    ima_keyring = ima_file_signatures.ImaKeyring.from_string(agent['ima_sign_verification_keys'])
  File "/usr/local/lib/python3.7/site-packages/keylime/ima_file_signatures.py", line 188, in from_string
    obj = json.loads(stringrepr)
  File "/usr/lib64/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>