### PR TITLE
Addresses issue #660 (database path while running local tests)

### DIFF
--- a/keylime/db/keylime_db.py
+++ b/keylime/db/keylime_db.py
@@ -60,7 +60,7 @@ class DBEngineManager:
                 database_file = "%s/%s" % (config.WORK_DIR, database)
                 # Create the path to where the sqlite database will be store with a perm umask of 077
                 os.umask(0o077)
-                kl_dir = os.path.dirname(os.path.abspath(database))
+                kl_dir = os.path.dirname(os.path.abspath(database_file))
                 if not os.path.exists(kl_dir):
                     os.makedirs(kl_dir, 0o700)
 

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -777,7 +777,7 @@ class TestRestful(unittest.TestCase):
         allowlist = {'exclude': ['*']}
         data = {
             'v': b64_v,
-            'mb_refstate': None, 
+            'mb_refstate': None,
             'cloudagent_ip': tenant_templ.cloudagent_ip,
             'cloudagent_port': tenant_templ.cloudagent_port,
             'tpm_policy': json.dumps(self.tpm_policy),

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -777,6 +777,7 @@ class TestRestful(unittest.TestCase):
         allowlist = {'exclude': ['*']}
         data = {
             'v': b64_v,
+            'mb_refstate': None, 
             'cloudagent_ip': tenant_templ.cloudagent_ip,
             'cloudagent_port': tenant_templ.cloudagent_port,
             'tpm_policy': json.dumps(self.tpm_policy),


### PR DESCRIPTION
Fix the database creation while running local tests, ensuring that the
sqlite database directory is correctly created.

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>