### PR TITLE
agent: Fix issue #667 by testing for an empty ima_sign_verification_k…

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -154,7 +154,7 @@ class Tenant():
         self.vtpm_policy = TPM_Utilities.readPolicy(vtpm_policy)
         logger.info("TPM PCR Mask from policy is %s", self.vtpm_policy['mask'])
 
-        if args.get("ima_sign_verification_keys") is not None:
+        if len(args.get("ima_sign_verification_keys")) > 0:
             # Auto-enable IMA (or-bit mask)
             self.tpm_policy['mask'] = "0x%X" % (
                     int(self.tpm_policy['mask'], 0) | (1 << config.IMA_PCR))


### PR DESCRIPTION
…eys list

In commit 3eed812 the default command line variable for collecting the IMA
signature verification keys changed from None to an empty list. We now have
to also test for an empty list when accessing the command line argument
rather than checking for 'None'.

This then fixes the following issue when no IMA measurement list verification
is to be done:

> keylime_tenant -c add -t <server> -v 127.0.0.1 \
  -u D432FBB3-D2F1-4A97-9EF7-75BD81C00000 -f ~/filetosend
2021-05-11 19:46:27.895 - keylime.tpm - INFO - TPM2-TOOLS Version: 5.0
2021-05-11 19:46:27.902 - keylime.tenant - INFO - Setting up client TLS in /var/lib/keylime/cv_ca
2021-05-11 19:46:27.903 - keylime.tenant - INFO - TPM PCR Mask from policy is 0x408000
2021-05-11 19:46:27.903 - keylime.tenant - INFO - TPM PCR Mask from policy is 0x808000
Traceback (most recent call last):
  File "/usr/lib64/python3.8/configparser.py", line 789, in get
    value = d[option]
  File "/usr/lib64/python3.8/collections/__init__.py", line 898, in __getitem__
    return self.__missing__(key)            # support subclasses that define __missing__
  File "/usr/lib64/python3.8/collections/__init__.py", line 890, in __missing__
    raise KeyError(key)
KeyError: 'ima_allowlist'

The error occurred because the IMA PCR was added to the PCRs to quote, which then
caused the access for the (missing) ima_allowlist variable in the tenant section
of /etc/keylime.conf.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>