### PR TITLE
agent: Rename allowlist to ima_allowlist in keylime.conf

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -335,7 +335,7 @@ vtpm_policy = {"23":["ffffffffffffffffffffffffffffffffffffffff","000000000000000
 # this file is used if tenant provides "default" as the allowlist file
 # this file should be in the form
 # SHA1sum path_to_file
-allowlist = allowlist.txt
+ima_allowlist = allowlist.txt
 
 # Specify a file containing paths that should be ignored by IMA.
 # WARNING: use with great caution as it will affect the security of IMA.


### PR DESCRIPTION
The keylime.conf file should have an ima_allowlist variable in the
tenant section, but it's currently called 'allowlist' therefore leading
to errors when trying to access it.

keylime/ima.py:348:        al_path = config.get('tenant', 'ima_allowlist')

This patch fixes this type of an error when using the tenant tool:

2021-05-11 19:46:27.895 - keylime.tpm - INFO - TPM2-TOOLS Version: 5.0
2021-05-11 19:46:27.902 - keylime.tenant - INFO - Setting up client TLS in /var/lib/keylime/cv_ca
2021-05-11 19:46:27.903 - keylime.tenant - INFO - TPM PCR Mask from policy is 0x408000
2021-05-11 19:46:27.903 - keylime.tenant - INFO - TPM PCR Mask from policy is 0x808000
Traceback (most recent call last):
  File "/usr/lib64/python3.8/configparser.py", line 789, in get
    value = d[option]
  File "/usr/lib64/python3.8/collections/__init__.py", line 898, in __getitem__
    return self.__missing__(key)            # support subclasses that define __missing__
  File "/usr/lib64/python3.8/collections/__init__.py", line 890, in __missing__
    raise KeyError(key)
KeyError: 'ima_allowlist'

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>