### PR TITLE
agent: Fix the usage of dmidecode during the agent startup (issue #664)

### DIFF
--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -502,8 +502,12 @@ def main():
     elif agent_uuid == 'dmidecode':
         cmd = ['dmidecode', '-s', 'system-uuid']
         ret = cmd_exec.run(cmd)
-        sys_uuid = ret['retout'].decode('utf-8')
+        sys_uuid = ret['retout'][0].decode('utf-8')
         agent_uuid = sys_uuid.strip()
+        try:
+            uuid.UUID(agent_uuid)
+        except ValueError as e:
+            raise RuntimeError("The UUID returned from dmidecode is invalid: %s" % e)  # pylint: disable=raise-missing-from
     elif agent_uuid == 'hostname':
         agent_uuid = socket.getfqdn()
     if config.STUB_VTPM and config.TPM_CANNED_VALUES is not None:


### PR DESCRIPTION
The field ret['retout'] returned from cmd_exec.run(cmd) is a list,
so we have to select the first entry of the list to get to the
value returned by dmidecode.

This patch fixes the following error as pointed out in issue #664:

Traceback (most recent call last):
File "/usr/bin/keylime_agent", line 11, in
load_entry_point('keylime==0.0.0', 'console_scripts', 'keylime_agent')()
File "/usr/lib/python3/dist-packages/keylime/cmd/agent.py", line 15, in main
keylime_agent.main()
File "/usr/lib/python3/dist-packages/keylime/keylime_agent.py", line 507, in main
sys_uuid = ret['retout'].decode('utf-8')
AttributeError: 'list' object has no attribute 'decode'

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>