### PR TITLE
config: Add optional fallback parameter to get()

### DIFF
--- a/keylime/config.py
+++ b/keylime/config.py
@@ -155,19 +155,27 @@ def get_config():
     return _CURRENT_CONFIG
 
 
-def get(section, option):
+def get(section, option, fallback=None):
+    if fallback is not None:
+        return get_config().get(section, option, fallback=fallback)
     return get_config().get(section, option)
 
 
-def getint(section, option):
+def getint(section, option, fallback=None):
+    if fallback is not None:
+        return get_config().get(section, option, fallback=fallback)
     return get_config().getint(section, option)
 
 
-def getboolean(section, option):
+def getboolean(section, option, fallback=None):
+    if fallback is not None:
+        return get_config().get(section, option, fallback=fallback)
     return get_config().getboolean(section, option)
 
 
-def getfloat(section, option):
+def getfloat(section, option, fallback=None):
+    if fallback is not None:
+        return get_config().get(section, option, fallback=fallback)
     return get_config().getfloat(section, option)
 
 


### PR DESCRIPTION
Add an optional fallback parameter with the default value to the config's
get() function and related ones like getint(). If a fallback parameter is
given we will return that fallback parameter in case the section is missing
the given option. The variant without the fallback parameter will throw
an exception in case of a missing parameter.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>