### PR TITLE
installer: Add '-r' option to cp to copy directory (issue #671)

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -576,7 +576,7 @@ echo "==========================================================================
 if [ ! -d "/var/lib/keylime/tpm_cert_store" ]; then
   echo "Creating new tpm_cert_store"
   mkdir -p /var/lib/keylime
-  cp $KEYLIME_DIR/tpm_cert_store /var/lib/keylime/tpm_cert_store
+  cp -r $KEYLIME_DIR/tpm_cert_store /var/lib/keylime/tpm_cert_store
 else
   echo "Updating existing cert store"
   cp -n $KEYLIME_DIR/tpm_cert_store/* /var/lib/keylime/tpm_cert_store/


### PR DESCRIPTION
This patch fixes the following issue described in issue #671:

```
				Check for tpm_cert_store
==================================================================================
Creating new tpm_cert_store
cp: -r not specified; omitting directory '/home/stefanb/dev/keylime/tpm_cert_store'
==================================================================================
```

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>