### PR TITLE
Incremental attestation for IMA

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -64,7 +64,7 @@ case "$ID" in
         echo "${ID} selected."
         PACKAGE_MGR=$(command -v apt-get)
         PYTHON_PREIN="git patch"
-        PYTHON_DEPS="python3 python3-pip python3-dev python3-setuptools python3-zmq python3-tornado python3-cryptography python3-simplejson python3-requests gcc g++ libssl-dev swig python3-yaml python3-gnupg wget"
+        PYTHON_DEPS="python3 python3-pip python3-dev python3-setuptools python3-zmq python3-tornado python3-cryptography python3-simplejson python3-requests python3-psutil gcc g++ libssl-dev swig python3-yaml python3-gnupg wget"
         if [ "$(uname -m)" = "x86_64" ]; then
             PYTHON_DEPS+=" libefivar-dev"
         fi
@@ -80,7 +80,7 @@ case "$ID" in
                 PACKAGE_MGR=$(command -v yum)
                 NEED_EPEL=1
                 PYTHON_PREIN="python36 python36-devel python36-setuptools python36-pip git wget patch openssl"
-                PYTHON_DEPS="gcc gcc-c++ openssl-devel swig python36-PyYAML python36-tornado python36-simplejson python36-cryptography python36-requests python36-zmq yaml-cpp-devel"
+                PYTHON_DEPS="gcc gcc-c++ openssl-devel swig python36-PyYAML python36-tornado python36-simplejson python36-cryptography python36-requests python36-zmq yaml-cpp-devel python3-psutil"
                 if [ "$(uname -m)" = "x86_64" ]; then
                     PYTHON_DEPS+=" efivar-libs"
                 fi
@@ -93,7 +93,7 @@ case "$ID" in
                 PACKAGE_MGR=$(command -v dnf)
                 NEED_EPEL=1
                 PYTHON_PREIN="python3 python3-devel python3-setuptools python3-pip"
-                PYTHON_DEPS="gcc gcc-c++ openssl-devel python3-yaml python3-requests swig python3-cryptography wget git python3-tornado python3-zmq python3-simplejson python3-gnupg"
+                PYTHON_DEPS="gcc gcc-c++ openssl-devel python3-yaml python3-requests swig python3-cryptography wget git python3-tornado python3-zmq python3-simplejson python3-gnupg python3-psutil"
                 if [ "$(uname -m)" = "x86_64" ]; then
                     PYTHON_DEPS+=" efivar-libs"
                 fi
@@ -113,7 +113,7 @@ case "$ID" in
         echo "${ID} selected."
         PACKAGE_MGR=$(command -v dnf)
         PYTHON_PREIN="python3 python3-devel python3-setuptools git wget patch"
-        PYTHON_DEPS="python3-pip gcc gcc-c++ openssl-devel swig python3-pyyaml python3-m2crypto  python3-zmq python3-cryptography python3-tornado python3-simplejson python3-requests python3-gnupg yaml-cpp-devel procps-ng"
+        PYTHON_DEPS="python3-pip gcc gcc-c++ openssl-devel swig python3-pyyaml python3-m2crypto  python3-zmq python3-cryptography python3-tornado python3-simplejson python3-requests python3-gnupg yaml-cpp-devel procps-ng python3-psutil"
         if [ "$(uname -m)" = "x86_64" ]; then
             PYTHON_DEPS+=" efivar-devel"
         fi

--- a/keylime/agentstates.py
+++ b/keylime/agentstates.py
@@ -39,6 +39,7 @@ class AgentAttestState():
 
         self.agent_id = agent_id
         self.next_ima_ml_entry = 0
+        self.set_boottime(0)
 
         self.tpm_state = TPMState()
         self.ima_pcrs = set()
@@ -54,6 +55,7 @@ class AgentAttestState():
         self.next_ima_ml_entry = 0
         for pcr_num in self.ima_pcrs:
             self.tpm_state.reset_pcr(pcr_num)
+        self.set_boottime(0)
 
     def update_ima_attestation(self, pcr_num, pcr_value, num_ml_entries):
         """ Update the attestation by remembering the new PCR value and the
@@ -70,6 +72,17 @@ class AgentAttestState():
         """ Return the PCR state of the given PCR """
         return self.tpm_state.get_pcr(pcr_num)
 
+    def get_boottime(self):
+        """ Return the boottime of the system """
+        return self.boottime
+
+    def set_boottime(self, boottime):
+        """ Set the boottime of the system """
+        self.boottime = boottime
+
+    def is_expected_boottime(self, boottime):
+        """ Check whether the given boottime is the expected boottime """
+        return self.boottime == boottime
 
 class AgentAttestStates():
     """ AgentAttestStates administers a map of AgentAttestState's indexed by agent_id """

--- a/keylime/agentstates.py
+++ b/keylime/agentstates.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2021 IBM Corporation
+'''
+
+import threading
+
+class AgentAttestState():
+    """ AgentAttestState is used to support incremental attestation """
+    def __init__(self, agent_id):
+        """ constructor """
+        self.agent_id = agent_id
+
+    def get_agent_id(self):
+        """ Get the agent_id """
+        return self.agent_id
+
+
+class AgentAttestStates():
+    """ AgentAttestStates administers a map of AgentAttestState's indexed by agent_id """
+    instance = None
+    @staticmethod
+    def get_instance():
+        """ Create and return a singleton AgentAttestState """
+        if not AgentAttestStates.instance:
+            AgentAttestStates.instance = AgentAttestStates()
+        return AgentAttestStates.instance
+
+    def __init__(self):
+        """ constructor """
+        self.map_lock = threading.Lock()
+        self.map = {}
+
+    def get_by_agent_id(self, agent_id):
+        """ Get an agent's state given its id """
+
+        self.map_lock.acquire()
+        agentAttestState = self.map.get(agent_id)
+        if not agentAttestState:
+            agentAttestState = AgentAttestState(agent_id)
+            self.map[agent_id] = agentAttestState
+        self.map_lock.release()
+
+        return agentAttestState
+
+    def delete_by_agent_id(self, agent_id):
+        """ Delete an agent's state given its id """
+
+        self.map_lock.acquire()
+        try:
+            del self.map[agent_id]
+        except KeyError:
+            pass
+        self.map_lock.release()

--- a/keylime/agentstates.py
+++ b/keylime/agentstates.py
@@ -27,6 +27,10 @@ class TPMState():
         """ Get the state of a PCR """
         return self.pcrs[pcr_num]
 
+    def set_pcr(self, pcr_num, pcr_value):
+        """ Set the value of a PCR """
+        self.pcrs[pcr_num] = pcr_value
+
 
 class AgentAttestState():
     """ AgentAttestState is used to support incremental attestation """
@@ -50,6 +54,13 @@ class AgentAttestState():
         self.next_ima_ml_entry = 0
         for pcr_num in self.ima_pcrs:
             self.tpm_state.reset_pcr(pcr_num)
+
+    def update_ima_attestation(self, pcr_num, pcr_value, num_ml_entries):
+        """ Update the attestation by remembering the new PCR value and the
+            number of lines that were successfully processed. """
+        self.ima_pcrs.add(pcr_num)
+        self.tpm_state.set_pcr(pcr_num, pcr_value)
+        self.next_ima_ml_entry += num_ml_entries
 
     def get_next_ima_ml_entry(self):
         """ Return the next IMA measurement list entry we want to request from agent """

--- a/keylime/agentstates.py
+++ b/keylime/agentstates.py
@@ -64,6 +64,13 @@ class AgentAttestState():
         self.tpm_state.set_pcr(pcr_num, pcr_value)
         self.next_ima_ml_entry += num_ml_entries
 
+    def get_ima_pcrs(self):
+        """ Return a dict with the IMA pcrs """
+        ima_pcrs_dict = {}
+        for pcr_num in self.ima_pcrs:
+            ima_pcrs_dict[pcr_num] = self.tpm_state.get_pcr(pcr_num)
+        return ima_pcrs_dict
+
     def get_next_ima_ml_entry(self):
         """ Return the next IMA measurement list entry we want to request from agent """
         return self.next_ima_ml_entry

--- a/keylime/agentstates.py
+++ b/keylime/agentstates.py
@@ -11,10 +11,21 @@ class AgentAttestState():
     def __init__(self, agent_id):
         """ constructor """
         self.agent_id = agent_id
+        self.next_ima_ml_entry = 0
+
+        self.reset_ima_attestation()
 
     def get_agent_id(self):
         """ Get the agent_id """
         return self.agent_id
+
+    def reset_ima_attestation(self):
+        """ Reset the IMA attestation state to start over with 1st entry """
+        self.next_ima_ml_entry = 0
+
+    def get_next_ima_ml_entry(self):
+        """ Return the next IMA measurement list entry we want to request from agent """
+        return self.next_ima_ml_entry
 
 
 class AgentAttestStates():

--- a/keylime/agentstates.py
+++ b/keylime/agentstates.py
@@ -71,9 +71,19 @@ class AgentAttestState():
             ima_pcrs_dict[pcr_num] = self.tpm_state.get_pcr(pcr_num)
         return ima_pcrs_dict
 
+    def set_ima_pcrs(self, ima_pcrs_dict):
+        """ Set the values of the given ima_pcrs dict in the tpm_state """
+        for pcr_num, pcr_value in ima_pcrs_dict.items():
+            self.tpm_state.set_pcr(pcr_num, pcr_value)
+        self.ima_pcrs = set(ima_pcrs_dict.keys())
+
     def get_next_ima_ml_entry(self):
         """ Return the next IMA measurement list entry we want to request from agent """
         return self.next_ima_ml_entry
+
+    def set_next_ima_ml_entry(self, next_ima_ml_entry):
+        """ Set the value of the next_ima_ml_entry field """
+        self.next_ima_ml_entry = next_ima_ml_entry
 
     def get_pcr_state(self, pcr_num):
         """ Return the PCR state of the given PCR """
@@ -127,3 +137,10 @@ class AgentAttestStates():
         except KeyError:
             pass
         self.map_lock.release()
+
+    def add(self, agent_id, boottime, ima_pcrs_dict, next_ima_ml_entry):
+        """ Add or replace an existing AgentAttestState initialized with the given values """
+        agentAttestState = self.get_by_agent_id(agent_id)
+        agentAttestState.set_boottime(boottime)
+        agentAttestState.set_ima_pcrs(ima_pcrs_dict)
+        agentAttestState.set_next_ima_ml_entry(next_ima_ml_entry)

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -139,15 +139,20 @@ def process_quote_response(agent, json_response):
         quote = json_response["quote"]
 
         ima_measurement_list = json_response.get("ima_measurement_list", None)
+        ima_measurement_list_entry = json_response.get("ima_measurement_list_entry", 0)
         mb_measurement_list = json_response.get("mb_measurement_list", None)
 
         logger.debug("received quote:      %s", quote)
         logger.debug("for nonce:           %s", agent['nonce'])
         logger.debug("received public key: %s", received_public_key)
         logger.debug("received ima_measurement_list    %s", (ima_measurement_list is not None))
+        logger.debug("received ima_measurement_list_entry: %d", ima_measurement_list_entry)
         logger.debug("received boot log    %s", (mb_measurement_list is not None))
     except Exception:
         return None
+
+    if not isinstance(ima_measurement_list_entry, int):
+        raise Exception("ima_measurement_list_entry parameter must be an integer")
 
     # if no public key provided, then ensure we have cached it
     if received_public_key is None:
@@ -257,6 +262,7 @@ def prepare_get_quote(agent):
         'nonce': agent['nonce'],
         'mask': tpm_policy['mask'],
         'vmask': vtpm_policy['mask'],
+        'ima_ml_entry': 0,
     }
     return params
 

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -200,6 +200,16 @@ def process_quote_response(agent, json_response, agentAttestState):
         raise Exception(
             "TPM Quote is using an unaccepted signing algorithm: %s" % sign_alg)
 
+    if ima_measurement_list_entry == 0:
+        agentAttestState.reset_ima_attestation()
+    elif ima_measurement_list_entry != agentAttestState.get_next_ima_ml_entry():
+        # If we requested a particular entry number then the agent must return either
+        # starting at 0 (handled above) or with the requested number.
+        raise Exception(
+            "Agent did not respond with requested next IMA measurement list entry %d but started at %d" %
+            (agentAttestState.get_next_ima_ml_entry(), ima_measurement_list_entry))
+
+
     ima_keyring = ima_file_signatures.ImaKeyring.from_string(agent['ima_sign_verification_keys'])
     validQuote = get_tpm_instance().check_quote(
         agentAttestState,

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -667,8 +667,8 @@ async def invoke_get_quote(agent, need_pubkey):
 
     version = keylime_api_version.current_version()
     res = tornado_requests.request("GET",
-                                   "http://%s:%d/v%s/quotes/integrity?nonce=%s&mask=%s&vmask=%s&partial=%s" %
-                                   (agent['ip'], agent['port'], version, params["nonce"], params["mask"], params['vmask'], partial_req), context=None)
+                                   "http://%s:%d/v%s/quotes/integrity?nonce=%s&mask=%s&vmask=%s&partial=%s&ima_ml_entry=%d" %
+                                   (agent['ip'], agent['port'], version, params["nonce"], params["mask"], params['vmask'], partial_req, params['ima_ml_entry']), context=None)
     response = await res
 
     if response.status_code != 200:

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -26,6 +26,7 @@ from keylime import cloud_verifier_common
 from keylime import revocation_notifier
 from keylime import tornado_requests
 from keylime import api_version as keylime_api_version
+from keylime.ima_ast import START_HASH
 
 logger = keylime_logging.init_logging('cloudverifier')
 
@@ -77,7 +78,11 @@ def _from_db_obj(agent_db_obj):
                 'accept_tpm_signing_algs', \
                 'hash_alg', \
                 'enc_alg', \
-                'sign_alg']
+                'sign_alg', \
+                'boottime', \
+                'ima_pcrs', \
+                'pcr10', \
+                'next_ima_ml_entry']
     agent_dict = {}
     for field in fields:
         agent_dict[field] = getattr(agent_db_obj, field, None)
@@ -377,6 +382,10 @@ class AgentsHandler(BaseHandler):
                     agent_data['enc_alg'] = ""
                     agent_data['sign_alg'] = ""
                     agent_data['agent_id'] = agent_id
+                    agent_data['boottime'] = 0
+                    agent_data['ima_pcrs'] = []
+                    agent_data['pcr10'] = START_HASH
+                    agent_data['next_ima_ml_entry'] = 0
                     agent_data['verifier_id'] = config.get('cloud_verifier', 'cloudverifier_id', cloud_verifier_common.DEFAULT_VERIFIER_ID)
                     agent_data['verifier_ip'] = config.get('cloud_verifier', 'cloudverifier_ip')
                     agent_data['verifier_port'] = config.get('cloud_verifier', 'cloudverifier_port')

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -6,7 +6,7 @@ Copyright 2020 Luke Hinds (lhinds@redhat.com), Red Hat, Inc.
 import simplejson as json
 
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, String, Integer, PickleType, Text
+from sqlalchemy import Column, String, Integer, PickleType, Text, LargeBinary
 from sqlalchemy import schema
 
 
@@ -42,6 +42,10 @@ class VerfierMain(Base):
     hash_alg = Column(String(10))
     enc_alg = Column(String(10))
     sign_alg = Column(String(10))
+    boottime = Column(Integer)
+    ima_pcrs = Column(JSONPickleType(pickler=json))
+    pcr10 = Column(LargeBinary)
+    next_ima_ml_entry = Column(Integer)
 
 
 class VerifierAllowlist(Base):

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -166,7 +166,7 @@ def process_measurement_list(agentAttestState, lines, lists=None, m2w=None, pcrv
          }
     )
 
-    for line in lines:
+    for linenum, line in enumerate(lines):
         line = line.strip()
         if line == '':
             continue
@@ -183,6 +183,8 @@ def process_measurement_list(agentAttestState, lines, lists=None, m2w=None, pcrv
             if not found_pcr:
                 # End of list should equal pcr value
                 found_pcr = (running_hash == pcrval_bytes)
+                if found_pcr:
+                    logger.debug('Found match at linenum %s' % (linenum + 1))
 
             # Keep old functionality for writing the parsed files with hashes into a file
             if m2w is not None and (type(entry.mode) in [ima_ast.Ima, ima_ast.ImaNg, ima_ast.ImaSig]):

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -127,7 +127,7 @@ def _validate_ima_sig(exclude_regex, ima_keyring, allowlist, digest: ima_ast.Dig
     return valid_signature
 
 
-def process_measurement_list(agentAttestState, lines, lists=None, m2w=None, pcrval=None, ima_keyring=None, boot_aggregates=None):
+def _process_measurement_list(agentAttestState, lines, lists=None, m2w=None, pcrval=None, ima_keyring=None, boot_aggregates=None):
     running_hash = agentAttestState.get_pcr_state(config.IMA_PCR)
     found_pcr = (pcrval is None)
     errors = {}
@@ -207,6 +207,19 @@ def process_measurement_list(agentAttestState, lines, lists=None, m2w=None, pcrv
         return None
 
     return codecs.encode(running_hash, 'hex').decode('utf-8')
+
+
+def process_measurement_list(agentAttestState, lines, lists=None, m2w=None, pcrval=None, ima_keyring=None, boot_aggregates=None):
+    result = None
+    try:
+        result = _process_measurement_list(agentAttestState, lines, lists=lists, m2w=m2w, pcrval=pcrval, ima_keyring=ima_keyring, boot_aggregates=boot_aggregates)
+    except:  # pylint: disable=try-except-raise
+        raise
+    finally:
+        if not result:
+            agentAttestState.reset_ima_attestation()
+
+    return result
 
 
 def process_allowlists(allowlist, exclude):

--- a/keylime/ima_test.py
+++ b/keylime/ima_test.py
@@ -1,0 +1,41 @@
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2021 IBM Corporation
+'''
+
+import tempfile
+import unittest
+
+from keylime import ima
+
+class TestIMA(unittest.TestCase):
+
+    def test_read_measurement_list(self):
+        filedata = '0-entry\n1-entry\n2-entry\n'
+        tf = tempfile.NamedTemporaryFile(delete=True)
+        tf.write(filedata.encode('utf-8'))
+        tf.flush()
+
+        # Request the 2nd entry, which is available
+        ml, nth_entry, num_entries = ima.read_measurement_list(tf.name, 2)
+        self.assertEqual(num_entries, 3)
+        self.assertEqual(nth_entry, 2)
+        self.assertTrue(ml.startswith('2-entry'))
+
+        # Request the 3rd entry, which is not available yet, thus we get an empty list
+        ml, nth_entry, num_entries = ima.read_measurement_list(tf.name, 3)
+        self.assertEqual(num_entries, 3)
+        self.assertEqual(nth_entry, 3)
+        self.assertTrue(ml == '')
+
+        # Request the 4th entry, which is beyond the next entry; since this is wrong,
+        # we expect the entire list now.
+        ml, nth_entry, num_entries = ima.read_measurement_list(tf.name, 4)
+        self.assertEqual(num_entries, 3)
+        self.assertEqual(nth_entry, 0)
+        self.assertTrue(ml.startswith('0-entry'))
+
+        tf.close()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -23,6 +23,7 @@ import io
 import importlib
 import shutil
 import subprocess
+import psutil
 
 import simplejson as json
 
@@ -144,6 +145,8 @@ class Handler(BaseHTTPRequestHandler):
                     'sign_alg': sign_alg,
                     'pubkey': self.server.rsapublickey_exportable,
                 }
+
+            response['boottime'] = self.server.boottime
 
             # return a measurement list if available
             if TPM_Utilities.check_mask(imaMask, config.IMA_PCR):
@@ -353,6 +356,7 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
     final_U = None
     agent_uuid = None
     next_ima_ml_entry = 0 # The next IMA log offset the verifier may ask for.
+    boottime = int(psutil.boot_time())
 
     def __init__(self, server_address, RequestHandlerClass, agent_uuid):
         """Constructor overridden to provide ability to pass configuration arguments to the server"""

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -30,6 +30,7 @@ from keylime import config
 from keylime import keylime_logging
 from keylime import cmd_exec
 from keylime import crypto
+from keylime import ima
 from keylime import openstack
 from keylime import revocation_notifier
 from keylime import registrar_client
@@ -142,11 +143,8 @@ class Handler(BaseHTTPRequestHandler):
 
             # return a measurement list if available
             if TPM_Utilities.check_mask(imaMask, config.IMA_PCR):
-                if not os.path.exists(config.IMA_ML):
-                    logger.warning("IMA measurement list not available: %s", config.IMA_ML)
-                else:
-                    with open(config.IMA_ML, 'r') as f:
-                        ml = f.read()
+                ml, _, filesize = ima.read_measurement_list(config.IMA_ML, 0)
+                if filesize > 0:
                     response['ima_measurement_list'] = ml
 
             # similar to how IMA log retrievals are triggered by IMA_PCR, we trigger boot logs with MEASUREDBOOT_PCRs

--- a/keylime/migrations/versions/7d5db1a6ffb0_add_agentstates_columns.py
+++ b/keylime/migrations/versions/7d5db1a6ffb0_add_agentstates_columns.py
@@ -1,0 +1,50 @@
+"""Add agentstates columns
+
+Revision ID: 7d5db1a6ffb0
+Revises: f82c4252bc4f
+Create Date: 2021-07-16 10:31:26.693430
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+import keylime
+
+
+# revision identifiers, used by Alembic.
+revision = '7d5db1a6ffb0'
+down_revision = 'f82c4252bc4f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+    op.add_column('verifiermain', sa.Column('boottime', sa.Integer(), nullable=True))
+    op.add_column('verifiermain', sa.Column('ima_pcrs', keylime.db.verifier_db.JSONPickleType(), nullable=True))
+    op.add_column('verifiermain', sa.Column('pcr10', sa.LargeBinary(), nullable=True))
+    op.add_column('verifiermain', sa.Column('next_ima_ml_entry', sa.Integer(), nullable=True))
+
+def downgrade_cloud_verifier():
+    op.drop_column('verifiermain', 'boottime')
+    op.drop_column('verifiermain', 'ima_pcrs')
+    op.drop_column('verifiermain', 'pcr10')
+    op.drop_column('verifiermain', 'next_ima_ml_entry')

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -21,6 +21,7 @@ import requests
 
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 
+from keylime.agentstates import AgentAttestState
 from keylime.requests_client import RequestsClient
 from keylime.common import states
 from keylime import config
@@ -503,7 +504,7 @@ class Tenant():
             logger.warning("AIK not found in registrar, quote not validated")
             return False
 
-        if not self.tpm_instance.check_quote(self.agent_uuid, self.nonce, public_key, quote, reg_data['aik_tpm'], hash_alg=hash_alg):
+        if not self.tpm_instance.check_quote(AgentAttestState(self.agent_uuid), self.nonce, public_key, quote, reg_data['aik_tpm'], hash_alg=hash_alg):
             if reg_data['regcount'] > 1:
                 logger.error("WARNING: This UUID had more than one ek-ekcert registered to it! This might indicate that your system is misconfigured or a malicious host is present. Run 'regdelete' for this agent and restart")
                 sys.exit()

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -208,7 +208,7 @@ class AbstractTPM(metaclass=ABCMeta):
         logger.info("Checking IMA measurement list on agent: %s", agentAttestState.get_agent_id())
         if config.STUB_IMA:
             pcrval = None
-        ex_value = ima.process_measurement_list(ima_measurement_list.split('\n'), allowlist, pcrval=pcrval, ima_keyring=ima_keyring, boot_aggregates=boot_aggregates)
+        ex_value = ima.process_measurement_list(agentAttestState, ima_measurement_list.split('\n'), allowlist, pcrval=pcrval, ima_keyring=ima_keyring, boot_aggregates=boot_aggregates)
         if ex_value is None:
             return False
 

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -1071,7 +1071,7 @@ class tpm(tpm_abstract.AbstractTPM):
 
         return retout, True
 
-    def check_quote(self, agent_id, nonce, data, quote, aikTpmFromRegistrar, tpm_policy={}, ima_measurement_list=None, allowlist={}, hash_alg=None, ima_keyring=None, mb_measurement_list=None, mb_refstate=None):
+    def check_quote(self, agentAttestState, nonce, data, quote, aikTpmFromRegistrar, tpm_policy={}, ima_measurement_list=None, allowlist={}, hash_alg=None, ima_keyring=None, mb_measurement_list=None, mb_refstate=None):
         if hash_alg is None:
             hash_alg = self.defaults['hash']
 
@@ -1097,7 +1097,7 @@ class tpm(tpm_abstract.AbstractTPM):
         if len(pcrs) == 0:
             pcrs = None
 
-        return self.check_pcrs(agent_id, tpm_policy, pcrs, data, False, ima_measurement_list, allowlist, ima_keyring, mb_measurement_list, mb_refstate)
+        return self.check_pcrs(agentAttestState, tpm_policy, pcrs, data, False, ima_measurement_list, allowlist, ima_keyring, mb_measurement_list, mb_refstate)
 
     def sim_extend(self, hashval_1, hashval_0=None):
         # simulate extending a PCR value by performing TPM-specific extend procedure

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ sqlalchemy>=1.3 # MIT
 alembic>=1.1.0 # MIT
 python-gnupg>=0.4.6 # BSD
 packaging>=16.0 #BSD
+psutil>=5.4.2 # BSD

--- a/scripts/postgres_tables/verifiermain.sql
+++ b/scripts/postgres_tables/verifiermain.sql
@@ -42,7 +42,11 @@ CREATE TABLE public.verifiermain (
     accept_tpm_signing_algs text,
     hash_alg character varying,
     enc_alg character varying,
-    sign_alg character varying
+    sign_alg character varying,
+    boottime integer,
+    ima_pcrs character varying,
+    pcr10 bytea,
+    next_ima_ml_entry integer,
 );
 
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -10,15 +10,6 @@ alias python='/usr/bin/python3'
 # Find Keylime directory. It's one directory above the location of this script
 KEYLIME_DIR=$(realpath "$(dirname "$(readlink -f "$0")")/../")
 
-# Run separate unit tests
-pushd "${KEYLIME_DIR}"
-python3 -m unittest discover -s keylime -p '*_test.py' -v
-if [ $? -ne 0 ]; then
-	echo "Error: One or more unit tests failed."
-	exit 1
-fi
-popd
-
 # Get list of tests in the test directory
 TEST_LIST=`ls | grep "^test_.*\.py$"`
 
@@ -180,6 +171,16 @@ echo $'\t\t\tInstalling Keylime'
 echo "=================================================================================="
 cd $KEYLIME_DIR
 python3 -m pip install . -r requirements.txt
+
+echo "=================================================================================="
+echo $'\t\t\tRunning Unit Tests'
+echo "=================================================================================="
+# Run separate unit tests
+python3 -m unittest discover -s keylime -p '*_test.py' -v
+if [ $? -ne 0 ]; then
+	echo "Error: Unit tests failed"
+	exit 1
+fi
 
 # Run the tests as necessary
 if [[ "$COVERAGE" -eq "1" ]] ; then

--- a/test/test-requirements.txt
+++ b/test/test-requirements.txt
@@ -5,3 +5,4 @@ pyaml==18.11.0
 pyyaml>=4.2b1
 pytest-asyncio==0.10.0
 simplejson==3.16.0
+psutil>=5.4.2


### PR DESCRIPTION
This PR introduces incremental attestation for IMA by having the verifier maintain state about the last-requested measurement list entry and the state of the 'running hash' for PCR 10 at the last invocation for each agent separately.

We introduce a new parameter 'ima_ml_entry' in the agent's `quote/integrity` API so that the verifier can request the IMA measurement list at a certain entry number, starting with '0' (zero). An old agent will not look at this parameter and will just return the whole IMA measurement list and a new one may return it from that offset unless it was restarted or the request from the verifier is far beyond the number of measurement list entries (due to reboot maybe). A new agent will also return the indicator of the first measurement list entry it returns and and old agent won't respond with any such parameter. The verifier will assume that the whole list was returned by an old agent then (missing parameter) and otherwise work with the entry number that the agent return, which better be the requested number since otherwise the agent will fail attestation.

This series assumes affinity to an instance of a verifier since all state is maintained in memory only and the verifier initiates the request for the quotes. A restarting verifier will therefore request the entire IMA measurement log from all agents, which is as expensive as it is now, but then only request the new IMA measurement log entries afterwards, which should make the verifier by far less busy than it could be now. In fact, in most cases it will be more or less idle since it will not receive any new measurement log entries but only compare the last known PCR 10 state against the one reported by the agent.
