### PR TITLE
Increase flexibilty of IMA entry parsing and validation

### DIFF
--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -11,192 +11,87 @@ import os
 import re
 import json
 import datetime
+import functools
 
 from keylime import config
 from keylime import gpg
 from keylime import keylime_logging
+from keylime import ima_ast
+
 
 logger = keylime_logging.init_logging('ima')
 
-#         m = ima_measure_re.match(measure_line)
-#         measure  = m.group('file_hash')
-#         filename = m.group('file_path')
-
-START_HASH = (codecs.decode('0000000000000000000000000000000000000000', 'hex'))
-FF_HASH = (codecs.decode('ffffffffffffffffffffffffffffffffffffffff', 'hex'))
 
 # The version of the allowlist format that is supported by this keylime release
 ALLOWLIST_CURRENT_VERSION = 1
-
-
-# struct event {
-#     struct {
-#         u_int32_t pcr;
-#         u_int8_t digest[SHA_DIGEST_LENGTH];
-#         u_int32_t name_len;
-#     } header;
-#     char name[TCG_EVENT_NAME_LEN_MAX + 1];
-#     struct ima_template_desc *template_desc; /* template descriptor */
-#     u_int32_t template_data_len;
-#     u_int8_t *template_data;    /* template related data */
-# };
 
 
 def read_unpack(fd, fmt):
     return struct.unpack(fmt, fd.read(struct.calcsize(fmt)))
 
 
-TCG_EVENT_NAME_LEN_MAX = 255
-SHA_DIGEST_LEN = 20
+def _validate_ima_ng(exclude_regex, allowlist, digest: ima_ast.Digest, path: ima_ast.Name):
+    if allowlist is not None:
+        if exclude_regex is not None and exclude_regex.match(path.name):
+            logger.debug("IMA: ignoring excluded path %s" % path)
+            return True
 
-defined_templates = {
-    'ima': 'd|n',
-    'ima-ng': 'd-ng|n-ng',
-    'ima-sig': 'd-ng|n-ng|sig;',
-}
+        accept_list = allowlist.get(path.name, None)
+        if accept_list is None:
+            logger.warning("File not found in allowlist: %s" % (path.name))
+            return False
 
+        if codecs.encode(digest.hash, 'hex').decode('utf-8') not in accept_list:
+            logger.warning("Hashes for file %s don't match %s not in %s" %
+                           (path.name,
+                            codecs.encode(digest.hash, 'hex').decode('utf-8'),
+                            accept_list))
+            return False
 
-def ima_eventname_parse():
-    pass
-
-
-def ima_eventdigest_ng_parse():
-    pass
-
-
-def ima_eventname_ng_parse():
-    pass
-
-
-def ima_eventsig_parse():
-    pass
+    return True
 
 
-supported_fields = {
-    "n": ima_eventname_parse,
-    "d-ng": ima_eventdigest_ng_parse,
-    "n-ng": ima_eventname_ng_parse,
-    "sig": ima_eventsig_parse,
-}
+def _validate_ima_sig(exclude_regex, ima_keyring, allowlist, digest: ima_ast.Digest, path: ima_ast.Name,
+                      signature: ima_ast.Signature):
+    valid_signature = False
+    if ima_keyring and signature:
 
+        if exclude_regex is not None and exclude_regex.match(path):
+            logger.debug(f"IMA: ignoring excluded path {path.name}")
+            return True
 
-def _extract_from_ima(tokens, template_hash):
-    """ Extract filedata_hash & path form 'ima' entry; return 1 in case error occurred """
-    filedata_hash = codecs.decode(tokens[3], "hex")
-    path = str(tokens[4])
+        if not ima_keyring.integrity_digsig_verify(signature.data, digest.hash, digest.algorithm):
+            logger.warning(f"signature for file {path.name} is not valid")
+            return False
 
-    # this is some IMA weirdness
-    if template_hash == START_HASH:
-        return filedata_hash, path, 0
+        valid_signature = True
+        logger.debug("signature for file %s is good" % path)
 
-    # verify template hash. yep this is terrible
-    # name needs to be null padded out to MAX len. +1 is for the null terminator of the string itself
-    fmt = "<%ds%ds%ds" % (len(filedata_hash), len(path), TCG_EVENT_NAME_LEN_MAX - len(path) + 1)
-    tohash = struct.pack(fmt,
-                         filedata_hash, path.encode("utf-8"),
-                         bytearray(TCG_EVENT_NAME_LEN_MAX - len(path) + 1))
-    expected_template_hash = hashlib.sha1(tohash).digest()
+    # If there is also a allowlist verify the file against that.
+    # This happens in the case that no signature or keyring this given or the signature is valid.
+    if allowlist is not None:
+        # We use the normal ima_ng validator to validate hash
+        return _validate_ima_ng(exclude_regex, allowlist, digest, path)
 
-    if expected_template_hash != template_hash:
-        error = 1
-        logger.warning("template hash for file %s does not match %s != %s" %
-                       (path,
-                        codecs.encode(expected_template_hash, 'hex').decode('utf-8'),
-                        codecs.encode(template_hash, 'hex').decode('utf-8')))
-    else:
-        error = 0
+    # If we don't have a allowlist and don't have a keyring we just ignore the validation.
+    if ima_keyring is None:
+        return True
 
-    return filedata_hash, path, error
-
-
-def _extract_from_ima_ng(tokens, template_hash):
-    """ Extract filedata_hash & path form 'ima-ng' entry; return 1 in case error occurred """
-    filedata = tokens[3]
-    ftokens = filedata.split(":")
-    filedata_hash = codecs.decode(ftokens[1], 'hex')
-    path = str(tokens[4])
-
-    # this is some IMA weirdness
-    if template_hash == START_HASH:
-        return filedata_hash, path, 0
-
-    filedata_algo = str(ftokens[0])
-    # verify template hash. yep this is terrible
-    fmt = "<I%dsBB%dsI%dsB" % (len(filedata_algo), len(filedata_hash), len(path))
-    # +2 for the : and the null terminator, and +1 on path for null terminator
-    tohash = struct.pack(fmt,
-                         len(filedata_hash) + len(filedata_algo) + 2,
-                         filedata_algo.encode('utf-8'), ord(':'), ord('\0'),
-                         filedata_hash,
-                         len(path) + 1,
-                         path.encode("utf-8"),
-                         ord('\0'))
-    expected_template_hash = hashlib.sha1(tohash).digest()
-
-    if expected_template_hash != template_hash:
-        error = 1
-        logger.warning("template hash for file %s does not match %s != %s" %
-                       (path,
-                        codecs.encode(expected_template_hash, 'hex').decode('utf-8'),
-                        codecs.encode(template_hash, 'hex').decode('utf-8')))
-    else:
-        error = 0
-
-    return filedata_hash, path, error
-
-
-def _extract_from_ima_sig(tokens, template_hash):
-    """ Extract filedata_hash & path form 'ima-sig' entry; return 1 in case error occurred """
-    filedata = tokens[3]
-    ftokens = filedata.split(":")
-    filedata_hash = codecs.decode(ftokens[1], 'hex')
-    path = str(tokens[4])
-
-    # this is some IMA weirdness
-    if template_hash == START_HASH:
-        return filedata_hash, path, None, None, 0
-
-    filedata_algo = str(ftokens[0])
-    # verify template hash. yep this is terrible
-    fmt = "<I%dsBB%dsI%dsB" % (len(filedata_algo), len(filedata_hash), len(path))
-    # +2 for the : and the null terminator, and +1 on path for null terminator
-    tohash = struct.pack(fmt,
-                         len(filedata_hash) + len(filedata_algo) + 2,
-                         filedata_algo.encode('utf-8'), ord(':'), ord('\0'),
-                         filedata_hash,
-                         len(path) + 1,
-                         path.encode("utf-8"),
-                         ord('\0'))
-    signature = b''
-    if len(tokens) == 6:
-        signature = codecs.decode(tokens[5], 'hex')
-    tohash += struct.pack("<I%ds" % len(signature), len(signature), signature)
-    expected_template_hash = hashlib.sha1(tohash).digest()
-
-    if expected_template_hash != template_hash:
-        error = 1
-        logger.warning("template hash for file %s does not match %s != %s" %
-                       (path,
-                        codecs.encode(expected_template_hash, 'hex').decode('utf-8'),
-                        codecs.encode(template_hash, 'hex').decode('utf-8')))
-    else:
-        error = 0
-
-    return filedata_hash, path, signature, filedata_algo, error
+    return valid_signature
 
 
 def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyring=None):
-    errs = [0, 0, 0, 0, 0]
-    runninghash = START_HASH
+    running_hash = ima_ast.START_HASH
     found_pcr = (pcrval is None)
+    errors = {}
 
     if lists is not None:
         if isinstance(lists, str):
             lists = ast.literal_eval(lists)
-        allowlist = lists['allowlist']
+        allow_list = lists['allowlist']
         exclude_list = lists['exclude']
     else:
-        allowlist = None
+        allow_list = None
         exclude_list = None
 
     is_valid, compiled_regex, err_msg = config.valid_exclude_list(exclude_list)
@@ -206,118 +101,52 @@ def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyri
         err_msg += " Exclude list will be ignored."
         logger.error(err_msg)
 
+    ima_validator = ima_ast.Validator(
+        {ima_ast.ImaSig: functools.partial(_validate_ima_sig, compiled_regex, ima_keyring, allow_list),
+         ima_ast.ImaNg: functools.partial(_validate_ima_ng, compiled_regex, allow_list),
+         ima_ast.Ima: functools.partial(_validate_ima_ng, compiled_regex, allow_list)
+         }
+    )
+
     for line in lines:
         line = line.strip()
         if line == '':
             continue
 
-        tokens = line.split(None, 5)
-        if len(tokens) < 5 or len(tokens) > 6:
-            logger.error("invalid measurement list file line: -%s-" % (line))
-            return None
+        try:
+            entry = ima_ast.Entry(line, ima_validator)
 
-        # print tokens
-        # pcr = tokens[0]
-        template_hash = codecs.decode(tokens[1], 'hex')
-        mode = tokens[2]
-        signature = None
-        filedata_algo = None
+            # update hash
+            running_hash = hashlib.sha1(running_hash + entry.template_hash).digest()
 
-        if mode == "ima-ng":
-            filedata_hash, path, error = _extract_from_ima_ng(tokens,
-                                                              template_hash)
-        elif mode == "ima-sig":
-            filedata_hash, path, signature, filedata_algo, error = \
-                _extract_from_ima_sig(tokens, template_hash)
-        elif mode == 'ima':
-            filedata_hash, path, error = _extract_from_ima(tokens,
-                                                           template_hash)
-        else:
-            raise Exception("unsupported ima template mode: %s" % mode)
+            if not entry.valid():
+                errors[type(entry.mode)] = errors.get(type(entry.mode), 0) + 1
 
-        errs[0] += error
-        if template_hash == START_HASH:
-            template_hash = FF_HASH
+            if not found_pcr:
+                # End of list should equal pcr value
+                found_pcr = (codecs.encode(running_hash, 'hex').decode('utf-8') == pcrval)
 
-        # update hash
-        runninghash = hashlib.sha1(runninghash + template_hash).digest()
-
-        if not found_pcr:
-            found_pcr = \
-                (codecs.encode(runninghash, 'hex').decode('utf-8') == pcrval)
-
-        # write out the new hash
-        if m2w is not None:
-            m2w.write("%s %s\n" %
-                      (codecs.encode(filedata_hash, 'hex').decode('utf-8'),
-                       path))
-
-        evaluated = False
-
-        if signature and ima_keyring:
-            evaluated = True
-            # determine if path matches any exclusion list items
-            if compiled_regex is not None and compiled_regex.match(path):
-                logger.debug("IMA: ignoring excluded path %s" % path)
-                continue
-
-            if not ima_keyring.integrity_digsig_verify(signature, filedata_hash, filedata_algo):
-                logger.warning("signature for file %s is not valid" % (path))
-                errs[3] += 1
-            else:
-                logger.debug("signature for file %s is good" % path)
-
-        if allowlist is not None:
-            # just skip if it is a weird overwritten path
-            if template_hash == FF_HASH:
-                # print "excluding ffhash %s"%path
-                continue
-
-            # determine if path matches any exclusion list items
-            if compiled_regex is not None and compiled_regex.match(path):
-                logger.debug("IMA: ignoring excluded path %s" % path)
-                continue
-
-            accept_list = allowlist.get(path, None)
-            if accept_list is None:
-                # if it's NOT already evaluated by a file signature then a
-                # missing file entry is an error -- this enforces that every
-                # entry is 'covered' by signature or allowlist
-                if not evaluated:
-                    logger.warning("File not found in allowlist: %s" % (path))
-                    errs[1] += 1
-                continue
-
-            # print('codecs.encode', codecs.encode(filedata_hash, 'hex').decode('utf-8'))
-            # print('accept_list:', accept_list)
-            if codecs.encode(filedata_hash, 'hex').decode('utf-8') not in accept_list:
-                logger.warning("Hashes for file %s don't match %s not in %s" %
-                               (path,
-                                codecs.encode(filedata_hash, 'hex').decode('utf-8'),
-                                accept_list))
-                errs[2] += 1
-                continue
-
-            evaluated = True
-
-        if ima_keyring and not evaluated:
-            logger.warning("File %s not evaluated with signature or allowlist" % path)
-            errs[1] += 1
-
-        errs[4] += 1
+            # Keep old functionality for writing the parsed files with hashes into a file
+            if m2w is not None and (type(entry.mode) in [ima_ast.Ima, ima_ast.ImaNg, ima_ast.ImaSig]):
+                hash_value = codecs.encode(entry.mode.digest.hash, "hex")
+                path = entry.mode.path.name
+                m2w.write(f"{hash_value} {path}\n")
+        except ima_ast.ParserError:
+            logger.error(f"Line was not parsable into a valid IMA entry: {line}")
 
     # check PCR value has been found
     if not found_pcr:
         logger.error("IMA measurement list does not match TPM PCR %s" % pcrval)
         return None
 
-    # clobber the retval if there were IMA file errors
-    if sum(errs[:4]) > 0:
-        logger.error(
-            "IMA ERRORS: template-hash %d fnf %d hash %d bad-sig %d good %d" % tuple(errs))
+    # Check if any validators failed
+    if sum(errors.values()) > 0:
+        error_msg = "IMA ERRORS: Some entries couldn't be validated. Number of failures in modes: "
+        error_msg += ", ".join([f'{k.__name__ } {v}' for k, v in errors.items()])
+        logger.error(error_msg + ".")
         return None
 
-    return codecs.encode(runninghash, 'hex').decode('utf-8')
+    return codecs.encode(running_hash, 'hex').decode('utf-8')
 
 
 def process_allowlists(allowlist, exclude):

--- a/keylime/ima_ast.py
+++ b/keylime/ima_ast.py
@@ -1,0 +1,318 @@
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2021 Thore Sommer
+
+AST with parser and validator for IMA ASCII entries.
+Implements the templates (modes) and types as defined in:
+- https://elixir.bootlin.com/linux/latest/source/security/integrity/ima/ima_template.c
+- https://www.kernel.org/doc/html/v5.12/security/IMA-templates.html
+'''
+
+import binascii
+import codecs
+import hashlib
+import struct
+import abc
+import dataclasses
+
+from typing import Dict, Callable, Any, Optional
+from keylime import keylime_logging
+
+logger = keylime_logging.init_logging("ima")
+
+TCG_EVENT_NAME_LEN_MAX = 255
+SHA_DIGEST_LEN = 20
+MD5_DIGEST_LEN = 16
+
+START_HASH = (codecs.decode(b'0000000000000000000000000000000000000000', 'hex'))
+FF_HASH = (codecs.decode(b'ffffffffffffffffffffffffffffffffffffffff', 'hex'))
+
+NULL_BYTE = ord('\0')
+COLON_BYTE = ord(':')
+
+
+@dataclasses.dataclass
+class Validator:
+    functions: Dict[Any, Callable]
+
+    def get_validator(self, class_type) -> Callable:
+        validator = self.functions.get(class_type, None)
+        if validator is None:
+            logger.warning(f"No validator was implemented for: {class_type} . Using always false validator!")
+            return lambda *_: False
+        return validator
+
+
+class ParserError(TypeError):
+    """Is thrown when a type could not be constructed successfully."""
+
+
+class Mode(abc.ABC):
+    @abc.abstractmethod
+    def is_data_valid(self, validator: Validator):
+        pass
+
+    @abc.abstractmethod
+    def hash(self) -> bytes:
+        pass
+
+
+class Type(abc.ABC):
+    @abc.abstractmethod
+    def struct(self):
+        pass
+
+
+class HexData(Type):
+    data: bytes
+
+    def __init__(self, data: str):
+        try:
+            self.data = codecs.decode(data.encode("utf-8"), "hex")
+        except binascii.Error as e:
+            raise ParserError(f"Provided data was not valid hex: {data}") from e
+
+    def __str__(self):
+        return self.data.decode("utf-8")
+
+    def struct(self):
+        return struct.pack(f"<I{len(self.data)}s",
+                           len(self.data),
+                           self.data)
+
+
+class Signature(HexData):
+    """
+    Class for type "sig".
+    """
+
+
+class Buffer(HexData):
+    """
+    Class for type "buf".
+    """
+
+
+class Name(Type):
+    """
+    Class for type "n" and "n-ng".
+    """
+    name: str
+    legacy: bool = False
+
+    def __init__(self, name: str, legacy=False):
+        self.name = name
+        self.legacy = legacy
+
+    def __str__(self):
+        return self.name
+
+    def struct(self):
+        # The old "n" option is fixed length.
+        if self.legacy:
+            return struct.pack(f"{len(self.name)}sB{TCG_EVENT_NAME_LEN_MAX - len(self.name)}s",
+                               self.name.encode("utf-8"),
+                               NULL_BYTE,
+                               bytearray(TCG_EVENT_NAME_LEN_MAX - len(self.name)))
+
+        return struct.pack(f"<I{len(self.name)}sB",
+                           len(self.name) + 1,
+                           self.name.encode("utf-8"),
+                           NULL_BYTE)
+
+
+class Digest:
+    """
+    Class for types "d" and "d-ng" with and without algorithm
+    """
+    hash: bytes
+    algorithm: Optional[str] = None
+    legacy: bool = False
+
+    def __init__(self, digest: str, legacy=False):
+        self.legacy = legacy
+        tokens = digest.split(":")
+        if len(tokens) == 1:
+            try:
+                self.hash = codecs.decode(tokens[0].encode("utf-8"), "hex")
+            except binascii.Error as e:
+                raise ParserError(f"Digest hash is not valid hex. Got: {tokens[0]}") from e
+            if not (len(self.hash) == SHA_DIGEST_LEN or len(self.hash) == MD5_DIGEST_LEN):
+                raise ParserError(
+                    "Cannot create Digest. No hash algorithm is provided and hash does not belong to a md5 or sha1 hash.")
+        elif len(tokens) == 2:
+            try:
+                self.hash = codecs.decode(tokens[1].encode("utf-8"), "hex")
+            except binascii.Error as e:
+                raise ParserError(f"Digest hash is not valid hex. Got: {tokens[1]}") from e
+            self.algorithm = tokens[0]
+        else:
+            raise ParserError(f"Cannot create Digest expected 1 or 2 tokens got: {len(tokens)} for {digest}")
+
+    def struct(self):
+        # The legacy format "d" has fixed length, so it does not contain a length attribute
+        if self.legacy:
+            return struct.pack(f"<{len(self.hash)}s", self.hash)
+
+        if self.algorithm is None:
+            return struct.pack(f"<I{len(self.hash)}s", len(self.hash), self.hash)
+        # After the ':' must be a '\O':
+        # https://elixir.bootlin.com/linux/v5.12.10/source/security/integrity/ima/ima_template_lib.c#L230
+        return struct.pack(f"<I{len(self.algorithm)}sBB{len(self.hash)}s",
+                           len(self.algorithm) + 2 + len(self.hash),
+                           self.algorithm.encode("utf-8"),
+                           COLON_BYTE,
+                           NULL_BYTE,
+                           self.hash)
+
+
+class Ima(Mode):
+    """
+    Class for "ima". Contains the digest and a path.
+    """
+    digest: Digest
+    path: Name
+
+    def __init__(self, data: str):
+        tokens = data.split()
+        if len(tokens) != 2:
+            raise ParserError()
+        self.digest = Digest(tokens[0], legacy=True)
+        self.path = Name(tokens[1], legacy=True)
+
+    def hash(self):
+        tohash = self.digest.struct() + self.path.struct()
+        return hashlib.sha1(tohash).digest()
+
+    def is_data_valid(self, validator: Validator):
+        return validator.get_validator(type(self))(self.digest, self.path)
+
+
+class ImaNg(Mode):
+    """
+    Class for "ima-ng". Contains the digest and a path.
+    """
+    digest: Digest
+    path: Name
+
+    def __init__(self, data: str):
+        tokens = data.split()
+        if len(tokens) != 2:
+            raise ParserError(f"Cannot create ImaSig expected 2 tokens got: {len(tokens)}.")
+        self.digest = Digest(tokens[0])
+        self.path = Name(tokens[1])
+
+    def hash(self):
+        tohash = self.digest.struct() + self.path.struct()
+        return hashlib.sha1(tohash).digest()
+
+    def is_data_valid(self, validator):
+        return validator.get_validator(type(self))(self.digest, self.path)
+
+
+class ImaSig(Mode):
+    """
+    Class for "ima-sig" template. Nearly the same as ImaNg but can contain a optional signature.
+    """
+    digest: Digest
+    path: Name
+    signature: Optional[Signature] = None
+
+    def __init__(self, data: str):
+        tokens = data.split(maxsplit=4)
+        if len(tokens) in [2, 3]:
+            self.digest = Digest(tokens[0])
+            self.path = Name(tokens[1])
+        else:
+            raise ParserError(f"Cannot create ImaSig expected 2 or 3 tokens got: {len(tokens)}.")
+
+        if len(tokens) == 3:
+            self.signature = Signature(tokens[2])
+
+    def hash(self):
+        tohash = self.digest.struct() + self.path.struct()
+        # If no signature is there we sill have to add the entry for it
+        if self.signature is None:
+            tohash += struct.pack("<I0s", 0, b'')
+        else:
+            tohash += self.signature.struct()
+        return hashlib.sha1(tohash).digest()
+
+    def is_data_valid(self, validator):
+        return validator.get_validator(type(self))(self.digest, self.path, self.signature)
+
+
+class ImaBuf(Mode):
+    """
+    Class for "ima-buf". Contains a digest, buffer name and the buffer itself.
+    For validation the buffer must be done based on the name because IMA only provides it as an byte array.
+    """
+    digest: Digest
+    name: Name
+    data: Buffer
+
+    def __init__(self, data: str):
+        tokens = data.split(maxsplit=5)
+        if len(tokens) != 3:
+            raise ParserError(f"Cannot create ImaBuf expected 3 tokens got: {len(tokens)}.")
+        self.digest = Digest(tokens[0])
+        self.name = Name(tokens[1])
+        self.data = Buffer(tokens[2])
+
+    def hash(self):
+        tohash = self.digest.struct() + self.name.struct() + self.data.struct()
+        return hashlib.sha1(tohash).digest()
+
+    def is_data_valid(self, validator: Validator):
+        return validator.get_validator(type(self))(self.digest, self.name, self.data)
+
+
+class Entry:
+    """
+    IMA Entry. Contains the PCR, template hash and mode.
+    """
+    pcr: str
+    template_hash: bytes
+    mode: Mode
+    validator: Validator
+
+    mode_lookup = {
+        "ima": Ima,
+        "ima-ng": ImaNg,
+        "ima-sig": ImaSig,
+        "ima-buf": ImaBuf
+    }
+
+    def __init__(self, data: str, validator=None):
+        self.validator = validator
+        tokens = data.split(maxsplit=3)
+        if len(tokens) != 4:
+            raise ParserError(f"Cannot create Entry expected 4 tokens got: {len(tokens)}.")
+        self.pcr = tokens[0]
+        try:
+            self.template_hash = codecs.decode(tokens[1].encode(), "hex")
+        except binascii.Error as e:
+            raise ParserError(f"Cannot create Entry expected 4 tokens got: {len(tokens)}.") from e
+
+        mode = self.mode_lookup.get(tokens[2], None)
+        if mode is None:
+            raise ParserError(f"No parser for mode {tokens[2]} implemented.")
+        self.mode = mode(tokens[3])
+
+        # Ignore time of measure, time of use (ToMToU) errors and if a file is already opened for write.
+        # TODO make this configurable
+        # https://elixir.bootlin.com/linux/v5.12.12/source/security/integrity/ima/ima_main.c#L101
+        if self.template_hash == START_HASH:
+            self.template_hash = FF_HASH
+
+    def valid(self):
+        # Ignore template hash for ToMToU errors
+        if self.template_hash == FF_HASH:
+            logger.warning("Skipped template_hash validation entry with FF_HASH")
+            return self.mode.is_data_valid(self.validator)
+        if self.template_hash != self.mode.hash():
+            return False
+        if self.validator is None:
+            return False
+
+        return self.mode.is_data_valid(self.validator)

--- a/test/test_ima_ast.py
+++ b/test/test_ima_ast.py
@@ -1,0 +1,66 @@
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2021 Thore Sommer
+'''
+
+import unittest
+
+from keylime import ima_ast
+
+# BEGIN TEST DATA
+
+VALID_ENTRIES = {
+    "ima-sig-rsa": (ima_ast.ImaSig,
+                    '10 50873c47693cf9458e87eb4a02dd4f594f7a0c0f ima-sig sha1:1350320e5f7f51553bac8aa403489a1b135bc101 /usr/bin/dd 030202f3452d23010084c2a6cf7de1aeefa119220df0da265a7c44d34380f0d97002e7c778d09cfcf88c018e6595df3ee70eda926851f159332f852e7981a8fca1bc5e959958d06d234a0896861f13cc60da825905c8ed234df26c1deecfa816d5aa9bfb11b905e2814084a86b588be60423afada8dd0dd5a143774c6d890b64195ac42fb47ef5a9a00f0d6c80711d8e0c2b843ec38c02f60fd46bc46c7b4c329ad2dbb1b7625293703f9c739dc4c2bf0769126a2f3cb2cd031d1881cd0af64bf20fd474a993b48620f103a5c14999a2f17d60721bcc019a896b4138a688a59f50cb6cd94a4cfe3b8052e82dec025fef4feabb08c7ce412e3de850f903797e293ec27c329f57fd84e0'),
+    "ima-sig-ec": (ima_ast.ImaSig,
+                   '10 06e804489a77ddab51b9ef27e17053c0e5d503bd ima-sig sha1:1cb84b12db45d7da8de58ba6744187db84082f0e /usr/bin/zmore 030202531f402500483046022100bff9c02dc7b270c83cc94bfec10eecd42831de2cdcb04f024369a14623bc3a91022100cc4d015ae932fb98d6846645ed7d1bb1afd4621ec9089bc087126f191886dd31'),
+    "ima-sig-missing": (ima_ast.ImaSig,
+                        '10 5426cf3031a43f5bfca183d79950698a95a728f6 ima-sig sha256:f1125b940480d20ad841d26d5ea253edc0704b5ec1548c891edf212cb1a9365e /lib/modules/5.4.48-openpower1/kernel/drivers/usb/common/usb-common.ko'),
+    "ima-buf": (ima_ast.ImaBuf, "10 b7862dbbf1383ac6c7cca7f02d981a081aacb1f1 ima-buf sha1:6e0e6fc8a188ef4f059638949adca4d221946906 device_resume 6e616d653d544553543b757569643d43525950542d5645524954592d39656633326535623635623034343234613561386562343436636630653731332d544553543b63617061636974793d303b6d616a6f723d3235333b6d696e6f723d303b6d696e6f725f636f756e743d313b6e756d5f746172676574733d313b6163746976655f7461626c655f686173683d346565383065333365353635643336333430356634303238393436653837623365396563306335383661666639656630656436663561653762656237326431333b"),
+    "ima": (ima_ast.Ima, "10 d7026dc672344d3ee372217bdbc7395947788671 ima 6f66d1d8e2fffcc12dfcb78c04b81fe5b8bbae4e /usr/bin/kmod"),
+    "ima-ng": (ima_ast.ImaNg, "10 7936eb315fb4e74b99e7d461bc5c96049e1ee092 ima-ng sha1:bc026ae66d81713e4e852465e980784dc96651f8 /usr/lib/systemd/systemd"),
+}
+
+INVALID_ENTRIES = {
+    "invalid-mode": "10 7936eb315fb4e74b99e7d461bc5c96049e1ee092 not-ima sha1:bc026ae66d81713e4e852465e980784dc96651f8 /usr/lib/systemd/systemd",
+    "invalid-template-hash": "10 I936eb315fb4e74b99e7d461bc5c96049e1ee092 ima-ng sha1:bc026ae66d81713e4e852465e980784dc96651f8 /usr/lib/systemd/systemd",
+    "invalid-digest": "10 7936eb315fb4e74b99e7d461bc5c96049e1ee092 ima-ng sha1:Ic026ae66d81713e4e852465e980784dc96651f8 /usr/lib/systemd/systemd",
+    "not-ima-string": "this is text not an ima entry",
+}
+
+# END TEST DATA
+
+
+def _true(*_):
+    return True
+
+
+AlwaysTrueValidator = ima_ast.Validator({
+    ima_ast.Ima: _true,
+    ima_ast.ImaNg: _true,
+    ima_ast.ImaSig: _true,
+    ima_ast.ImaBuf: _true
+})
+
+
+class TestImaAst(unittest.TestCase):
+
+    def test_valid_entry_construction(self):
+        for name, (expected_mode, data) in VALID_ENTRIES.items():
+            err = None
+            try:
+                entry = ima_ast.Entry(data, AlwaysTrueValidator)
+                self.assertTrue(entry.pcr == "10", f"Expected pcr 10 for {name}. Got: {entry.pcr}")
+                self.assertTrue(isinstance(entry.mode, expected_mode)) # pylint: disable=isinstance-second-argument-not-valid-type
+                self.assertTrue(entry.template_hash == entry.mode.hash(),
+                                f"Constructed hash of {name} does not match template hash.\n Expected: {entry.template_hash}.\n Got: {entry.mode.hash()}")
+                self.assertTrue(entry.valid(), f"Entry of {name} couldn't be validated.")
+            except ima_ast.ParserError as e:
+                err = e
+            if err:
+                self.fail(f"Constructing entry {name} failed with: {err}")
+
+    def test_invalid_entries(self):
+        for _, data in INVALID_ENTRIES.items():
+            with self.assertRaises(ima_ast.ParserError):
+                ima_ast.Entry(data)

--- a/test/test_ima_verification.py
+++ b/test/test_ima_verification.py
@@ -49,6 +49,9 @@ class TestIMAVerification(unittest.TestCase):
         lines = MEASUREMENTS.splitlines()
         lists_map = ima.process_allowlists(ALLOWLIST, '')
 
+        self.assertTrue(ima.process_measurement_list(lines) is not None,
+                        "Validation should always work when no allowlist and no keyring is specified")
+
         self.assertTrue(ima.process_measurement_list(lines, lists_map) is not None)
         # test with list as a string
         self.assertTrue(ima.process_measurement_list(lines, str(lists_map)) is not None)


### PR DESCRIPTION
This PR introduces a flexible way for parsing and validating IMA entries. 
A entry is parsed into an AST with basic input validation and provides functions to reconstruct and validate the template hash. For an entry a validator can be specified which can be specialized based on the IMA template.

Making the parsing more flexible allows Keylime to support more use cases of IMA than files which is introduced with kernel [5.12](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e58bb688f2e44237990dfb6). Those use mostly `ima-buf` as their template format which is currently not supported in Keylime.

For https://github.com/keylime/enhancements/pull/47 this makes it easier to add granular error context because the validation is unified into a single interface to use.

We are currently testing the experimental IMA support for device-mapper targets and this allows us to easily parse and validate those entries without duplicating the parsing and template hash validation work.

The old code skipped the validation of the template hash if it none or all bits set.  Why is that the case? 
I couldn't find a good explanation by looking around the kernel IMA implementation and Keylime git history.
If this behavior is necessary it should be documented before merging. 