### PR TITLE
ci: make run_local.sh work with newer docker versions

### DIFF
--- a/.ci/run_local.sh
+++ b/.ci/run_local.sh
@@ -17,7 +17,8 @@ function tpm2 {
     container_id=$(mktemp)
     docker run --detach --privileged \
         -v $REPO:/root/keylime \
-        -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+        -v /sys/fs/cgroup:/sys/fs/cgroup \
+        --cgroupns=host \
         -it ${tpm20image}:${tpm20tag} >> ${container_id}
     docker exec -u 0 -it --tty "$(cat ${container_id})" \
         /bin/bash /root/keylime/.ci/test_wrapper.sh


### PR DESCRIPTION
The old configuration would result in the following error:

Initializing machine ID from random generator.
Failed to create /init.scope control group: Read-only file system
Failed to allocate manager object: Read-only file system
[!!!!!!] Failed to allocate manager object.
Exiting PID 1...

Tested with docker version 20.10.7.

Signed-off-by: Thore Sommer <mail@thson.de>