### PR TITLE
Set default UUID as lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,16 +365,16 @@ done either with the keylime tenant or webapp.
 The `keylime_tenant` utility can be used to provision your agent.
 
 As an example, the following command tells keylime to provision a new agent
-at 127.0.0.1 with UUID D432FBB3-D2F1-4A97-9EF7-75BD81C00000 and talk to a
+at 127.0.0.1 with UUID d432fbb3-d2f1-4a97-9ef7-75bd81c00000 and talk to a
 verifier at 127.0.0.1.  Finally it will encrypt a file called `filetosend`
 and send it to the agent allowing it to decrypt it only if the configured TPM
 policy (in `/etc/keylime.conf`) is satisfied:
 
-`keylime_tenant -c add -t 127.0.0.1 -v 127.0.0.1 -u D432FBB3-D2F1-4A97-9EF7-75BD81C00000 -f filetosend`
+`keylime_tenant -c add -t 127.0.0.1 -v 127.0.0.1 -u D432fbb3-d2f1-4a97-9ef7-75bd81c00000 -f filetosend`
 
 To stop keylime from requesting attestations:
 
-`keylime_tenant -c delete -t 127.0.0.1 -u D432FBB3-D2F1-4A97-9EF7-75BD81C00000`
+`keylime_tenant -c delete -t 127.0.0.1 -u d432fbb3-d2f1-4a97-9ef7-75bd81c00000`
 
 For additional advanced options for the tenant utility run:
 
@@ -426,7 +426,7 @@ You may wonder why this is in keylime at all?  Well, you can tell `keylime_tenan
 automatically create a key and then provision an agent with it.  Use the --cert
 option in `keylime_tenant` to do this.  This takes in the directory of the CA:
 
-`keylime_tenant -c add -t 127.0.0.1 -u D432FBB3-D2F1-4A97-9EF7-75BD81C00000 --cert /var/lib/keylime/ca`
+`keylime_tenant -c add -t 127.0.0.1 -u d432fbb3-d2f1-4a97-9ef7-75bd81c00000 --cert /var/lib/keylime/ca`
 
 If you also have the option extract_payload_zip in `/etc/keylime.conf` set to `True` on
 the keylime agent, then it will automatically extract the zip containing an unprotected

--- a/demo/agent_monitor/autorun.sh
+++ b/demo/agent_monitor/autorun.sh
@@ -7,7 +7,7 @@
 
 if [ "$AGENT_UUID" = "" ]
 then
-   AGENT_UUID=D432FBB3-D2F1-4A97-9EF7-75BD81C00000
+   AGENT_UUID=d432fbb3-d2f1-4a97-9ef7-75bd81c00000
 fi
 
 wget --ca-certificate=cacert.crt --post-data '{}' \

--- a/demo/agent_monitor/tenant_agent_monitor.py
+++ b/demo/agent_monitor/tenant_agent_monitor.py
@@ -6,9 +6,9 @@ Copyright 2017 Massachusetts Institute of Technology.
 '''
 
 # wget  --ca-certificate=/var/lib/keylime/secure/unzipped/cacert.crt --post-data '{}'
-#       --certificate=/var/lib/keylime/secure/unzipped/D432FBB3-D2F1-4A97-9EF7-75BD81C00000-cert.crt
-#       --private-key=/var/lib/keylime/secure/unzipped/D432FBB3-D2F1-4A97-9EF7-75BD81C00000-private.pem
-#        https://localhost:6892/agents/D432FBB3-D2F1-4A97-9EF7-75BD81C00000
+#       --certificate=/var/lib/keylime/secure/unzipped/d432fbb3-d2f1-4a97-9ef7-75bd81c00000-cert.crt
+#       --private-key=/var/lib/keylime/secure/unzipped/d432fbb3-d2f1-4a97-9ef7-75bd81c00000-private.pem
+#        https://localhost:6892/agents/d432fbb3-d2f1-4a97-9ef7-75bd81c00000
 
 from tornado import httpserver
 import threading

--- a/doc/xen-vtpm-notes.md
+++ b/doc/xen-vtpm-notes.md
@@ -384,11 +384,11 @@ log message like the following means that it worked:
 
 Copy this uuid.  Shutdown the keylime vm and its vtpm.  Put this UUID into the cfg file for the vtpm:
 
-`vtpm=["backend=vtpmmgr,uuid=33C6AD2C-F20D-40B0-B3F6-BC0FB0627637"]`
+`vtpm=["backend=vtpmmgr,uuid=33c6ad2c-f20d-40b0-b3f6-bc0fb0627637"]`
     
 Boot the vtpm back up.  then boot up the linux machine.  Now you must put this UUID into the keylime vm /etc/keylime.conf.
 
-`agent_uuid=33C6AD2C-F20D-40B0-B3F6-BC0FB0627637`
+`agent_uuid=33c6ad2c-f20d-40b0-b3f6-bc0fb0627637`
 
 Ok, now it is time to start up the agent process.  (this is where it all comes together, so if this works, the rest likely will too)
 
@@ -404,7 +404,7 @@ Now lets actualy run through the entire process:
 
 back on dom0 xen machine we want to run the tenant:
 
-`keylime_tenant -u 33C6AD2C-F20D-40B0-B3F6-BC0FB0627637 -t 10.0.0.4 --verify -f SOMEFILE.txt`
+`keylime_tenant -u 33c6ad2c-f20d-40b0-b3f6-bc0fb0627637 -t 10.0.0.4 --verify -f SOMEFILE.txt`
 
 where SOMEFILE.txt is any old file that you want delivered securely to the agent.  The --verify option will poll the agent to make sure everything worked
 

--- a/keylime.conf
+++ b/keylime.conf
@@ -68,7 +68,7 @@ extract_payload_zip = True
 # 'dmidecode -s system-uuid'.
 # If you set this to "hostname", Keylime will use the full qualified domain
 # name of current host as the agent id.
-agent_uuid = D432FBB3-D2F1-4A97-9EF7-75BD81C00000
+agent_uuid = d432fbb3-d2f1-4a97-9ef7-75bd81c00000
 
 # Whether to listen for revocation notifications from the verifier or not.
 listen_notfications = True

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -1096,8 +1096,8 @@ def main(argv=sys.argv):
             mytenant.agent_uuid = hashlib.sha256(
                 mytenant.agent_uuid).hexdigest()
     else:
-        logger.warning("Using default UUID D432FBB3-D2F1-4A97-9EF7-75BD81C00000")
-        mytenant.agent_uuid = "D432FBB3-D2F1-4A97-9EF7-75BD81C00000"
+        logger.warning("Using default UUID d432fbb3-d2f1-4a97-9ef7-75bd81c00000")
+        mytenant.agent_uuid = "d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
 
     if config.STUB_VTPM and config.TPM_CANNED_VALUES is not None:
         # Use canned values for agent UUID

--- a/test/test_registrar_db.py
+++ b/test/test_registrar_db.py
@@ -13,7 +13,7 @@ from keylime.db.keylime_db import SessionManager
 # BEGIN TEST DATA
 
 test_data = {
-    'agent_id': '4d32fbb3-d2f1-4a97-9ef7-75bd81c00000',
+    'agent_id': 'd432fbb3-d2f1-4a97-9ef7-75bd81c00000',
     'ek_tpm': """-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0dLxdAABVJO6qxamjCMh
 yhWZgiFHZHnPEe0tMFyK3fNVr/w8lX9r+QOLxLmkT0IdgsEYtGZGefbD+qQl4O1s

--- a/test/test_registrar_db.py
+++ b/test/test_registrar_db.py
@@ -13,7 +13,7 @@ from keylime.db.keylime_db import SessionManager
 # BEGIN TEST DATA
 
 test_data = {
-    'agent_id': 'D432FBB3-D2F1-4A97-9EF7-75BD81C00000',
+    'agent_id': '4d32fbb3-d2f1-4a97-9ef7-75bd81c00000',
     'ek_tpm': """-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0dLxdAABVJO6qxamjCMh
 yhWZgiFHZHnPEe0tMFyK3fNVr/w8lX9r+QOLxLmkT0IdgsEYtGZGefbD+qQl4O1s
@@ -66,7 +66,7 @@ DueRMS6lblvRKiZgmGAg7YaKOkOaEmVDMQ+fTo2Po7hI5wc=
     'regcount': 1
 }
 
-agent_id = 'D432FBB3-D2F1-4A97-9EF7-75BD81C00000'
+agent_id = 'd432fbb3-d2f1-4a97-9ef7-75bd81c00000'
 
 # END TEST DATA
 

--- a/test/test_verifier_db.py
+++ b/test/test_verifier_db.py
@@ -21,7 +21,7 @@ test_data = {
     'public_key': '',
     'tpm_policy': '{"22": ["0000000000000000000000000000000000000001", "0000000000000000000000000000000000000000000000000000000000000001", "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001", "ffffffffffffffffffffffffffffffffffffffff", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"], "15": ["0000000000000000000000000000000000000000", "0000000000000000000000000000000000000000000000000000000000000000", "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"], "mask": "0x408400"}',
     'vtpm_policy': '{"23": ["ffffffffffffffffffffffffffffffffffffffff", "0000000000000000000000000000000000000000"], "15": ["0000000000000000000000000000000000000000"], "mask": "0x808000"}',
-    'meta_data': '{"cert_serial": 2, "subject": "/C=US/CN=D432FBB3-D2F1-4A97-9EF7-75BD81C00000/ST=MA/L=Lexington/O=MITLL/OU=53"}',
+    'meta_data': '{"cert_serial": 2, "subject": "/C=US/CN=d432fbb3-d2f1-4a97-9ef7-75bd81c00000/ST=MA/L=Lexington/O=MITLL/OU=53"}',
     'allowlist': '{"allowlist": {"/boot/System.map-5.1.17-300.fc30.x86_64": ["bdc084cc61c67dada53ff92c3235fbc774eace36aceb11967718399837e36485"], "/boot/vmlinuz-5.0.9-301.fc30.x86_64": ["187e65c35f449df145b57940cb73606623ab1eccc352f5b0d9b64c4d2ad3be58"], "/boot/initramfs-5.1.15-300.fc30.x86_64.img": ["7fb94b644d95de6ed2f70c247cf9a572027815b8f6a00b8c5f7b9fd2feef0ff1"], "/boot/config-5.0.9-301.fc30.x86_64": ["540f7b2732b8018be45dcfdf737fa6e51d9f5924d85b6c1987ddb4215260b49f"], "boot_aggregate": ["0000000000000000000000000000000000000000"]}, "exclude": ["/*"]}',
     'ima_sign_verification_keys': '',
     'revocation_key': '-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDs1onKjLZHDnqu\nnrsCb5aZohK2FU+jjU4NT23x1UzYzpFU9wBZ0avj+HeFYbQiAKanSbS7PvhjJMdE\naWMgRMgigr2K1xx+ZhBu4zTPFMy11msxMIL/HPROSYx/9wUZrhf4z/rBsuppFVs3\nKfKmQHuptjZX+D+m+nANO8WOILyW2+5YO5FNw1XJ3gVO6elJJ/CzQcYWIioONuTM\nQ+g8OQc+yTZruwedcSpOX56GpBImWUKXzTz3zoX7AlYxjEBjT86rxoBVXo3ZIwYx\n+mJk7NADN2qvLSXxTnLBxISHdsUDBP5DfurFQPhZC5oARN6/Y4zPESnhm8iwlG5o\n2ZjxVzphAgMBAAECggEBAKVKudImUJTY8yBp4aS6koXYymxQBUvlM8MwW1A7iK2L\nxXxiAtms7uVlJK1vWhOdFrKMS1mfgiVXpscFMkx0FKWZT4XVyaohu3hYlCOupYyH\nADrNW6+G2q7EwA0TLnkUuuBI7v4+y0DZydZ/LT2ApY31gIn21R3JjWh+/crK6DP0\nJO51hLO+z4GAMbWimRzA3lnYltUSJEvam3EHnj/pW+hlczjdI6AfJTWRWx6+gqP3\nRBvLcjBA9ZIx4JzYab5tnvwnd8ZzVItYBQJ8UhxzNsrSzEGguUEO4G/jYQTtYi6T\nufksmewcIClp48AfDThKSCMQXgFwpVI4EPxwmfd6Mt0CgYEA+i+2jjeFREMNam4p\nEBf5tmY2xvg3HXGgCjBfllepZQZHQatfv/kEqhFW497W+okyjTXflMR1TkjMKAqO\nahA+D1lItycPxsvTTiZ85KgrybbQT7Y+s2ET2f68wZh2XyiJIYE/MNi3ZclIBFaY\npyXicj0RIB6IY9PIHNgdEHI4casCgYEA8ldrcbWof8YpwJ6KFVuMvkYKniVF0aXH\nsQUWL/dyjBYIq/jg3Z4J+b0360DhZVpp1SaO4jFISxVMRzkDf3/gbKxH9F4a9Id8\nDmGH15v1ooKBYfkk7GwEB3AOY4gN3RMnWb1hxxhjsM9pmeTffqgqYzHYzv1ArjHe\ntYkjWOqPECMCgYBT//kXPuTrymeSuHHpCWO6Lg9uNqCqrh/BzAQMAlrJpJYAIn3/\ngqhiQXgfAg7EB5SFfPUYie2o3yBMwV6XleSAWsXjWKYfZQgJUTrVuvEYxNykJthe\nedWkd7cAeSQlRwLj0PVafSj2b+JSMpEGbd3d5Ur+scGxYsXpiVYY04DICQKBgBPZ\nhTtzHbIZkSHt2nGVZhnPst7xPp7FbW3adM7I/eDrjRpI8GI2p6qFDSd/0PZ0SWbk\nGZ/9WWaNAAp1aQvwdXlxQxOJAbw1vLuQ0Yefhqcg+WgE+DlFP688RnFwm3IYN4jq\nMjAUl1XMJ2IrlQLS02X8lz2dEMcz3oIQEY0e6UjxAoGAFeiOjFF2i4wRRUKx8kpb\nnBKRmFaMXdkeMV2IQALJ4skNNflf0YdDFVniFUyq9vfbq2drJSnMiy8Dvju0j5PC\n+MALz22fsNoIV2h6gz0i1lXiyVgpoAhYCbbPv0wO6iHKPBzH3Onv6BKrVMy1pnzh\n6QsfbhjzBfFg1Zxp/h1tBqA=\n-----END PRIVATE KEY-----\n',
@@ -34,7 +34,7 @@ test_data = {
     'hash_alg': '',
     'enc_alg': '',
     'sign_alg': '',
-    'agent_id': 'D432FBB3-D2F1-4A97-9EF7-75BD81C00000',
+    'agent_id': 'd432fbb3-d2f1-4a97-9ef7-75bd81c00000',
     'verifier_id' : 'default',
     'verifier_ip' : '127.0.0.1',
     'verifier_port' : 8881
@@ -47,7 +47,7 @@ test_allowlist_data = {
     'ima_policy': '{"allowlist": {"/boot/System.map-5.1.17-300.fc30.x86_64": ["bdc084cc61c67dada53ff92c3235fbc774eace36aceb11967718399837e36485"], "/boot/vmlinuz-5.0.9-301.fc30.x86_64": ["187e65c35f449df145b57940cb73606623ab1eccc352f5b0d9b64c4d2ad3be58"], "/boot/initramfs-5.1.15-300.fc30.x86_64.img": ["7fb94b644d95de6ed2f70c247cf9a572027815b8f6a00b8c5f7b9fd2feef0ff1"], "/boot/config-5.0.9-301.fc30.x86_64": ["540f7b2732b8018be45dcfdf737fa6e51d9f5924d85b6c1987ddb4215260b49f"], "boot_aggregate": ["0000000000000000000000000000000000000000"]}, "exclude": ["/*"]}',
 }
 
-agent_id = 'D432FBB3-D2F1-4A97-9EF7-75BD81C00000'
+agent_id = 'd432fbb3-d2f1-4a97-9ef7-75bd81c00000'
 
 TENANT_FAILED = 10
 


### PR DESCRIPTION
This change was a lot less disruptive then I thought

It turns out the python UUID lib generates lower case as default:

```
>>> import uuid
>>> uuid.uuid4()
UUID('fb00e830-7a99-4761-8523-63e494431d7f')
```

So all higher case instances were as a result of the UUID entry
in `keylime.conf`

I have now changed all these to lowercase.

With the code as it it, there will be no need to patch existing UUIDs
in a users database. Anything using `generate` will already be lower
case. Anything that already exists in the db using highercase can
remain that way.

Resolves: #691

Signed-off-by: Luke Hinds <lhinds@redhat.com>