### PR TITLE
measured_boot: drop process_refstate

### DIFF
--- a/keylime/measured_boot.py
+++ b/keylime/measured_boot.py
@@ -26,11 +26,6 @@ def read_mb_refstate(mb_path=None):
 
     return mb_data
 
-def process_refstate(mb_refstate_data=None) :
-    if isinstance(mb_refstate_data, dict) :
-        return mb_refstate_data
-    return mb_refstate_data
-
 def get_policy(mb_refstate_str):
     """ Convert the mb_refstate_str to JSON and get the measured boot policy.
     :param mb_refstate_str: String representation of measured boot reference state

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -234,7 +234,7 @@ class Tenant():
         if TPM_Utilities.check_mask(self.tpm_policy['mask'], config.MEASUREDBOOT_PCRS[2]) :
 
             # Process measured boot reference state
-            self.mb_refstate = measured_boot.process_refstate(mb_refstate_data)
+            self.mb_refstate = mb_refstate_data
 
     def init_add(self, args):
         """ Set up required values. Command line options can overwrite these config values


### PR DESCRIPTION
The funcion "process_refstate" check if the parameter is a dict, and if
so returns the same parameter, and if not returns the same parameter.

This function is a noop.  This patch drop the function and the only
place where it is called.

Signed-off-by: Alberto Planas <aplanas@suse.com>