### PR TITLE
ima: Convert pcrval to bytes to increase efficiency

### DIFF
--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -86,6 +86,9 @@ def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyri
     running_hash = ima_ast.START_HASH
     found_pcr = (pcrval is None)
     errors = {}
+    pcrval_bytes = b''
+    if pcrval is not None:
+        pcrval_bytes = codecs.decode(pcrval.encode('utf-8'), 'hex')
 
     if lists is not None:
         if isinstance(lists, str):
@@ -126,7 +129,7 @@ def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyri
 
             if not found_pcr:
                 # End of list should equal pcr value
-                found_pcr = (codecs.encode(running_hash, 'hex').decode('utf-8') == pcrval)
+                found_pcr = (running_hash == pcrval_bytes)
 
             # Keep old functionality for writing the parsed files with hashes into a file
             if m2w is not None and (type(entry.mode) in [ima_ast.Ima, ima_ast.ImaNg, ima_ast.ImaSig]):


### PR DESCRIPTION
The pcrval in process_measurement_list originates from the IMA log and is
a hex number in string form. Convert it to its bytes representation once
rather than converting the running_hash every time we do a comparison.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>