### PR TITLE
Automatically calculates the boot_aggregate from the measured boot log.

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -121,7 +121,7 @@ case "$ID" in
         GOPKG="golang"
         if [[ ${VERSION_ID} -ge 30 ]] ; then
         # if fedora 30 or greater, then using TPM2 tool packages
-            TPM2_TOOLS_PKGS="tpm2-tools tpm2-tss tpm2-abrmd"
+            TPM2_TOOLS_PKGS="tpm2-tools tpm2-tss tpm2-abrmd tss2"
             NEED_BUILD_TOOLS=0
             HAS_GO_PKG=1
         else

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -82,7 +82,7 @@ def _validate_ima_sig(exclude_regex, ima_keyring, allowlist, digest: ima_ast.Dig
     return valid_signature
 
 
-def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyring=None):
+def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyring=None, boot_aggregates=None):
     running_hash = ima_ast.START_HASH
     found_pcr = (pcrval is None)
     errors = {}
@@ -98,6 +98,14 @@ def process_measurement_list(lines, lists=None, m2w=None, pcrval=None, ima_keyri
     else:
         allow_list = None
         exclude_list = None
+
+    if boot_aggregates :
+        if "boot_aggregate" not in allow_list :
+            allow_list["boot_aggregate"] = []
+        for alg in boot_aggregates.keys() :
+            for val in boot_aggregates[alg] :
+                if val not in allow_list["boot_aggregate"] :
+                    allow_list["boot_aggregate"].append(val)
 
     is_valid, compiled_regex, err_msg = config.valid_exclude_list(exclude_list)
     if not is_valid:

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -203,11 +203,11 @@ class AbstractTPM(metaclass=ABCMeta):
     def _get_tpm_rand_block(self, size=4096):
         pass
 
-    def __check_ima(self, agent_id, pcrval, ima_measurement_list, allowlist, ima_keyring):
+    def __check_ima(self, agent_id, pcrval, ima_measurement_list, allowlist, ima_keyring, boot_aggregates):
         logger.info("Checking IMA measurement list on agent: %s", agent_id)
         if config.STUB_IMA:
             pcrval = None
-        ex_value = ima.process_measurement_list(ima_measurement_list.split('\n'), allowlist, pcrval=pcrval, ima_keyring=ima_keyring)
+        ex_value = ima.process_measurement_list(ima_measurement_list.split('\n'), allowlist, pcrval=pcrval, ima_keyring=ima_keyring, boot_aggregates=boot_aggregates)
         if ex_value is None:
             return False
 
@@ -227,7 +227,7 @@ class AbstractTPM(metaclass=ABCMeta):
         pcr_allowlist = {int(k): v for k, v in list(pcr_allowlist.items())}
 
         mb_policy, mb_refstate_data = measured_boot.get_policy(mb_refstate_str)
-        mb_pcrs_sha256, mb_measurement_data, success = self.parse_mb_bootlog(mb_measurement_list)
+        mb_pcrs_sha256, boot_aggregates, mb_measurement_data, success = self.parse_mb_bootlog(mb_measurement_list)
         if not success:
             return False
 
@@ -261,7 +261,7 @@ class AbstractTPM(metaclass=ABCMeta):
                     logger.error("IMA PCR in policy, but no measurement list provided")
                     return False
 
-                if self.__check_ima(agent_id, pcrval, ima_measurement_list, allowlist, ima_keyring):
+                if self.__check_ima(agent_id, pcrval, ima_measurement_list, allowlist, ima_keyring, boot_aggregates):
                     pcrsInQuote.add(pcrnum)
                     continue
 


### PR DESCRIPTION
This PR uses the tsseventextend tool (found on package tss2), which
reads the binary measured boot log (sent from the `agent` to the
`verifier`), and then uses it to calculate the boot_aggregate.
This is done by using the (also calculated) values for PCRs 0-7(9)
also from the measured boot log (the need for contemplate both
PCRs 0-7 and 0-9 comes from the combination of older kernels and
older versions of grub).

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>