### PR TITLE
tenant: do_cvdelete wait until 404

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -705,7 +705,7 @@ class Tenant():
                     verify=False
                 )
 
-                if response.status_code in (200, 404):
+                if response.status_code == 404:
                     deleted = True
                     break
                 time.sleep(.4)


### PR DESCRIPTION
do_cvdelete sends a delete request, and if received a 202 response
(accepted), actively iterate until the next get receives a 200 or 404.

The issue is that a get of 200 imply that the object is still available,
that causes the "update" operation to fail a bit later (update is a
delete followed of an add, and this last action will fail if the object
is still present)

This patch change the active polling to consider the agent deleted only
when a 404 is received.

Fix #711

Signed-off-by: Alberto Planas <aplanas@suse.com>