### PR TITLE
Add default verifier-check value

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -677,9 +677,8 @@ class Tenant():
 
         return None
 
-    def do_cvdelete(self, verifier_check):
-        """Delete agent from Verifier
-        """
+    def do_cvdelete(self, verifier_check=True):
+        """Delete agent from Verifier."""
         if verifier_check:
             agent_json = self.do_cvstatus(listing=False, returnresponse=True)
             self.verifier_ip = agent_json["verifier_ip"]
@@ -741,9 +740,8 @@ class Tenant():
         registrar_client.doRegistrarDelete(
             self.registrar_ip, self.registrar_port, self.agent_uuid)
 
-    def do_cvreactivate(self, verifier_check):
-        """ Reactive Agent
-        """
+    def do_cvreactivate(self, verifier_check=True):
+        """Reactive Agent."""
         if verifier_check:
             agent_json = self.do_cvstatus(listing=False, returnresponse=True)
             self.verifier_ip = agent_json['verifier_ip']
@@ -752,7 +750,7 @@ class Tenant():
         do_cvreactivate = RequestsClient(
             self.verifier_base_url, self.tls_enabled)
         response = do_cvreactivate.put(
-            (f'/v{self.api_version}/agents/{self.agent_uuid}/reactivate'),
+            f'/v{self.api_version}/agents/{self.agent_uuid}/reactivate',
             data=b'',
             cert=self.cert,
             verify=False

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -627,7 +627,7 @@ def parse_data_uri(data_uri):
 
 def start_tornado(tornado_server, port):
     tornado_server.listen(port)
-    logger.info("Starting Torando on port %s", port)
+    logger.info("Starting Tornado on port %s", port)
     tornado.ioloop.IOLoop.instance().start()
     logger.info("Tornado finished")
 


### PR DESCRIPTION
Set the verifier-check to True in do_cvreactivate and do_cvdelete,
according to the default value set for the corresponding arg set
in tenant.py.
This handles the issue in tenant_webapp.py where the do_cvreactivate
and the do_cvdelete functions are called without specifying the value
for verifier-check.

Also fix a typo and a reduntant parenthesis.
