### PR TITLE
add infrastructure to tag and collect revocation events in Keylime

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -278,6 +278,17 @@ measured_boot_policy_name = accept-all
 # The default value for this config item is the empty string.
 # measured_boot_imports = keylime.elchecking
 
+# Severity labels for revocation events strictly ordered from least severity to
+# highest severtiy.
+severity_labels = ["info", "notice", "warning", "error", "critical", "alert", "emergency"]
+
+# Severity policy that matches different event_ids to the severity label.
+# The rules are evaluated from the beginning of the list and the first match is
+# used. The event_id can also be a regex. Default policy assigns the highest
+# severity to all events.
+severity_policy = [{"event_id": ".*", "severity_label": "emergency"}]
+
+
 #=============================================================================
 [tenant]
 #=============================================================================

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -19,6 +19,7 @@ from keylime import crypto
 from keylime import ca_util
 from keylime import revocation_notifier
 from keylime.agentstates import AgentAttestStates
+from keylime.failure import Failure, Component
 from keylime.tpm.tpm_main import tpm
 from keylime.tpm.tpm_abstract import TPM_Utilities
 from keylime.common import algorithms
@@ -133,11 +134,12 @@ def init_mtls(section='cloud_verifier', generatedir='cv_ca'):
     return context
 
 
-def process_quote_response(agent, json_response, agentAttestState):
+def process_quote_response(agent, json_response, agentAttestState) -> Failure:
     """Validates the response from the Cloud agent.
 
     This method invokes an Registrar Server call to register, and then check the quote.
     """
+    failure = Failure(Component.QUOTE_VALIDATION)
     received_public_key = None
     quote = None
     # in case of failure in response content do not continue
@@ -157,9 +159,11 @@ def process_quote_response(agent, json_response, agentAttestState):
         logger.debug("received ima_measurement_list_entry: %d", ima_measurement_list_entry)
         logger.debug("received boottime: %s", boottime)
         logger.debug("received boot log    %s", (mb_measurement_list is not None))
-    except Exception:
-        return None
+    except Exception as e:
+        failure.add_event("invalid_data", {"message": "parsing agents get quote respone failed", "data": e}, False)
+        return failure
 
+    # TODO: Are those separate failures?
     if not isinstance(ima_measurement_list_entry, int):
         raise Exception("ima_measurement_list_entry parameter must be an integer")
 
@@ -170,7 +174,8 @@ def process_quote_response(agent, json_response, agentAttestState):
     if received_public_key is None:
         if agent.get('public_key', "") == "" or agent.get('b64_encrypted_V', "") == "":
             logger.error("agent did not provide public key and no key or encrypted_v was cached at CV")
-            return False
+            failure.add_event("no_pubkey", "agent did not provide public key and no key or encrypted_v was cached at CV", False)
+            return failure
         agent['provide_V'] = False
         received_public_key = agent['public_key']
 
@@ -180,7 +185,8 @@ def process_quote_response(agent, json_response, agentAttestState):
             "cloud_verifier", "registrar_port"), agent['agent_id'])
         if registrar_data is None:
             logger.warning("AIK not found in registrar, quote not validated")
-            return False
+            failure.add_event("no_aik", "AIK not found in registrar, quote not validated", False)
+            return failure
         agent['registrar_data'] = registrar_data
 
     hash_alg = json_response.get('hash_alg')
@@ -194,38 +200,50 @@ def process_quote_response(agent, json_response, agentAttestState):
 
     # Ensure hash_alg is in accept_tpm_hash_alg list
     if not algorithms.is_accepted(hash_alg, agent['accept_tpm_hash_algs']):
-        raise Exception(
-            "TPM Quote is using an unaccepted hash algorithm: %s" % hash_alg)
+        logger.error(f"TPM Quote is using an unaccepted hash algorithm: {hash_alg}")
+        failure.add_event("invalid_hash_alg",
+                          {"message": f"TPM Quote is using an unaccepted hash algorithm: {hash_alg}", "data": hash_alg},
+                          False)
+        return failure
 
     # Ensure enc_alg is in accept_tpm_encryption_algs list
     if not algorithms.is_accepted(enc_alg, agent['accept_tpm_encryption_algs']):
-        raise Exception(
-            "TPM Quote is using an unaccepted encryption algorithm: %s" % enc_alg)
+        logger.error(f"TPM Quote is using an unaccepted encryption algorithm: {enc_alg}")
+        failure.add_event("invalid_enc_alg",
+                          {"message": f"TPM Quote is using an unaccepted encryption algorithm: {enc_alg}", "data": enc_alg},
+                          False)
+        return failure
 
     # Ensure sign_alg is in accept_tpm_encryption_algs list
     if not algorithms.is_accepted(sign_alg, agent['accept_tpm_signing_algs']):
-        raise Exception(
-            "TPM Quote is using an unaccepted signing algorithm: %s" % sign_alg)
+        logger.error(f"TPM Quote is using an unaccepted signing algorithm: {sign_alg}")
+        failure.add_event("invalid_sign_alg",
+                          {"message": f"TPM Quote is using an unaccepted signing algorithm: {sign_alg}", "data": {sign_alg}},
+                          False)
+        return failure
 
     if ima_measurement_list_entry == 0:
         agentAttestState.reset_ima_attestation()
     elif ima_measurement_list_entry != agentAttestState.get_next_ima_ml_entry():
         # If we requested a particular entry number then the agent must return either
         # starting at 0 (handled above) or with the requested number.
-        raise Exception(
-            "Agent did not respond with requested next IMA measurement list entry %d but started at %d" %
-            (agentAttestState.get_next_ima_ml_entry(), ima_measurement_list_entry))
+        logger.error("Agent did not respond with requested next IMA measurement list entry "
+                     f"{agentAttestState.get_next_ima_ml_entry()} but started at {ima_measurement_list_entry}")
+        failure.add_event("invalid_ima_entry_nb",
+                          {"message": "Agent did not respond with requested next IMA measurement list entry",
+                           "got": ima_measurement_list_entry, "expected": agentAttestState.get_next_ima_ml_entry()},
+                          False)
     elif not agentAttestState.is_expected_boottime(boottime):
         # agent sent a list not starting at 0 and provided a boottime that doesn't
         # match the expected boottime, so it must have been rebooted; we would fail
         # attestation this time so we retry with a full attestation next time.
         agentAttestState.reset_ima_attestation()
-        return True
+        return failure
 
     agentAttestState.set_boottime(boottime)
 
     ima_keyring = ima_file_signatures.ImaKeyring.from_string(agent['ima_sign_verification_keys'])
-    validQuote = get_tpm_instance().check_quote(
+    quote_validation_failure = get_tpm_instance().check_quote(
         agentAttestState,
         agent['nonce'],
         received_public_key,
@@ -238,21 +256,21 @@ def process_quote_response(agent, json_response, agentAttestState):
         ima_keyring,
         mb_measurement_list,
         agent['mb_refstate'])
-    if not validQuote:
-        return False
+    failure.merge(quote_validation_failure)
 
-    # set a flag so that we know that the agent was verified once.
-    # we only issue notifications for agents that were at some point good
-    agent['first_verified'] = True
+    if not failure:
+        # set a flag so that we know that the agent was verified once.
+        # we only issue notifications for agents that were at some point good
+        agent['first_verified'] = True
 
-    # has public key changed? if so, clear out b64_encrypted_V, it is no longer valid
-    if received_public_key != agent.get('public_key', ""):
-        agent['public_key'] = received_public_key
-        agent['b64_encrypted_V'] = ""
-        agent['provide_V'] = True
+        # has public key changed? if so, clear out b64_encrypted_V, it is no longer valid
+        if received_public_key != agent.get('public_key', ""):
+            agent['public_key'] = received_public_key
+            agent['b64_encrypted_V'] = ""
+            agent['provide_V'] = True
 
     # ok we're done
-    return validQuote
+    return failure
 
 
 def prepare_v(agent):
@@ -333,6 +351,8 @@ def process_get_status(agent):
                 'verifier_id' : agent.verifier_id,
                 'verifier_ip' : agent.verifier_ip,
                 'verifier_port' : agent.verifier_port,
+                'severity_level': agent.severity_level,
+                'last_event_id': agent.last_event_id
                 }
     return response
 
@@ -340,7 +360,7 @@ def process_get_status(agent):
 # sign a message with revocation key.  telling of verification problem
 
 
-def notify_error(agent, msgtype='revocation'):
+def notify_error(agent, msgtype='revocation', event=None):
     if not config.getboolean('cloud_verifier', 'revocation_notifier'):
         return
 
@@ -353,6 +373,10 @@ def notify_error(agent, msgtype='revocation'):
                   'vtpm_policy': agent['vtpm_policy'],
                   'meta_data': agent['meta_data'],
                   'event_time': time.asctime()}
+    if event:
+        revocation['event_id'] = event.event_id
+        revocation['severity_label'] = event.severity_label.name
+        revocation['context'] = event.context
 
     tosend = {'msg': json.dumps(revocation).encode('utf-8')}
 

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -46,6 +46,8 @@ class VerfierMain(Base):
     ima_pcrs = Column(JSONPickleType(pickler=json))
     pcr10 = Column(LargeBinary)
     next_ima_ml_entry = Column(Integer)
+    severity_level = Column(Integer, nullable=True)
+    last_event_id = Column(String(200), nullable=True)
 
 
 class VerifierAllowlist(Base):

--- a/keylime/failure.py
+++ b/keylime/failure.py
@@ -1,0 +1,201 @@
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2021 Thore Sommer
+
+Tagging of failure events that might cause revocation in Keylime.
+'''
+import ast
+import dataclasses
+import enum
+import functools
+import json
+import re
+from typing import List, Optional, Tuple, Callable, Union
+
+from keylime import config
+from keylime import keylime_logging
+
+logger = keylime_logging.init_logging("failure")
+
+
+@functools.total_ordering
+@dataclasses.dataclass(frozen=True)
+class SeverityLabel:
+    """
+    Severity label that can be attached to an event.
+
+    The severity level is assigned dynamically based on the configuration,
+    so only use the name for use outside use of the tagging module.
+    """
+    name: str
+    severity: int
+
+    def __lt__(self, other):
+        return self.severity < other.severity
+
+    def __eq__(self, other):
+        return self.severity == other.severity
+
+
+class Component(enum.Enum):
+    """
+    Main components of Keylime that can generate revocations.
+    """
+    QUOTE_VALIDATION = "qoute_validation"
+    PCR_VALIDATION = "pcr_validation"
+    MEASURED_BOOT = "measured_boot"
+    IMA = "ima"
+    INTERNAL = "internal"
+    DEFAULT = "default"
+
+
+@dataclasses.dataclass
+class Event:
+    """
+    Event that might be the reason for revocation.
+
+    The context is string
+    """
+    event_id: str
+    severity_label: SeverityLabel
+    context: str
+    recoverable: bool
+
+    def __init__(self, component: Component,
+                 sub_components: Optional[List[str]],
+                 event_id: str,
+                 context: Union[str, dict],
+                 recoverable: bool):
+
+        # Build full event id with the format "component.[sub_component].event_id"
+        self.event_id = component.value
+        if sub_components is not None:
+            self.event_id += "." + ".".join(sub_components)
+        self.event_id += f".{event_id}"
+
+        # Convert message
+        if isinstance(context, str):
+            context = {"message": context}
+        self.context = json.dumps(context)
+
+        self.severity_label = _severity_match(self.event_id)
+        self.recoverable = recoverable
+
+
+class Failure:
+    """
+    Failure Object that collects all events that might cause a revocation.
+
+    If recoverable is set to False the validation process returned early and might skipped other validation steps.
+    """
+    events: List[Event]
+    recoverable: bool
+    highest_severity: Optional[SeverityLabel]
+    _component: Optional[Component]
+    _sub_components: Optional[List[str]]
+
+    def __init__(self, component, sub_components=None):
+        self._component = component
+        self._sub_components = sub_components
+        self.events = []
+        self.recoverable = True
+        self.highest_severity_event: Optional[Event] = None  # This only holds the first event that has the highest severity
+        self.highest_severity: Optional[SeverityLabel] = None
+
+    def _add(self, event: Event):
+        if not event.recoverable:
+            self.recoverable = False
+            if event.severity_label != MAX_SEVERITY_LABEL:
+                logger.warning(
+                    f"Irrecoverable Event with id: {event.event_id} has not the highest severity level.\n "
+                    f"Setting it the the highest severity level.")
+                event.severity_label = MAX_SEVERITY_LABEL
+
+        if self.highest_severity is None or event.severity_label > self.highest_severity:
+            self.highest_severity = event.severity_label
+            self.highest_severity_event = event
+
+        self.events.append(event)
+
+    def add_event(self, event_id: str, context: Union[str, dict], recoverable: bool, sub_components=None):
+        """
+        Add event to Failure object. Uses the component and subcomponents specified in the Failure object.
+
+        As context specify either a string that contains a message or a dict that contains useful information about that
+        event.
+        Set recoverable to False if the code skips other not directly related checks. Those events should always have
+        the highest severity label assigned and if not we manually do that.
+
+        Example usage:
+            failure.add_event("ima_hash",
+                              {"message": "IMA hash does not match the calculated hash.",
+                               "expected": self.template_hash, "got": self.mode.hash()}, True)
+        """
+        if sub_components is not None and self._sub_components is not None:
+            sub_components = self._sub_components + sub_components
+        elif self._sub_components is not None:
+            sub_components = self._sub_components
+        event = Event(self._component, sub_components, event_id, context, recoverable)
+        self._add(event)
+
+    def merge(self, other):
+        if self.recoverable:
+            self.recoverable = other.recoverable
+        if self.highest_severity is None:
+            self.highest_severity = other.highest_severity
+            self.highest_severity_event = other.highest_severity_event
+        elif other.highest_severity is not None and self.highest_severity < other.highest_severity:
+            self.highest_severity = other.highest_severity
+            self.highest_severity_event = other.highest_severity_event
+
+        self.events.extend(other.events)
+
+    def __bool__(self):
+        return not self.recoverable or len(self.events) > 0
+
+
+def _eval_severity_config() -> Tuple[List[Callable[[str], Optional[SeverityLabel]]], SeverityLabel]:
+    """
+    Generates the list of rules to match a event_id against.
+    """
+
+    labels_list = ast.literal_eval(config.get("cloud_verifier", "severity_labels"))
+    labels = {}
+    for label, level in zip(labels_list, range(0, len(labels_list))):
+        labels[label] = SeverityLabel(label, level)
+
+    label_max = labels[labels_list[-1]]
+
+    policies = ast.literal_eval(config.get("cloud_verifier", "severity_policy"))
+    rules = []
+    for policy in policies:
+        # TODO validate regex
+        regex = re.compile(policy["event_id"])
+
+        def rule(policy_regex, label_str: str, event_id: str) -> Optional[SeverityLabel]:
+            if policy_regex.fullmatch(event_id):
+                policy_label = labels.get(label_str)
+                if policy_label is None:
+                    logger.error(f"Label {label_str} is not a valid label. Defaulting to maximal severity label!")
+                    return label_max
+                return policy_label
+            return None
+
+        rules.append(functools.partial(rule, regex, policy["severity_label"]))
+    return rules, label_max
+
+
+# Only evaluate the policy once on module load
+SEVERITY_RULES, MAX_SEVERITY_LABEL = _eval_severity_config()
+
+
+def _severity_match(event_id: str) -> SeverityLabel:
+    """
+    Match the event_id to a severity label.
+    """
+    for rule in SEVERITY_RULES:
+        match = rule(event_id)
+        if match is not None:
+            return match
+    logger.warning(f"No rule matched for event_id: {event_id}. Defaulting to max severity label")
+    return MAX_SEVERITY_LABEL

--- a/keylime/migrations/versions/257fe0f0c039_add_fields_for_revocation_context_to_.py
+++ b/keylime/migrations/versions/257fe0f0c039_add_fields_for_revocation_context_to_.py
@@ -1,0 +1,45 @@
+"""Add fields for revocation context to verifier
+
+Revision ID: 257fe0f0c039
+Revises: f35cdd35eb83
+Create Date: 2021-08-20 12:42:30.427138
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '257fe0f0c039'
+down_revision = 'f35cdd35eb83'
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+    op.add_column('verifiermain', sa.Column('severity_level', sa.Integer))
+    op.add_column('verifiermain', sa.Column('last_event_id', sa.String))
+
+
+def downgrade_cloud_verifier():
+    op.drop_column('verifiermain', 'severity_level')
+    op.drop_column('verifiermain', sa.Column('last_event_id', sa.Integer))

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -684,6 +684,8 @@ class Tenant():
                     if not bulk:
                         operational_state = response_json["results"]["operational_state"]
                         logger.info('Agent Status: "%s"', states.state_to_str(operational_state))
+                        logger.info('Agent severity level: "%s"', response_json["results"]["severity_level"])
+                        logger.info('Agent last event id: "%s"', response_json["results"]["last_event_id"])
                     else:
                         for agent in response_json["results"].keys():
                             response_json["results"][agent]["operational_state"] = states.state_to_str(response_json["results"][agent]["operational_state"])

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -507,7 +507,8 @@ class Tenant():
             logger.warning("AIK not found in registrar, quote not validated")
             return False
 
-        if not self.tpm_instance.check_quote(AgentAttestState(self.agent_uuid), self.nonce, public_key, quote, reg_data['aik_tpm'], hash_alg=hash_alg):
+        failure = self.tpm_instance.check_quote(AgentAttestState(self.agent_uuid), self.nonce, public_key, quote, reg_data['aik_tpm'], hash_alg=hash_alg)
+        if failure:
             if reg_data['regcount'] > 1:
                 logger.error("WARNING: This UUID had more than one ek-ekcert registered to it! This might indicate that your system is misconfigured or a malicious host is present. Run 'regdelete' for this agent and restart")
                 sys.exit()

--- a/test/test_ima_ast.py
+++ b/test/test_ima_ast.py
@@ -6,6 +6,7 @@ Copyright 2021 Thore Sommer
 import unittest
 
 from keylime import ima_ast
+from keylime.failure import Failure, Component
 
 # BEGIN TEST DATA
 
@@ -32,7 +33,7 @@ INVALID_ENTRIES = {
 
 
 def _true(*_):
-    return True
+    return Failure(Component.DEFAULT)
 
 
 AlwaysTrueValidator = ima_ast.Validator({
@@ -54,7 +55,7 @@ class TestImaAst(unittest.TestCase):
                 self.assertTrue(isinstance(entry.mode, expected_mode)) # pylint: disable=isinstance-second-argument-not-valid-type
                 self.assertTrue(entry.template_hash == entry.mode.hash(),
                                 f"Constructed hash of {name} does not match template hash.\n Expected: {entry.template_hash}.\n Got: {entry.mode.hash()}")
-                self.assertTrue(entry.valid(), f"Entry of {name} couldn't be validated.")
+                self.assertTrue(not entry.invalid(), f"Entry of {name} couldn't be validated.")
             except ima_ast.ParserError as e:
                 err = e
             if err:

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -557,13 +557,13 @@ class TestRestful(unittest.TestCase):
         self.assertIn("pubkey", json_response["results"], "Malformed response body!")
 
         # Check the quote identity
-        self.assertTrue(tpm_instance.check_quote(tenant_templ.agent_uuid,
+        failure = tpm_instance.check_quote(tenant_templ.agent_uuid,
                                         nonce,
                                         json_response["results"]["pubkey"],
                                         json_response["results"]["quote"],
                                         aik_tpm,
-                                        hash_alg=json_response["results"]["hash_alg"]),
-                        "Invalid quote!")
+                                        hash_alg=json_response["results"]["hash_alg"])
+        self.assertTrue(not failure, "Invalid quote!")
 
     @unittest.skip("Testing of agent's POST /keys/vkey disabled!  (spawned CV should do this already)")
     def test_023_agent_keys_vkey_post(self):
@@ -846,14 +846,14 @@ class TestRestful(unittest.TestCase):
         quote = json_response["results"]["quote"]
         hash_alg = json_response["results"]["hash_alg"]
 
-        validQuote = tpm_instance.check_quote(tenant_templ.agent_uuid,
+        failure = tpm_instance.check_quote(tenant_templ.agent_uuid,
                                      nonce,
                                      public_key,
                                      quote,
                                      aik_tpm,
                                      self.tpm_policy,
                                      hash_alg=hash_alg)
-        self.assertTrue(validQuote)
+        self.assertTrue(not failure)
 
     async def test_041_agent_keys_verify_get(self):
         """Test agent's GET /keys/verify Interface


### PR DESCRIPTION
I've implemented the general tagging infrastructure and converted the IMA checks to demonstrate it's usage.
Before I now convert the rest of the code base I would like to get some feedback for the current implementation.

## Design
Currently Keylime operates in a binary state when it comes failures that cause revocations and does not collect information where and why that revocation happened.

This commit introduces the tagging and collection infrastructure and configuration for revocation events and adding context to them.

SeverityLabel

 * Has a name that can be set in the keylime.conf and a severity that is dynamically calculated based on the order in the configuration.

Components

 * Is a enumeration that contains the main components of Keylime that can cause events. Must be specified when creating a Failure object.

Event

 * Holds a revocation event. An event can be identified by their event_id which has the format: "component.[sub_component].event"
 * The severity is automatically assigned based on the event_id.
 * The event contains a context which is string encoded JSON object.
 * An event must be marked irrecoverable if other validation steps are skipped by early returning.

Failure

 * Holds a collection of events and provides add_event(...) for adding new events to it and merge(...) to merge it with another Failure object.
 * Is False if no events are currently in the Failure object and is otherwise True.

Future changes that cause a revocation must extend and return a Failure object instead of returning a boolean value.

Part of enhancement proposal keylime/enhancements#48
