### PR TITLE
Additional fix for the processing of "tpm_policy"

### DIFF
--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -233,6 +233,9 @@ class AbstractTPM(metaclass=ABCMeta):
 
     def check_pcrs(self, agentAttestState, tpm_policy, pcrs, data, virtual, ima_measurement_list, allowlist, ima_keyring, mb_measurement_list, mb_refstate_str):
 
+        if isinstance(tpm_policy, str):
+            tpm_policy = json.loads(tpm_policy)
+
         pcr_allowlist = tpm_policy.copy()
 
         if 'mask' in pcr_allowlist:


### PR DESCRIPTION
The "tpm_policy" dictionary (per-`agent` attribute) is converted
to a string by the code on `tenant.py` (used by `keylime_tenant`).
It is is then processed by the `verifier` even before it is stored
on the database, causing an error. This PR ensures that the the
contents of this attribute is selectively converted back to a
dictionary before processing.

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>