### PR TITLE
Typo fix in measured boot code

### DIFF
--- a/keylime/measured_boot.py
+++ b/keylime/measured_boot.py
@@ -29,7 +29,9 @@ def read_mb_refstate(mb_path=None):
 def get_policy(mb_refstate_str):
     """ Convert the mb_refstate_str to JSON and get the measured boot policy.
     :param mb_refstate_str: String representation of measured boot reference state
-    :returns: Returns the JSON object of the measured boot reference state and the measured boot policy;
+    :returns: Returns 
+                  * the measured boot policy object
+                  * the JSON object of the measured boot reference state
               both can be None if mb_refstate_str was empty
     """
 
@@ -57,7 +59,7 @@ def get_policy(mb_refstate_str):
     else:
         mb_policy = None
 
-    return mb_refstate_data, mb_policy
+    return mb_policy, mb_refstate_data
 
 def evaluate_policy(mb_policy, mb_refstate_data, mb_measurement_data, pcrsInQuote, pcrPrefix, agent_id):
     missing = list(set(config.MEASUREDBOOT_PCRS).difference(pcrsInQuote))

--- a/keylime/measured_boot.py
+++ b/keylime/measured_boot.py
@@ -29,7 +29,7 @@ def read_mb_refstate(mb_path=None):
 def get_policy(mb_refstate_str):
     """ Convert the mb_refstate_str to JSON and get the measured boot policy.
     :param mb_refstate_str: String representation of measured boot reference state
-    :returns: Returns 
+    :returns: Returns
                   * the measured boot policy object
                   * the JSON object of the measured boot reference state
               both can be None if mb_refstate_str was empty


### PR DESCRIPTION
measuredboot.py : get_policy returns a tuple consisting of a policy check object and associated mb refstate data.
In some previous commit the order in the tuple was accidentally reversed. Fixing that.

Signed-off-by: George Almasi <gheorghe@us.ibm.com>