### PR TITLE
Solves #703 by adding a "non-trivial" example of a "measured boot policy"

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -258,6 +258,26 @@ revocation_notifier_port = 8992
 # size of the actual payloads
 max_upload_size = 104857600
 
+# Change it to specify the directory (e.g., <KEYLIME_DIR>/keylime/elcheking)
+# where the measured boot "policies" can be found. "Policies" are written in 
+# python, and the code uses as inputs both a "measured boot reference state"
+# and the current measured boot event log provided by an agent. The "measured
+# boot reference state" can be specified on a per-agent basis, but it can be 
+# written in a way that is "generic enough" to apply to multiple agents.
+# The "elchecking" policy is provided as an illustrative example, together with
+# an example "measured boot reference state" (a json file that can be moved 
+# elsewhere)
+# IMPORTANT: if this parameter is kept commented out, then no policy will be
+# applied to the measured boot log and the only check made by the verifier 
+# will be to replay the boot log and compare with the values of PCRs 0-9
+# measured_boot_imports = keylime.elchecking
+
+# Usually, there is a basic policy which is applied by default by default 
+# whenever "measured_boot_imports" is specified. This policy is defined on
+# <KEYLIME_DIR>/keylime/<MEASURED_BOOT_IMPORTS>/__init__.py. If an additional
+# policy (previously written) is required, it can be specified here
+# measured_boot_policy_name = specialboot
+
 #=============================================================================
 [tenant]
 #=============================================================================

--- a/keylime/elchecking/__init__.py
+++ b/keylime/elchecking/__init__.py
@@ -6,3 +6,4 @@
 
 # Basic policies are built in.
 # Additional policies are dynamically loaded according to config.
+from . import example

--- a/keylime/elchecking/policies.py
+++ b/keylime/elchecking/policies.py
@@ -93,7 +93,7 @@ def evaluate(policy_name: str, refstate: RefState, eventlog: tests.Data) -> str:
 
 
 imports = config.MEASUREDBOOT_IMPORTS
-print(f'importing {imports!r}, __package__={__package__!r}')
+#print(f'importing {imports!r}, __package__={__package__!r}')
 for imp in imports:
     if imp:
         importlib.import_module(imp, __package__)

--- a/keylime/elchecking/tests.py
+++ b/keylime/elchecking/tests.py
@@ -33,11 +33,10 @@ class Test(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-
-# type_test constructs a test of data type that is expected to pass
+# type_test constructs a test of data type that is expected to pass.
+# This and the following are used to check reference state for bugs.
 def type_test(t) -> typing.Callable[[typing.Any], bool]:
     """Returns a lambda that tests against the given type.
-
     The lambda returns True on pass, raises Exception on fail."""
     def test(v: typing.Any) -> bool:
         if isinstance(v, t):


### PR DESCRIPTION
The original code for it was provided by mspreitz@us.ibm.com, and it was
slightly adapted by me for testing on a cluster of "generic" Ubuntu Focal
 VMs running with Secure Boot enabled. In addition to the example policy,
there is also an example "measured boot reference state", and a couple of
 comments on `/etc/keylime.conf` for two new `verifier`-specific attributes
 (`measured_boot_imports` and `measured_boot_policy_name`), both disabled
 by default.

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>