### PR TITLE
One-liner to set the minimum version of TLS to v1.2

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -114,6 +114,7 @@ def init_mtls(section='cloud_verifier', generatedir='cv_ca'):
 
     try:
         context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         context.load_verify_locations(cafile=ca_path)
         context.load_cert_chain(
             certfile=my_cert, keyfile=my_priv_key, password=my_key_pw)


### PR DESCRIPTION
TLS v1 and v1.1 have vulnerabilities which will trigger
security scanners when a `verifier` in a corporate
network. This single-line PR just sets the minimum
TLS version for the `verifier` SSL context, avoiding
this problem.

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>