### PR TITLE
verifier: add option to send revocation messages via webhook

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -253,6 +253,13 @@ revocation_notifier = True
 revocation_notifier_ip = 127.0.0.1
 revocation_notifier_port = 8992
 
+# Enable revocation notifications via webhook. This can be used to notify other
+# systems that do not have a Keylime agent running.
+revocation_notifier_webhook = False
+
+# Webhook url for revocation notifications.
+webhook_url = ''
+
 # The verifier limits the size of upload payloads (allowlists) which defaults to
 # 100MB (104857600 bytes). This setting can be raised (or lowered) based on the
 # size of the actual payloads

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -365,7 +365,9 @@ def process_get_status(agent):
 
 
 def notify_error(agent, msgtype='revocation', event=None):
-    if not config.getboolean('cloud_verifier', 'revocation_notifier'):
+    send_mq = config.getboolean('cloud_verifier', 'revocation_notifier')
+    send_webhook = config.getboolean('cloud_verifier', 'revocation_notifier_webhook', False)
+    if not (send_mq or send_webhook):
         return
 
     # prepare the revocation message:
@@ -391,7 +393,10 @@ def notify_error(agent, msgtype='revocation', event=None):
 
     else:
         tosend['signature'] = "none"
-    revocation_notifier.notify(tosend)
+    if send_mq:
+        revocation_notifier.notify(tosend)
+    if send_webhook:
+        revocation_notifier.notify_webhook(tosend)
 
 
 def validate_agent_data(agent_data):


### PR DESCRIPTION
This introduces the option to also send revocation messages via webhook instead of 0mq. 
It is useful for systems that need to act on revocation messages but are not running the Keylime agent.
