### PR TITLE
Fixing pylint erros

### DIFF
--- a/keylime/benchmark/utility_average_logged_deltas.py
+++ b/keylime/benchmark/utility_average_logged_deltas.py
@@ -21,7 +21,7 @@ def main(argv=sys.argv):
     for each_file in glob.glob(args.filename + "*.txt"):
         # command line options can overwrite config values
         if each_file is not None:
-            with open(each_file) as f:
+            with open(each_file, encoding="utf-8") as f:
                 content = [x.strip() for x in f.readlines()]
                 # remove last element (could be weird)
                 # del content[-1:]

--- a/keylime/benchmark/utility_make_1_second_interval_average_list.py
+++ b/keylime/benchmark/utility_make_1_second_interval_average_list.py
@@ -30,7 +30,7 @@ def main(argv=sys.argv):
         # command line options can overwrite config values
         if each_file is not None:
 
-            with open(each_file) as input_file:
+            with open(each_file, encoding="utf-8") as input_file:
                 content = [x.strip() for x in input_file.readlines()]
                 index = 0
                 for each_value in content:
@@ -44,7 +44,7 @@ def main(argv=sys.argv):
                     the_list.append(float(each_value))
                     index = index + 1
 
-    with open(outfile, "w") as output_file:
+    with open(outfile, "w", encoding="utf-8") as output_file:
 
         index = 0
         for _, each_list in number_map.items():

--- a/keylime/benchmark/utility_plot_time_series.py
+++ b/keylime/benchmark/utility_plot_time_series.py
@@ -28,7 +28,7 @@ def main(argv=sys.argv):
 
     cycle_quantity_per_second_list = []
 
-    with open(infile) as input_file:
+    with open(infile, encoding="utf-8") as input_file:
         content = [x.strip() for x in input_file.readlines()]
         index = 0
         for cycle_quantity_per_second in content:

--- a/keylime/benchmark/utility_smoothed_ts.py
+++ b/keylime/benchmark/utility_smoothed_ts.py
@@ -20,7 +20,7 @@ def main(argv=sys.argv):
     for each_file in glob.glob(args.filename + "*.txt"):
         # command line options can overwrite config values
         if each_file is not None:
-            with open(each_file) as f:
+            with open(each_file, encoding="utf-8") as f:
                 content = [x.strip() for x in f.readlines()]
                 # remove last element (could be weird)
                 # del content[-1:]

--- a/keylime/ca_impl_cfssl.py
+++ b/keylime/ca_impl_cfssl.py
@@ -166,7 +166,7 @@ def mk_signed_cert(cacert, ca_pk, name, serialnum):
         # need to temporarily write out the private key with no password
         # to tmpfs
         ca_pk.save_key('%s/ca-key.pem' % secdir, None)
-        with open('%s/cfsslconfig.yml' % secdir, 'w') as f:
+        with open(os.path.join(secdir, 'cfsslconfig.yml'), 'w', encoding="utf-8") as f:
             json.dump(cfsslconfig, f)
 
         cmdline = "-config=%s/cfsslconfig.yml" % secdir
@@ -201,7 +201,7 @@ def gencrl(serials, cert, ca_pk):
         # need to temporarily write out the private key with no password
         # to tmpfs
         priv_key = os.path.abspath("%s/ca-key.pem" % secdir)
-        with open(priv_key, 'w') as f:
+        with open(priv_key, 'w', encoding="utf-8") as f:
             f.write(ca_pk)
         cmdline = " -ca-key %s -ca cacert.crt" % (priv_key)
 

--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -182,19 +182,19 @@ def cmd_certpkg(workingdir, name, insecure=False):
         config.ch_dir(workingdir, logger)
         # zip up the crt, private key, and public key
 
-        with open('cacert.crt') as f:
+        with open('cacert.crt', 'rb') as f:
             cacert = f.read()
 
-        with open(f"{name}-public.pem") as f:
+        with open(f"{name}-public.pem", 'rb') as f:
             pub = f.read()
 
-        with open(f"{name}-cert.crt") as f:
+        with open(f"{name}-cert.crt", 'rb') as f:
             cert = f.read()
 
         with open('cacrl.der', 'rb') as f:
             crl = f.read()
 
-        with open('cacrl.pem') as f:
+        with open('cacrl.pem', 'rb') as f:
             crlpem = f.read()
 
         cert_obj = X509.load_cert_string(cert)
@@ -204,7 +204,7 @@ def cmd_certpkg(workingdir, name, insecure=False):
         priv = read_private()
         private = priv[0][name]
 
-        with open(f"{name}-private.pem") as f:
+        with open(f"{name}-private.pem", 'rb') as f:
             prot_priv = f.read()
 
         # no compression to avoid extraction errors in tmpfs
@@ -221,7 +221,7 @@ def cmd_certpkg(workingdir, name, insecure=False):
         if insecure:
             logger.warning(
                 "Unprotected private keys in cert package being written to disk")
-            with open('%s-pkg.zip' % name, 'w') as f:
+            with open(f'{name}-pkg.zip', 'wb') as f:
                 f.write(pkg)
         else:
             # actually output the package to disk with a protected private key
@@ -243,7 +243,7 @@ def cmd_certpkg(workingdir, name, insecure=False):
 
 def convert_crl_to_pem(derfile, pemfile):
     if config.get('general', 'ca_implementation') == 'openssl':
-        with open(pemfile, 'w') as f:
+        with open(pemfile, 'w', encoding="utf-8") as f:
             f.write("")
     else:
         cmd = ('openssl', 'crl', '-in', derfile, '-inform', 'der',
@@ -289,7 +289,7 @@ def cmd_revoke(workingdir, name=None, serial=None):
         serial = str(serial)
 
         # get the ca key cert and keys as strings
-        with open('cacert.crt') as f:
+        with open('cacert.crt', encoding="utf-8") as f:
             cacert = f.read()
         ca_pk = priv[0]['ca'].decode('utf-8')
 
@@ -320,7 +320,7 @@ def cmd_regencrl(workingdir):
         priv = read_private()
 
         # get the ca key cert and keys as strings
-        with open('cacert.crt') as f:
+        with open('cacert.crt', encoding="utf-8") as f:
             cacert = f.read()
         ca_pk = str(priv[0]['ca'])
 
@@ -453,7 +453,7 @@ def write_private(inp):
     ciphertext = crypto.encrypt(priv_encoded, key)
     towrite = {'salt': salt, 'priv': ciphertext}
 
-    with os.fdopen(os.open('private.yml', os.O_WRONLY | os.O_CREAT, 0o600), 'w') as f:
+    with os.fdopen(os.open('private.yml', os.O_WRONLY | os.O_CREAT, 0o600), 'w', encoding="utf-8") as f:
         yaml.dump(towrite, f, Dumper=SafeDumper)
 
 
@@ -464,7 +464,7 @@ def read_private(warn=False):
             "Please enter the password to decrypt your keystore: "))
 
     if os.path.exists('private.yml'):
-        with open('private.yml') as f:
+        with open('private.yml', encoding="utf-8") as f:
             toread = yaml.load(f, Loader=SafeLoader)
         key = crypto.kdf(global_password, toread['salt'])
         try:

--- a/keylime/cmd/ima_emulator_adapter.py
+++ b/keylime/cmd/ima_emulator_adapter.py
@@ -21,7 +21,7 @@ FF_HASH = 'ffffffffffffffffffffffffffffffffffffffff'
 
 
 def ml_extend(ml, position, searchHash=None):
-    f = open(ml, 'r')
+    f = open(ml, encoding="utf-8")
     lines = itertools.islice(f, position, None)
 
     for line in lines:
@@ -87,7 +87,7 @@ def main():
 
     print("Monitoring %s" % (config.IMA_ML))
     poll_object = select.poll()
-    fd_object = open(config.IMA_ML, "r")
+    fd_object = open(config.IMA_ML, encoding="utf-8")
     number = fd_object.fileno()
     poll_object.register(fd_object, select.POLLIN | select.POLLPRI)
 

--- a/keylime/cmd/provider_platform_init.py
+++ b/keylime/cmd/provider_platform_init.py
@@ -47,10 +47,10 @@ def main(argv=sys.argv):
             "\t nv_readvalue -pwdo <owner-password> -in 1000f000 -cert -of tpm_ekcert.der")
         sys.exit(-1)
 
-    f = open(argv[1], 'r')
+    f = open(argv[1], 'rb')
     ek = f.read()
     f.close()
-    f = open(argv[2], 'r')
+    f = open(argv[2], 'rb')
     ekcert = base64.b64encode(f.read())
     f.close()
 
@@ -82,7 +82,7 @@ def main(argv=sys.argv):
     }
 
     # store the key and the group UUID in a file to add to vtpms later
-    with open("group-%d-%s.tpm" % (group_num, group_uuid), 'w') as f:
+    with open(f"group-{group_num}-{group_uuid}.tpm", 'w', encoding="utf-8") as f:
         yaml.dump(output, f, Dumper=SafeDumper)
 
     logger.info("Activated VTPM group %d, UUID %s" % (group_num, group_uuid))

--- a/keylime/cmd/provider_vtpm_add.py
+++ b/keylime/cmd/provider_vtpm_add.py
@@ -24,7 +24,7 @@ logger = keylime_logging.init_logging('platform-init')
 
 def add_vtpm(inputfile):
     # read in the file
-    with open(inputfile, 'r') as f:
+    with open(inputfile, encoding="utf-8") as f:
         group = yaml.load(f, Loader=SafeLoader)
 
     # fetch configuration parameters

--- a/keylime/cmd/user_data_encrypt.py
+++ b/keylime/cmd/user_data_encrypt.py
@@ -43,13 +43,13 @@ def main(argv=sys.argv):
         print("ERROR: File %s not found." % infile)
         usage()
 
-    f = open(infile, 'r')
+    f = open(infile, encoding="utf-8")
     contents = f.read()
 
     ret = encrypt(contents)
 
     print("Writing keys to content_keys.txt")
-    f = open('content_keys.txt', 'w')
+    f = open('content_keys.txt', 'w', encoding="utf-8")
     f.write(base64.b64encode(ret['k']).decode('utf-8'))
     f.write('\n')
     f.write(base64.b64encode(ret['v']).decode('utf-8'))
@@ -59,7 +59,7 @@ def main(argv=sys.argv):
     f.close()
 
     print("Writing encrypted data to content_payload.txt")
-    f = open('content_payload.txt', 'w')
+    f = open('content_payload.txt', 'w', encoding="utf-8")
     f.write(ret['ciphertext'].decode('utf-8'))
     f.close()
 

--- a/keylime/elchecking/__main__.py
+++ b/keylime/elchecking/__main__.py
@@ -24,7 +24,7 @@ refstate = json.loads(refstate_str)
 log_bin = args.eventlog_file.read()
 tpm = tpm_main.tpm()
 log_data = tpm.parse_binary_bootlog(log_bin)
-with open('/tmp/parsed.json', 'wt') as log_data_file:
+with open('/tmp/parsed.json', 'wt', encoding="utf-8") as log_data_file:
     log_data_file.write(json.dumps(log_data, indent=True))
 why_not = policy.evaluate(refstate, log_data)
 if why_not:

--- a/keylime/elchecking/policies.py
+++ b/keylime/elchecking/policies.py
@@ -49,7 +49,7 @@ class AcceptAll(Policy):
 
 
 def _mkreg() -> typing.Mapping[str, Policy]:
-    return dict()
+    return {}
 
 
 _registry = _mkreg()

--- a/keylime/elchecking/tests.py
+++ b/keylime/elchecking/tests.py
@@ -162,7 +162,7 @@ class Dispatcher(Test):
             raise Exception('Dispatcher given empty list of key names')
         list(map(type_test(str), key_names))
         self.key_names = key_names
-        self.tests = dict()
+        self.tests = {}
 
     def set(self, key_vals: typing.Tuple[str, ...], test: Test) -> None:
         """Set the test for the given value tuple"""
@@ -327,7 +327,7 @@ class DelayToFields(Test):
 
     def why_not(self, globs: Globals, subject: Data) -> str:
         """Test the stashed field values"""
-        delayed = dict()
+        delayed = {}
         for field_name in self.field_names:
             delayed[field_name] = globs.get(field_name, None)
         return self.fields_test.why_not(globs, delayed)
@@ -390,7 +390,7 @@ class DigestsTest(Test):
     def __init__(self, good_digests_list: typing.Iterable[Digest]):
         """good_digests_list is a list of good {alg:hash}"""
         super().__init__()
-        self.good_digests = dict()
+        self.good_digests = {}
         'map from alg to set of good digests'
         for good_digests in good_digests_list:
             type_test(dict)(good_digests)

--- a/keylime/gpg.py
+++ b/keylime/gpg.py
@@ -15,7 +15,7 @@ def gpg_verify_filesignature(gpg_key_file, filename, gpg_sig_file, file_descript
        with the file (filename).
     """
     gpg = gnupg.GPG()
-    with open(gpg_key_file) as key_f:
+    with open(gpg_key_file, encoding="utf-8") as key_f:
         logger.debug("Importing GPG key %s", gpg_key_file)
         gpg_imported = gpg.import_keys(key_f.read())
         if gpg_imported.count == 1: # pylint: disable=E1101

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -63,7 +63,7 @@ def read_measurement_list(filename, nth_entry):
     if not os.path.exists(filename):
         logger.warning("IMA measurement list not available: %s", filename)
     else:
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding="utf-8") as f:
             filedata = f.read()
         ml, num_entries = get_from_nth_entry(filedata, nth_entry)
         if nth_entry > num_entries:
@@ -284,7 +284,7 @@ def read_allowlist(al_path=None, checksum="", gpg_sig_file=None, gpg_key_file=No
         return copy.deepcopy(empty_allowlist)
 
     # Purposefully die if path doesn't exist
-    with open(al_path) as f:
+    with open(al_path, 'rb') as f:
         pass
 
     # verify GPG signature if needed
@@ -372,7 +372,7 @@ def read_excllist(exclude_path=None):
 
     excl_list = []
     if os.path.exists(exclude_path):
-        with open(exclude_path) as f:
+        with open(exclude_path, encoding="utf-8") as f:
             excl_list = f.read()
         excl_list = excl_list.splitlines()
 
@@ -398,10 +398,10 @@ def main():
     # measure_path='../scripts/ima/ascii_runtime_measurements_ima'
     # measure_path = '../scripts/gerardo/ascii_runtime_measurements'
     print("reading measurement list from %s" % measure_path)
-    f = open(measure_path)
+    f = open(measure_path, encoding="ascii")
     lines = f.readlines()
 
-    m2a = open('measure2allow.txt', "w")
+    m2a = open('measure2allow.txt', "w", encoding="utf-8")
     digest = process_measurement_list(AgentAttestState('1'), lines, lists, m2a)
     print("final digest is %s" % digest)
     f.close()

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -240,7 +240,7 @@ class Handler(BaseHTTPRequestHandler):
             shutil.rmtree("%s/unzipped" % secdir)
 
         # write out key file
-        f = open(secdir + "/" + self.server.enc_keyname, 'w')
+        f = open(secdir + "/" + self.server.enc_keyname, 'w', encoding="utf-8")
         f.write(base64.b64encode(self.server.K).decode())
         f.close()
 
@@ -609,7 +609,7 @@ def main():
             # load actions from unzipped
             action_list_path = os.path.join(secdir, "unzipped/action_list")
             if os.path.exists(action_list_path):
-                with open(action_list_path) as f:
+                with open(action_list_path, encoding="utf-8") as f:
                     actionlisttxt = f.read()
                 if actionlisttxt.strip() != "":
                     localactions = actionlisttxt.strip().split(',')

--- a/keylime/measured_boot.py
+++ b/keylime/measured_boot.py
@@ -19,7 +19,7 @@ def read_mb_refstate(mb_path=None):
 
     mb_data = None
     # Purposefully die if path doesn't exist
-    with open(mb_path) as f:
+    with open(mb_path, encoding="utf-8") as f:
         mb_data = json.load(f)
 
     logger.debug("Loaded measured boot reference state from %s", mb_path)

--- a/keylime/migrations/env.py
+++ b/keylime/migrations/env.py
@@ -74,7 +74,7 @@ def run_migrations_offline():
         file_ = "%s.sql" % name
         logger.info("Writing output to %s" % file_)
 
-        with open(file_, "w") as buffer:
+        with open(file_, "w", encoding="utf-8") as buffer:
             engine = DBEngineManager().make_engine(name)
             connection = engine.connect()
             context.configure(

--- a/keylime/revocation_actions/update_crl.py
+++ b/keylime/revocation_actions/update_crl.py
@@ -58,7 +58,7 @@ def execute(json_revocation):
 
         # write out the updated CRL
         logger.debug("Updating CRL in %s/unzipped/cacrl.der" % (secdir))
-        with open("%s/unzipped/cacrl.der" % (secdir), "w") as f:
+        with open("%s/unzipped/cacrl.der" % (secdir), "wb") as f:
             f.write(response.body)
         ca_util.convert_crl_to_pem(
             "%s/unzipped/cacrl.der" % (secdir), "%s/unzipped/cacrl.pem" % secdir)

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -108,7 +108,7 @@ def await_notifications(callback, revocation_cert_path):
             if revocation_cert_path is not None and os.path.exists(revocation_cert_path):
                 logger.info(
                     "Lazy loading the revocation certificate from %s" % revocation_cert_path)
-                with open(revocation_cert_path) as f:
+                with open(revocation_cert_path, "rb") as f:
                     certpem = f.read()
                 cert_key = crypto.x509_import_pubkey(certpem)
 

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -328,7 +328,7 @@ class Tenant():
                 else:
                     raise UserError("Invalid key file provided")
             else:
-                f = open(args["keyfile"])
+                f = open(args["keyfile"], encoding="utf-8")
             self.K = base64.b64decode(f.readline())
             self.U = base64.b64decode(f.readline())
             self.V = base64.b64decode(f.readline())
@@ -340,7 +340,7 @@ class Tenant():
                     self.payload = args["payload"]["data"][0]
             else:
                 if args["payload"] is not None:
-                    f = open(args["payload"])
+                    f = open(args["payload"], 'rb')
                     self.payload = f.read()
                     f.close()
 
@@ -357,7 +357,7 @@ class Tenant():
                 else:
                     raise UserError("Invalid file payload provided")
             else:
-                with open(args["file"]) as f:
+                with open(args["file"], 'rb') as f:
                     contents = f.read()
             ret = user_data_encrypt.encrypt(contents)
             self.K = ret['k']

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -381,7 +381,7 @@ class AgentsHandler(BaseHandler):
             if "pos" in rest_params and rest_params["pos"] is not None and rest_params["pos"].isdigit():
                 offset = int(rest_params["pos"])
             # intercept requests for logs
-            with open(keylime_logging.LOGSTREAM) as f:
+            with open(keylime_logging.LOGSTREAM, encoding="utf-8") as f:
                 logValue = f.readlines()
                 config.echo_json_response(self, 200, "Success", {
                                           'log': logValue[offset:]})

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -135,7 +135,7 @@ class AbstractTPM(metaclass=ABCMeta):
         os.umask(0o077)
         if os.geteuid() != 0 and config.REQUIRE_ROOT:
             logger.warning("Creating tpm metadata file without root. Sensitive trust roots may be at risk!")
-        with open('tpmdata.yml', 'w') as f:
+        with open('tpmdata.yml', 'w', encoding="utf-8") as f:
             yaml.dump(self.global_tpmdata, f, Dumper=SafeDumper)
 
     def get_tpm_metadata(self, key):

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -1255,7 +1255,7 @@ class tpm(tpm_abstract.AbstractTPM):
         old_pcrs = log['pcrs']
         if not isinstance(old_pcrs, dict):
             return
-        new_pcrs = dict()
+        new_pcrs = {}
         for hash_alg, cells in old_pcrs.items():
             if not isinstance(cells, dict):
                 new_pcrs[hash_alg] = cells

--- a/keylime/tpm_ek_ca.py
+++ b/keylime/tpm_ek_ca.py
@@ -32,7 +32,7 @@ def cert_loader():
     file_list = glob.glob(os.path.join(os.getcwd(), tpm_cert_store + "*.pem"))
     my_trusted_certs = []
     for file_path in file_list:
-        with open(file_path) as f_input:
+        with open(file_path, encoding="utf-8") as f_input:
             my_trusted_certs.append(f_input.read())
     return my_trusted_certs
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ Copyright 2017 Massachusetts Institute of Technology.
 '''
 import setuptools
 
-with open('README.md', 'r') as fh:
+with open('README.md', encoding="utf-8") as fh:
     long_description = fh.read()
 
 

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -132,7 +132,7 @@ def setUpModule():
         its.wait()
         tsd = subprocess.Popen(["tpm_serverd"], shell=False, env=env)
         tsd.wait()
-    except Exception as e:
+    except Exception:
         print("WARNING: Restarting TPM emulator failed!")
     # Note: the following is required as abrmd is failing to reconnect to MSSIM, once
     # MSSIM is killed and restarted. If this is an proved an actual bug and is
@@ -150,7 +150,7 @@ def setUpModule():
                     manager.RestartUnit('tpm2-abrmd.service', 'fail')
                 except dbus.exceptions.DBusException as e:
                     print(e)
-    except Exception as e:
+    except Exception:
         print("Non systemd agent detected, no tpm2-abrmd restart required.")
 
     try:
@@ -159,7 +159,7 @@ def setUpModule():
         fileRemove(config.WORK_DIR + "/cv_data.sqlite")
         fileRemove(config.WORK_DIR + "/reg_data.sqlite")
         shutil.rmtree(config.WORK_DIR + "/cv_ca", True)
-    except Exception as e:
+    except Exception:
         print("WARNING: Cleanup of TPM files failed!")
 
     # CV must be run first to create CA and certs!


### PR DESCRIPTION
This fixes W1514, W0612 and R1735 pylint errors.

W1514 enforces that an encoding is specified when open is used. 

I defaulted to "utf-8" and  used "ascii" or byte encoding where I was relative sure that this is correct. 
Someone else should also look at those changes to make sure that I haven't made wrong assumptions. 