### PR TITLE
systemd: Add KillSignal=SIGINT to keylime_agent.service

### DIFF
--- a/services/keylime_agent.service
+++ b/services/keylime_agent.service
@@ -3,6 +3,7 @@ Description=The Keylime compute agent
 
 [Service]
 ExecStart=/usr/bin/keylime_agent
+KillSignal=SIGINT
 
 [Install]
 WantedBy=default.target

--- a/services/keylime_agent.service.template
+++ b/services/keylime_agent.service.template
@@ -3,6 +3,7 @@ Description=The Keylime compute agent
 
 [Service]
 ExecStart=KEYLIMEDIR/keylime_agent
+KillSignal=SIGINT
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
If systemd sends SIGTERM to the agent it terminates the agent immediately without the cleanup functions being called. This will result in the TPM NV being full after a couple of agent restarts.

Using SIGINT instead of SIGTERM fixes this issue.