### PR TITLE
small bug fix for malformed refstates not failing MBA

### DIFF
--- a/keylime/measured_boot.py
+++ b/keylime/measured_boot.py
@@ -69,9 +69,7 @@ def evaluate_policy(mb_policy, mb_refstate_data, mb_measurement_data, pcrsInQuot
     try:
         reason = mb_policy.evaluate(mb_refstate_data, mb_measurement_data)
     except Exception as exn:
-        logger.error("Boot attestation for agent %s, configured policy %s, refstate=%s, raised Exception %s",
-            agent_id, config.MEASUREDBOOT_POLICYNAME, json.dumps(mb_refstate_data), str(exn))
-        reason = ''
+        reason= "policy evaluation failed: %s"%(str(exn))
     if reason:
         logger.error("Boot attestation failed for agent %s, configured policy %s, refstate=%s, reason=%s",
             agent_id, config.MEASUREDBOOT_POLICYNAME, json.dumps(mb_refstate_data), reason)


### PR DESCRIPTION
One-line bug fix that prevents measured boot attestation from continuing as if normal if the refstate is malformed or the policy is buggy and causes an exception.

Second try -- the first attempt failed because it included another PR by accident.

Signed-off-by: George Almasi <gheorghe@us.ibm.com>