### PR TITLE
tenant: open file to send utf-8 encoded

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -357,7 +357,7 @@ class Tenant():
                 else:
                     raise UserError("Invalid file payload provided")
             else:
-                with open(args["file"], 'rb') as f:
+                with open(args["file"], encoding="utf-8") as f:
                     contents = f.read()
             ret = user_data_encrypt.encrypt(contents)
             self.K = ret['k']


### PR DESCRIPTION
Was by mistake changed to byte encoding in 2ba03e9a.