### PR TITLE
By default use the kernel resource manager instead of tpm2-abrmd

### DIFF
--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -38,7 +38,8 @@ def _get_cmd_env():
         lib_path = env['LD_LIBRARY_PATH']
     if 'TPM2TOOLS_TCTI' not in env:
         # Don't clobber existing setting (if present)
-        env['TPM2TOOLS_TCTI'] = 'tabrmd:bus_name=com.intel.tss2.Tabrmd'
+        env['TPM2TOOLS_TCTI'] = 'device:/dev/tpmrm0'
+        # env['TPM2TOOLS_TCTI'] = 'tabrmd:bus_name=com.intel.tss2.Tabrmd'
         # Other (not recommended) options are direct emulator and chardev communications:
         # env['TPM2TOOLS_TCTI'] = 'mssim:port=2321'
         # env['TPM2TOOLS_TCTI'] = 'device:/dev/tpm0'


### PR DESCRIPTION
The linux kernel starting with 4.12 ships with its own resource manager  which makes tpm2-abrmd not needed anymore for most use cases. This changes the installer script to not install tpm2-adrmd and changes the default to `device:/dev/tpmrm0`.

We already dropped the tpm2-abrmd dependency for the Debian package by setting that value manually.