### PR TITLE
Simulating use of SSLContext.minimum_version on ssl v3.6

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -9,6 +9,7 @@ import os
 import ssl
 import socket
 import time
+import sys
 
 import simplejson as json
 
@@ -114,7 +115,10 @@ def init_mtls(section='cloud_verifier', generatedir='cv_ca'):
 
     try:
         context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-        context.minimum_version = ssl.TLSVersion.TLSv1_2
+        if sys.version_info >= (3,7):
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+        else:
+            context.options &= ~ssl.OP_NO_TLSv1_2
         context.load_verify_locations(cafile=ca_path)
         context.load_cert_chain(
             certfile=my_cert, keyfile=my_priv_key, password=my_key_pw)


### PR DESCRIPTION
Hi all,

keylime code is using SSL library version 3.7+ but we have 3.6 in Ubuntu Focal. So, the idea is to adapt the needed calls or use of functions and constants to 3.6 with the same functionality. Following this https://docs.python.org/3/library/ssl.html#ssl.OP_NO_TLSv1 and https://docs.python.org/3/library/ssl.html#ssl.create_default_context,  here is a proposal.

We tested that services are up and running after the change.

Any suggestions or concerns are welcome... Thanks in advance.