### PR TITLE
Sanitize the exclude list while it is ingested at `tenant` by removing comments (^#) and empty lines.

### DIFF
--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -391,8 +391,11 @@ def read_excllist(exclude_path=None):
     excl_list = []
     if os.path.exists(exclude_path):
         with open(exclude_path, encoding="utf-8") as f:
-            excl_list = f.read()
-        excl_list = excl_list.splitlines()
+            for line in f :
+                line = line.strip()
+                if line.startswith('#') or len(line) == 0:
+                    continue
+                excl_list.append(line)
 
         logger.debug("Loaded exclusion list from %s: %s" %
                      (exclude_path, excl_list))


### PR DESCRIPTION


Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>