### PR TITLE
code improvement: removal of extra dependencies in measured boot attestation

### DIFF
--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -1277,21 +1277,23 @@ class tpm(tpm_abstract.AbstractTPM):
         Error conditions caused by improper string formatting etc. are
         ignored. The current assumption is that the boot event log PCR
         values are in decimal encoding, but this is liable to change.'''
-        if (not isinstance(log, dict)) or 'pcrs' not in log: return
+        if (not isinstance(log, dict)) or 'pcrs' not in log:
+            return
         log['boot_aggregates'] = {}
         for hashalg in log['pcrs'].keys():
             log['boot_aggregates'][hashalg] = []
             for maxpcr in [8,10]:
                 try:
-                    h = eval('hashlib.' + hashalg + '()')
+                    hashclass = getattr(hashlib,hashalg)
+                    h = hashclass()
                     for pcrno in range(0,maxpcr):
                         pcrstrg=log['pcrs'][hashalg][str(pcrno)]
                         pcrhex= '{0:0{1}x}'.format(pcrstrg, h.digest_size*2)
                         h.update(bytes.fromhex(pcrhex))
                     log['boot_aggregates'][hashalg].append(h.hexdigest())
-                except:
+                except Exception:
                     pass
-                
+
     def parse_binary_bootlog(self, log_bin:bytes) -> dict:
         '''Parse and enrich a BIOS boot log
 

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -1276,8 +1276,7 @@ class tpm(tpm_abstract.AbstractTPM):
 
         Error conditions caused by improper string formatting etc. are
         ignored. The current assumption is that the boot event log PCR
-        values are in decimal encoding, but this is liable to change.
-        '''
+        values are in decimal encoding, but this is liable to change.'''
         if (not isinstance(log, dict)) or 'pcrs' not in log: return
         log['boot_aggregates'] = {}
         for hashalg in log['pcrs'].keys():
@@ -1298,7 +1297,12 @@ class tpm(tpm_abstract.AbstractTPM):
 
         The input is the binary log.
         The output is the result of parsing and applying other conveniences.'''
-        log_parsed_data = {}
+        with tempfile.NamedTemporaryFile() as log_bin_file:
+            log_bin_file.write(log_bin)
+            log_bin_filename = log_bin_file.name
+            retDict_tpm2 = self.__run(['tpm2_eventlog', '--eventlog-version=2', log_bin_filename])
+        log_parsed_strs = retDict_tpm2['retout']
+        log_parsed_data = config.yaml_to_dict(log_parsed_strs, add_newlines=False)
         #pylint: disable=import-outside-toplevel
         try:
             from keylime import tpm_bootlog_enrich

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -1278,6 +1278,7 @@ class tpm(tpm_abstract.AbstractTPM):
         ignored. The current assumption is that the boot event log PCR
         values are in decimal encoding, but this is liable to change.
         '''
+        if (not isinstance(log, dict)) or 'pcrs' not in log: return
         log['boot_aggregates'] = {}
         for hashalg in log['pcrs'].keys():
             log['boot_aggregates'][hashalg] = []


### PR DESCRIPTION
This code fix removes the dependency on `tsseventextend` and thereby implicitly on the tss2 package. Whereas previously `tsseventextend` was used to calculate boot aggregate candidates for IMA, now that is done by using Python's `hashlib` functions.

* The code dependency on `tss2_eventlog` is unchanged.

* Possible boot aggregates are computed by using the output of the *parsed* and *replayed* binary boot log. We consider this acceptable (not a security risk) because the boot log is authenticated against the actual tpm quote before the generated boot aggregates have a chance of being used.

* The recalculation of boot aggregates is done in every attestation cycle instead of just once. This is an optimization problem for later consideration.