### PR TITLE
Fix bug #757 where revoc cert was treated as text

### DIFF
--- a/keylime/crypto.py
+++ b/keylime/crypto.py
@@ -44,8 +44,7 @@ def rsa_import_privkey(privkey):
 
 
 def x509_import_pubkey(pubkey):
-    key = x509.load_pem_x509_certificate(
-        pubkey.encode('utf-8'), backend=default_backend())
+    key = x509.load_pem_x509_certificate(pubkey, backend=default_backend())
     return key.public_key()
 
 


### PR DESCRIPTION
Recent changes to make opens more explicit now open
the revocation cert as binary, so no need to encode it as text.