### PR TITLE
ima: make ToMToU errors not a failure by default

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -295,6 +295,11 @@ severity_labels = ["info", "notice", "warning", "error", "critical", "alert", "e
 # severity to all events.
 severity_policy = [{"event_id": ".*", "severity_label": "emergency"}]
 
+# If files are already opened when IMA tries to measure them this causes
+# a time of measure, time of use (ToMToU) error entry.
+# By default we ignore those entries and only print a warning.
+# Set to True to treat ToMToU entries as errors.
+tomtou_errors = False
 
 #=============================================================================
 [tenant]


### PR DESCRIPTION
This adds the option to either treat ToMToU errors as a failure or not.

@mpeters can you test if this works for you?