### PR TITLE
ima: Extend allowlist to be able to handle generic ima-buf entries

### DIFF
--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -27,7 +27,7 @@ logger = keylime_logging.init_logging('ima')
 
 
 # The version of the allowlist format that is supported by this keylime release
-ALLOWLIST_CURRENT_VERSION = 3
+ALLOWLIST_CURRENT_VERSION = 4
 
 
 def get_from_nth_entry(filedata, nth_entry):
@@ -153,6 +153,9 @@ def _validate_ima_buf(exclude_regex, allowlist, ima_keyrings: ima_file_signature
             if not failure:
                 # Add the key only now that it's validated (no failure)
                 ima_keyrings.add_pubkey_to_keyring(pubkey, path.name, keyidv2=keyidv2)
+    else:
+        # handling of generic ima-buf entries that for example carry a hash in the buf field
+        failure = _validate_ima_ng(exclude_regex, allowlist, digest, path, hash_types='ima-buf')
 
     # Anything else evaluates to true for now
     return failure
@@ -280,6 +283,9 @@ def update_allowlist(allowlist):
         allowlist["ima"] = {}
     if not "ignored_keyrings" in allowlist["ima"]:
         allowlist["ima"]["ignored_keyrings"] = []
+    # version 4 added 'ima-buf'
+    if "ima-buf" not in allowlist:
+        allowlist["ima-buf"] = {}
 
     return allowlist
 

--- a/test/test_ima_verification.py
+++ b/test/test_ima_verification.py
@@ -241,7 +241,7 @@ class TestIMAVerification(unittest.TestCase):
         al_data = ima.read_allowlist(allowlist_file)
         self.assertIsNotNone(al_data, "AllowList data is present")
         self.assertIsNotNone(al_data["meta"], "AllowList metadata is present")
-        self.assertEqual(al_data["meta"]["version"], 3, "AllowList metadata version is correct")
+        self.assertEqual(al_data["meta"]["version"], 4, "AllowList metadata version is correct")
         self.assertEqual(al_data["meta"]["generator"], "keylime-legacy-format-upgrade", "AllowList metadata generator is correct")
         self.assertNotIn("checksum", al_data["meta"], "AllowList metadata no checksum")
         self.assertIsNotNone(al_data["hashes"], "AllowList hashes are present")


### PR DESCRIPTION
Extend the allowlist to be able to handle generic ima-buf entries that for
example appear when one adds 'ima_policy=critical_data' to the Linux boot
command line parameters. With this policy one may get the following entries
in the measurement log:
    
```
10 6ddb524d7c630f0d64ac1c048ebf6e1a4b2099ac ima-buf sha256:acc2... kernel_version 352e31322e382d333030372e666333342e7838365f3634
10 b8562cfba9b8e9302f72b4cb9c3f4bbb07264589 ima-buf sha256:2dbb... selinux-policy-hash 5a5cd4968d0476b704e24f4ede5b372bda0b84fb46ccd2f53a7f93026218b08c
```
    
The kernel version's sha256 hash can be reproduced like this:
    
`uname -r | tr -d '\n' | sha256sum -> acc23743...`
    
The number string behind the kernel_version above is in human readable
format '5.12.8-3007.fc34.x86_64', so it's the same as
'uname -r | tr -d '\n''
    
The hash following the seclinux-policy-hash can be recreated using
`sha256sum < /sys/fs/selinux/policy`

The sha-256 of the actual measurement is the sha-256 of the binary
representation of the policy's hash.
    
So the simplest way to support this is to add an ima-buf entry to the
allowlist like shown below to be able to accept these measurements if they
show up:
    
```
    {
        "meta" : {
           "version": 3
        },
        "release": 0,
        "hashes": {
            [...]
        },
        "ima-buf": {
            "kernel-version": ["acc23743f9ff73d197875292691fa3ac586940c2fb2bde9b0c692cc6c5cb5b0a"],
            "selinux-policy-hash": ["2dbb2f53d0196d9e2c11d55f61549cc828740d6d9428e7df0c354326f979ea27"]
        }
    }
```
    
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>
