### PR TITLE
Fix a couple of pylint errors

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -104,7 +104,7 @@ def verifier_db_delete_agent(session, agent_id):
 
 def store_attestation_state(agentAttestState):
     # Only store if IMA log was evaluated
-    if len(agentAttestState.get_ima_pcrs()):
+    if agentAttestState.get_ima_pcrs():
         session = get_session()
         try:
             update_agent = session.query(VerfierMain).get(agentAttestState.get_agent_id())

--- a/pylintrc
+++ b/pylintrc
@@ -5,4 +5,4 @@ jobs=0
 disable=W1509,C0103,C0115,C0116,C0201,C0209,C0301,C0302,C0111,W0102,W0511,W0602,W0603,W0703,W1201,W1203,E1120,R0801,R0902,R0903,R0904,R0912,R0913,R0914,R0915,R0201,R0911,R1729,R1732
 
 [TYPECHECK]
-ignored-modules=zmq,alembic.op,alembic.context,M2Crypto.m2,Cryptodome,pylab,matplotlib,numpy
+ignored-modules=zmq,alembic.op,alembic.context,M2Crypto.m2,Cryptodome,pylab,matplotlib,numpy,cryptography.hazmat.primitives.asymmetric.rsa


### PR DESCRIPTION
Ignore E1101 errors in cryptography.hazmat.primitives.asymmetric.rsa

For C1801 checks, we don't need to use len in boolean checks of sequences