### PR TITLE
ima: Also add a sha256 default boot_aggregate hash with 64 '0's

### DIFF
--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -295,7 +295,7 @@ def process_allowlists(allowlist, exclude):
 
     if allowlist['hashes'].get('boot_aggregate') is None:
         logger.warning("No boot_aggregate value found in allowlist, adding an empty one")
-        allowlist['hashes']['boot_aggregate'] = ['0000000000000000000000000000000000000000']
+        allowlist['hashes']['boot_aggregate'] = ['0'*40, '0'*64]
 
     for excl in exclude:
         # remove commented out lines


### PR DESCRIPTION
Fix issue #702 by adding a sha256 all-zeros hash to the boot_aggregate.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>