### PR TITLE
add length to string object

### DIFF
--- a/keylime/migrations/versions/257fe0f0c039_add_fields_for_revocation_context_to_.py
+++ b/keylime/migrations/versions/257fe0f0c039_add_fields_for_revocation_context_to_.py
@@ -37,7 +37,7 @@ def downgrade_registrar():
 
 def upgrade_cloud_verifier():
     op.add_column('verifiermain', sa.Column('severity_level', sa.Integer))
-    op.add_column('verifiermain', sa.Column('last_event_id', sa.String))
+    op.add_column('verifiermain', sa.Column('last_event_id', sa.String(100)))
 
 
 def downgrade_cloud_verifier():

--- a/keylime/migrations/versions/a7a64155ab3a_add_ima_filesigning_keys_column.py
+++ b/keylime/migrations/versions/a7a64155ab3a_add_ima_filesigning_keys_column.py
@@ -33,7 +33,7 @@ def downgrade_registrar():
 
 
 def upgrade_cloud_verifier():
-    op.add_column('verifiermain', sa.Column('ima_sign_verification_keys', sa.String))
+    op.add_column('verifiermain', sa.Column('ima_sign_verification_keys', sa.String(1000)))
 
 
 def downgrade_cloud_verifier():

--- a/keylime/migrations/versions/ae898986c6e9_add_mb_refstate_column.py
+++ b/keylime/migrations/versions/ae898986c6e9_add_mb_refstate_column.py
@@ -36,7 +36,7 @@ def downgrade_registrar():
 
 
 def upgrade_cloud_verifier():
-    op.add_column('verifiermain', sa.Column('mb_refstate', sa.String))
+    op.add_column('verifiermain', sa.Column('mb_refstate', sa.String(1000)))
 
 
 def downgrade_cloud_verifier():

--- a/keylime/migrations/versions/b4d024197413_add_verfier_id_to_verifiermain_table.py
+++ b/keylime/migrations/versions/b4d024197413_add_verfier_id_to_verifiermain_table.py
@@ -36,8 +36,8 @@ def downgrade_registrar():
 
 
 def upgrade_cloud_verifier():
-    op.add_column('verifiermain', sa.Column('verifier_id', sa.String))
-    op.add_column('verifiermain', sa.Column('verifier_ip', sa.String))
+    op.add_column('verifiermain', sa.Column('verifier_id', sa.String(100)))
+    op.add_column('verifiermain', sa.Column('verifier_ip', sa.String(20)))
     op.add_column('verifiermain', sa.Column('verifier_port', sa.Integer))
 
 


### PR DESCRIPTION
If string length is not specified, migrating to MySQL database will give an error: VARCHAR requires a length on dialect mysql