### PR TITLE
ca: Use UTC when setting certificate validity

### DIFF
--- a/keylime/ca_impl_openssl.py
+++ b/keylime/ca_impl_openssl.py
@@ -24,7 +24,7 @@ def mk_cert_valid(cert_req, days=365):
     """
 
     one_day = datetime.timedelta(1, 0, 0)
-    today = datetime.datetime.today()
+    today = datetime.datetime.now(datetime.timezone.utc)
     cert_req = cert_req.not_valid_before(today)
     cert_req = cert_req.not_valid_after(today + (one_day * days))
     return cert_req


### PR DESCRIPTION
This is a small regression from the change that replaced M2Crypto with
python-cryptography, as the certificate was using UTC back then when
setting up its validity.

Fixes: #759 