### PR TITLE
config: fix getboolean with fallback

### DIFF
--- a/keylime/config.py
+++ b/keylime/config.py
@@ -168,7 +168,7 @@ def getint(section, option, fallback=None):
 
 def getboolean(section, option, fallback=None):
     if fallback is not None:
-        return get_config().get(section, option, fallback=fallback)
+        return get_config().getboolean(section, option, fallback=fallback)
     return get_config().getboolean(section, option)
 
 


### PR DESCRIPTION
When getboolean with a fallback was called, it was not converted to a boolean
instead the string was returned.

This now should fully fix #783 .