### PR TITLE
config: drop registrar_* TLS options in [registrar] section

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -508,14 +508,6 @@ private_key_pw = default
 # with the registar) by the CV.
 registrar_tls_dir = CV
 
-# The following three options set the filenames in the 'tls_dir' where the CA
-# certificate, client certificate, and client private key file can be found.
-# If 'tls_dir = default', then default values will be used for 'ca_cert =
-# cacert.pem', 'my_cert = client-cert.crt', and 'private_key = client-private.pem'.
-registrar_ca_cert = default
-registrar_my_cert = default
-registrar_private_key = default
-
 # Set the password needed to decrypt the private key file.
 # This should be set to a strong password.
 # If you are using the auto generated keys from the CV, set the same password


### PR DESCRIPTION
Those options are only used by the verifier and tenant connect via mTLS
to the registrar. The registrar does not use this API to talk to itself.

`init_client_tls(...)` in `registrar_client.py` uses these options, but this code is not used by the registrar.