### PR TITLE
Move cargo-tarpaulin install to separate command

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -73,8 +73,10 @@ which"
 RUN dnf makecache && \
   dnf -y install $PKGS_DEPS && \
   dnf clean all && \
-  rm -rf /var/cache/dnf/* && \
-  cargo install cargo-tarpaulin
+  rm -rf /var/cache/dnf/*
+
+# Install cargo dependencies
+RUN cargo install cargo-tarpaulin
 
 # Move keylime.conf to expected location in /etc/
 RUN git clone https://github.com/keylime/keylime.git && \


### PR DESCRIPTION
The cargo tarpaulin installation doesn't seem to be working when chained with dnf install. The old rust-keylime dockerfile uses a separate RUN command; this commit will try that out.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>