### PR TITLE
Make run_local.sh use a local copy of the repo

### DIFF
--- a/.ci/run_local.sh
+++ b/.ci/run_local.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# You can specify the path of the local keylime repository as argument
+# of this script or using the KEYLIME_REPO_PATH environment variable.
+# The default value is /home/${USER}/keylime
+REPO=${KEYLIME_REPO_PATH:-${1:-/home/${USER}/keylime}}
+
 # keylime images
 tpmimage="quay.io/keylime/keylime-ci"
 tpmtag="latest"
@@ -12,11 +17,9 @@ echo -e "Running Keylime's test suite"
 
 container_id=$(mktemp)
 docker run --detach --user root --env KEYLIME_TEST='true' \
+    -v $REPO:/root/keylime \
     --mount type=tmpfs,destination=/var/lib/keylime/,tmpfs-mode=1770 \
     -it ${tpmimage}:${tpmtag} >> ${container_id}
-# clone the Keylime repository
-docker exec -u root -it --tty "$(cat ${container_id})" \
-    git clone https://github.com/keylime/keylime.git /root/keylime
 # run the Keylime test suite
 docker exec -u root -it --tty "$(cat ${container_id})" \
     /bin/bash /root/keylime/.ci/test_wrapper.sh


### PR DESCRIPTION
Previously, it was cloning `master`, which isn't helpful for local testing. This change makes the test script copy in the local repo instead.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>