### PR TITLE
Fix permissions issue on volume mount in run_local.sh

### DIFF
--- a/.ci/run_local.sh
+++ b/.ci/run_local.sh
@@ -17,7 +17,7 @@ echo -e "Running Keylime's test suite"
 
 container_id=$(mktemp)
 docker run --detach --user root --env KEYLIME_TEST='true' \
-    -v $REPO:/root/keylime \
+    -v $REPO:/root/keylime:Z \
     --mount type=tmpfs,destination=/var/lib/keylime/,tmpfs-mode=1770 \
     -it ${tpmimage}:${tpmtag} >> ${container_id}
 # run the Keylime test suite


### PR DESCRIPTION
The volume mount was running into permissions issues due to SELinux. It appears this can be fixed with the `:Z` option: https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>