### PR TITLE
Remove the SHA1 requirement for IMA

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -115,12 +115,14 @@ max_retries = 10
 
 # TPM2-specific options, allows customizing default algorithms to use.
 # Specify the default crypto algorithms to use with a TPM2 for this agent.
+# On kernel versions less than 5.10 choose sha1 as hash algorithm, because
+# otherwise IMA attestation will fail.
 #
 # Currently accepted values include:
 # - hashing:    sha512, sha384, sha256 or sha1
 # - encryption: ecc or rsa
 # - signing:    rsassa, rsapss, ecdsa, ecdaa or ecschnorr
-tpm_hash_alg = sha256
+tpm_hash_alg = sha1
 tpm_encryption_alg = rsa
 tpm_signing_alg = rsassa
 

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -202,7 +202,8 @@ def process_quote_response(agent, json_response, agentAttestState) -> Failure:
     agent['sign_alg'] = sign_alg
 
     # Ensure hash_alg is in accept_tpm_hash_alg list
-    if not algorithms.is_accepted(hash_alg, agent['accept_tpm_hash_algs']):
+    if not algorithms.is_accepted(hash_alg, agent['accept_tpm_hash_algs'])\
+            or not algorithms.Hash.is_recognized(hash_alg):
         logger.error(f"TPM Quote is using an unaccepted hash algorithm: {hash_alg}")
         failure.add_event("invalid_hash_alg",
                           {"message": f"TPM Quote is using an unaccepted hash algorithm: {hash_alg}", "data": hash_alg},
@@ -258,7 +259,7 @@ def process_quote_response(agent, json_response, agentAttestState) -> Failure:
         agent['tpm_policy'],
         ima_measurement_list,
         agent['allowlist'],
-        hash_alg,
+        algorithms.Hash(hash_alg),
         ima_keyrings,
         mb_measurement_list,
         agent['mb_refstate'])

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -26,7 +26,6 @@ from keylime import cloud_verifier_common
 from keylime import revocation_notifier
 from keylime import tornado_requests
 from keylime import api_version as keylime_api_version
-from keylime.ima_ast import START_HASH
 from keylime.failure import MAX_SEVERITY_LABEL, Failure, Component
 
 logger = keylime_logging.init_logging('cloudverifier')
@@ -414,7 +413,7 @@ class AgentsHandler(BaseHandler):
                     agent_data['agent_id'] = agent_id
                     agent_data['boottime'] = 0
                     agent_data['ima_pcrs'] = []
-                    agent_data['pcr10'] = START_HASH
+                    agent_data['pcr10'] = None
                     agent_data['next_ima_ml_entry'] = 0
                     agent_data['learned_ima_keyrings'] = {}
                     agent_data['verifier_id'] = config.get('cloud_verifier', 'cloudverifier_id', cloud_verifier_common.DEFAULT_VERIFIER_ID)

--- a/keylime/cmd/ima_emulator_adapter.py
+++ b/keylime/cmd/ima_emulator_adapter.py
@@ -4,103 +4,91 @@ SPDX-License-Identifier: Apache-2.0
 Copyright 2017 Massachusetts Institute of Technology.
 '''
 
-import hashlib
+import codecs
 import sys
 import select
 import time
 import itertools
+import argparse
 
 from keylime.tpm.tpm_main import tpm
 from keylime.tpm.tpm_abstract import config
 from keylime.common import algorithms
+from keylime import ima_ast
 
 # Instaniate tpm
 tpm_instance = tpm(need_hw_tpm=True)
 
-START_HASH = '0000000000000000000000000000000000000000'
-FF_HASH = 'ffffffffffffffffffffffffffffffffffffffff'
 
-
-def ml_extend(ml, position, searchHash=None):
-    f = open(ml, encoding="utf-8")
+def measure_list(file_path, position, hash_alg, search_val=None):
+    f = open(file_path, encoding="utf-8")
     lines = itertools.islice(f, position, None)
+
+    runninghash = ima_ast.get_START_HASH(hash_alg)
+
+    if search_val is not None:
+        search_val = codecs.decode(search_val.encode('utf-8'), 'hex')
 
     for line in lines:
         line = line.strip()
-        tokens = line.split()
-
-        if line == '':
-            continue
-        if len(tokens) < 5:
-            print("ERROR: invalid measurement list file line: -%s-" % (line))
-            return position
         position += 1
 
-        # get the filename roughly
-        path = str(line[line.rfind(tokens[3]) + len(tokens[3]) + 1:])
-        template_hash = tokens[1]
+        entry = ima_ast.Entry(line, None, ima_hash_alg=hash_alg,  pcr_hash_alg=hash_alg)
 
-        # this is some IMA weirdness
-        if template_hash == START_HASH:
-            template_hash = FF_HASH
-
-        if searchHash is None:
-            print("extending hash %s for %s" % (template_hash, path))
-            # TODO: Add support for other hash algorithms
-            tpm_instance.extendPCR(config.IMA_PCR, template_hash, algorithms.Hash.SHA1)
+        if search_val is None:
+            val = codecs.encode(entry.pcr_template_hash, 'hex').decode("utf8")
+            tpm_instance.extendPCR(config.IMA_PCR, val, hash_alg)
         else:
-            # Let's only encode if its not a byte
-            try:
-                runninghash = START_HASH.encode('utf-8')
-            except AttributeError:
-                pass
-            # Let's only encode if its not a byte
-            try:
-                template_hash = template_hash.encode('utf-8')
-            except AttributeError:
-                pass
-
-            runninghash = hashlib.sha1(runninghash + template_hash).digest()
-
-            if runninghash == searchHash:
-                print("Located last IMA file updated: %s" % (path))
+            runninghash = hash_alg.hash(runninghash + entry.pcr_template_hash)
+            if runninghash == search_val:
                 return position
 
-    if searchHash is not None:
-        raise Exception(
-            "Unable to find current measurement list position, Resetting the TPM emulator may be neccesary")
+    if search_val is not None:
+        raise Exception("Unable to find current measurement list position, Resetting the TPM emulator may be neccesary")
 
     return position
 
 
-def main():
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-a', '--hash_algs', nargs='*', default=["sha1"],  help='PCR banks hash algorithms')
+    args = parser.parse_args(argv[1:])
+
     if not tpm_instance.is_emulator():
         raise Exception("This stub should only be used with a TPM emulator")
 
-    # initialize position in ML
-    pos = 0
+    position = {}
+    for hash_alg in args.hash_algs:
+        hash_alg = algorithms.Hash(hash_alg)
+        position[hash_alg] = 0
 
-    # check if pcr is clean
-    pcrval = tpm_instance.readPCR(config.IMA_PCR, algorithms.Hash.SHA1)
-    if pcrval != START_HASH:
-        print("Warning: IMA PCR is not empty, trying to find the last updated file in the measurement list...")
-        pos = ml_extend(config.IMA_ML, 0, pcrval)
+    for hash_alg in position.keys():
+        print(hash)
+        pcr_val = tpm_instance.readPCR(config.IMA_PCR, hash_alg)
+        if codecs.decode(pcr_val.encode('utf-8'), 'hex') != ima_ast.get_START_HASH(hash_alg):
+            print(f"Warning: IMA PCR is not empty for hash algorithm {hash_alg}, "
+                  "trying to find the last updated file in the measurement list...")
+            position[hash_alg] = measure_list(config.IMA_ML, position[hash_alg], hash_alg, pcr_val)
 
-    print("Monitoring %s" % (config.IMA_ML))
+    print(f"Monitoring {config.IMA_ML}")
     poll_object = select.poll()
     fd_object = open(config.IMA_ML, encoding="utf-8")
     number = fd_object.fileno()
     poll_object.register(fd_object, select.POLLIN | select.POLLPRI)
 
-    while True:
-        results = poll_object.poll()
-        for result in results:
-            if result[0] != number:
-                continue
-            pos = ml_extend(config.IMA_ML, pos)
-            time.sleep(0.2)
-    sys.exit(1)
+    try:
+        while True:
+            results = poll_object.poll()
+            for result in results:
+                if result[0] != number:
+                    continue
+                for hash_alg, pos in position.items():
+                    position[hash_alg] = measure_list(config.IMA_ML, pos, hash_alg)
+
+                time.sleep(0.2)
+    except (SystemExit, KeyboardInterrupt):
+        sys.exit(1)
 
 
 if __name__ == '__main__':
-    main()
+    main(sys.argv)

--- a/keylime/cmd/ima_emulator_adapter.py
+++ b/keylime/cmd/ima_emulator_adapter.py
@@ -4,13 +4,14 @@ SPDX-License-Identifier: Apache-2.0
 Copyright 2017 Massachusetts Institute of Technology.
 '''
 
+import hashlib
 import sys
 import select
 import time
 import itertools
 
 from keylime.tpm.tpm_main import tpm
-from keylime.tpm.tpm_abstract import config, hashlib
+from keylime.tpm.tpm_abstract import config
 from keylime.common import algorithms
 
 # Instaniate tpm

--- a/keylime/common/algorithms.py
+++ b/keylime/common/algorithms.py
@@ -2,6 +2,10 @@
 SPDX-License-Identifier: Apache-2.0
 Copyright 2020 Kaifeng Wang
 """
+import enum
+import hashlib
+
+from typing import Optional
 
 
 def is_accepted(algorithm, accepted):
@@ -13,17 +17,44 @@ def is_accepted(algorithm, accepted):
     return algorithm in accepted
 
 
-class Hash:
+class Hash(str, enum.Enum):
     SHA1 = 'sha1'
     SHA256 = 'sha256'
     SHA384 = 'sha384'
     SHA512 = 'sha512'
     SM3_256 = 'sm3_256'
-    supported_algorithms = (SHA1, SHA256, SHA384, SHA512, SM3_256)
 
     @staticmethod
     def is_recognized(algorithm):
-        return algorithm in Hash.supported_algorithms
+        try:
+            Hash(algorithm)
+            return True
+        except ValueError:
+            return False
+
+    def hash(self, data: bytes) -> Optional[bytes]:
+        if self == Hash.SHA1:
+            return hashlib.sha1(data).digest()
+        if self == Hash.SHA256:
+            return hashlib.sha256(data).digest()
+        if self == Hash.SHA384:
+            return hashlib.sha384(data).digest()
+        if self == Hash.SHA512:
+            return hashlib.sha512(data).digest()
+        if self == Hash.SM3_256:
+            # SM3 might not be guaranteed to be there
+            try:
+                return hashlib.new("sm3", data).digest()
+            except ValueError:
+                return None
+
+        return None
+
+    def get_size(self):
+        return _HASH_SIZE.get(self)
+
+    def __str__(self):
+        return self.value
 
 
 class Encrypt:
@@ -54,8 +85,5 @@ _HASH_SIZE = {
     Hash.SHA256: 256,
     Hash.SHA384: 384,
     Hash.SHA512: 512,
+    Hash.SM3_256: 256,
 }
-
-
-def get_hash_size(algorithm):
-    return _HASH_SIZE.get(algorithm, 0)

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -988,7 +988,8 @@ class Tenant():
             # Ensure hash_alg is in accept_tpm_hash_algs list
             hash_alg = response_body["results"]["hash_alg"]
             logger.debug("Agent_quote received hash algorithm: %s", hash_alg)
-            if not algorithms.is_accepted(hash_alg, config.get('tenant', 'accept_tpm_hash_algs').split(',')):
+            if not algorithms.is_accepted(hash_alg, config.get('tenant', 'accept_tpm_hash_algs').split(','))\
+                    or not algorithms.Hash.is_recognized(hash_alg):
                 raise UserError(
                     "TPM Quote is using an unaccepted hash algorithm: %s" % hash_alg)
 
@@ -1006,7 +1007,7 @@ class Tenant():
                 raise UserError(
                     "TPM Quote is using an unaccepted signing algorithm: %s" % sign_alg)
 
-            if not self.validate_tpm_quote(public_key, quote, hash_alg):
+            if not self.validate_tpm_quote(public_key, quote, algorithms.Hash(hash_alg)):
                 raise UserError(
                     "TPM Quote from cloud agent is invalid for nonce: %s" % self.nonce)
 

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -169,24 +169,17 @@ class AbstractTPM(metaclass=ABCMeta):
         if algorithm is None:
             algorithm = self.defaults['hash']
 
-        alg_size = algorithms.get_hash_size(algorithm) // 4
+        alg_size = algorithm.get_size() // 4
         return "0" * alg_size
 
     def hashdigest(self, payload, algorithm=None):
         if algorithm is None:
             algorithm = self.defaults['hash']
 
-        if algorithm == algorithms.Hash.SHA1:
-            measured = hashlib.sha1(payload).hexdigest()
-        elif algorithm == algorithms.Hash.SHA256:
-            measured = hashlib.sha256(payload).hexdigest()
-        elif algorithm == algorithms.Hash.SHA384:
-            measured = hashlib.sha384(payload).hexdigest()
-        elif algorithm == algorithms.Hash.SHA512:
-            measured = hashlib.sha512(payload).hexdigest()
-        else:
-            measured = None
-        return measured
+        digest = algorithm.hash(payload)
+        if digest is None:
+            return None
+        return codecs.encode(digest, 'hex').decode('utf-8')
 
     @abstractmethod
     def sim_extend(self, hashval_1, hashval_0=None):

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -181,7 +181,7 @@ class AbstractTPM(metaclass=ABCMeta):
         return codecs.encode(digest, 'hex').decode('utf-8')
 
     @abstractmethod
-    def sim_extend(self, hashval_1, hashval_0=None):
+    def sim_extend(self, hashval_1, hashval_0=None, hash_alg=None):
         pass
 
     @abstractmethod
@@ -256,7 +256,7 @@ class AbstractTPM(metaclass=ABCMeta):
 
         # Validate data PCR
         if config.TPM_DATA_PCR in pcr_nums and data is not None:
-            expectedval = self.sim_extend(data)
+            expectedval = self.sim_extend(data, hash_alg=hash_alg)
             if expectedval != pcrs[config.TPM_DATA_PCR]:
                 logger.error(
                     "%sPCR #%s: invalid bind data %s from quote does not match expected value %s",

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -942,17 +942,13 @@ class tpm(tpm_abstract.AbstractTPM):
         return self.get_tpm_metadata('ekcert'), self.get_tpm_metadata('ek_tpm'), self.get_tpm_metadata('aik_tpm')
 
     # tpm_quote
-    def __pcr_mask_to_list(self, mask, hash_alg):
+    @staticmethod
+    def __pcr_mask_to_list(mask):
         pcr_list = []
-        ima_appended = ""
         for pcr in range(24):
             if tpm_abstract.TPM_Utilities.check_mask(mask, pcr):
-                if hash_alg != algorithms.Hash.SHA1 and pcr == config.IMA_PCR:
-                    # IMA is only in SHA1 format
-                    ima_appended = "+sha1:" + str(pcr)
-                else:
-                    pcr_list.append(str(pcr))
-        return ",".join(pcr_list) + ima_appended
+                pcr_list.append(str(pcr))
+        return ",".join(pcr_list)
 
     def create_quote(self, nonce, data=None, pcrmask=tpm_abstract.AbstractTPM.EMPTYMASK, hash_alg=None):
         if hash_alg is None:
@@ -973,7 +969,7 @@ class tpm(tpm_abstract.AbstractTPM):
                 # add PCR 16 to pcrmask
                 pcrmask = "0x%X" % (int(pcrmask, 0) + (1 << config.TPM_DATA_PCR))
 
-            pcrlist = self.__pcr_mask_to_list(pcrmask, hash_alg)
+            pcrlist = self.__pcr_mask_to_list(pcrmask)
 
             with self.tpmutilLock:
                 if data is not None:
@@ -1113,18 +1109,12 @@ class tpm(tpm_abstract.AbstractTPM):
                 alg_size = hash_alg.get_size() // 4
                 for pcrval, hashval in jsonout["pcrs"][hash_alg].items():
                     pcrs.append("PCR " + str(pcrval) + " " + '{0:0{1}x}'.format(hashval, alg_size))
-            # IMA is always in SHA1 format, so don't leave it behind!
-            if hash_alg != algorithms.Hash.SHA1:
-                if algorithms.Hash.SHA1 in jsonout["pcrs"] and \
-                   config.IMA_PCR in jsonout["pcrs"][algorithms.Hash.SHA1]:
-                    sha1_size = algorithms.get_hash_size(algorithms.Hash.SHA1) // 4
-                    ima_val = jsonout["pcrs"][algorithms.Hash.SHA1][config.IMA_PCR]
-                    pcrs.append("PCR " + str(config.IMA_PCR) + " " + '{0:0{1}x}'.format(ima_val, sha1_size))
 
         if len(pcrs) == 0:
             pcrs = None
 
-        return self.check_pcrs(agentAttestState, tpm_policy, pcrs, data, False, ima_measurement_list, allowlist, ima_keyrings, mb_measurement_list, mb_refstate)
+        return self.check_pcrs(agentAttestState, tpm_policy, pcrs, data, False, ima_measurement_list, allowlist,
+                               ima_keyrings, mb_measurement_list, mb_refstate, hash_alg)
 
     def sim_extend(self, hashval_1, hashval_0=None):
         # simulate extending a PCR value by performing TPM-specific extend procedure

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -248,7 +248,7 @@ class tpm(tpm_abstract.AbstractTPM):
             # Assume their defaults are sane?
             pass
 
-        self.defaults['hash'] = defaultHash
+        self.defaults['hash'] = algorithms.Hash(defaultHash)
         self.defaults['encrypt'] = defaultEncrypt
         self.defaults['sign'] = defaultSign
         self.defaults['ek_handle'] = ek_handle
@@ -1110,7 +1110,7 @@ class tpm(tpm_abstract.AbstractTPM):
         jsonout = config.yaml_to_dict(retout)
         if "pcrs" in jsonout:
             if hash_alg in jsonout["pcrs"]:
-                alg_size = algorithms.get_hash_size(hash_alg) // 4
+                alg_size = hash_alg.get_size() // 4
                 for pcrval, hashval in jsonout["pcrs"][hash_alg].items():
                     pcrs.append("PCR " + str(pcrval) + " " + '{0:0{1}x}'.format(hashval, alg_size))
             # IMA is always in SHA1 format, so don't leave it behind!
@@ -1139,7 +1139,7 @@ class tpm(tpm_abstract.AbstractTPM):
 
     def extendPCR(self, pcrval, hashval, hash_alg=None, lock=True):
         if hash_alg is None:
-            hash_alg = self.defaults['hash']
+            hash_alg = self.defaults['hash'].value
 
         self.__run(["tpm2_pcrextend", "%d:%s=%s" % (pcrval, hash_alg, hashval)], lock=lock)
 
@@ -1157,7 +1157,7 @@ class tpm(tpm_abstract.AbstractTPM):
             raise Exception("Invalid hashing algorithm '%s' for reading PCR number %d." % (hash_alg, pcrval))
 
         # alg_size = Hash_Algorithms.get_hash_size(hash_alg)/4
-        alg_size = algorithms.get_hash_size(hash_alg) // 4
+        alg_size = hash_alg.get_size() // 4
         return '{0:0{1}x}'.format(jsonout[hash_alg][pcrval], alg_size)
 
     # tpm_random

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -1116,15 +1116,16 @@ class tpm(tpm_abstract.AbstractTPM):
         return self.check_pcrs(agentAttestState, tpm_policy, pcrs, data, False, ima_measurement_list, allowlist,
                                ima_keyrings, mb_measurement_list, mb_refstate, hash_alg)
 
-    def sim_extend(self, hashval_1, hashval_0=None):
+    def sim_extend(self, hashval_1, hashval_0=None, hash_alg=None):
         # simulate extending a PCR value by performing TPM-specific extend procedure
 
         if hashval_0 is None:
-            hashval_0 = self.START_HASH()
+            hashval_0 = self.START_HASH(hash_alg)
 
         # compute expected value  H(0|H(data))
         extendedval = self.hashdigest(codecs.decode(hashval_0, 'hex_codec') +
-                                      codecs.decode(self.hashdigest(hashval_1.encode('utf-8')), 'hex_codec')).lower()
+                                      codecs.decode(self.hashdigest(hashval_1.encode('utf-8'), hash_alg), 'hex_codec'),
+                                      hash_alg).lower()
         return extendedval
 
     def extendPCR(self, pcrval, hashval, hash_alg=None, lock=True):

--- a/test/test_ima_verification.py
+++ b/test/test_ima_verification.py
@@ -241,7 +241,7 @@ class TestIMAVerification(unittest.TestCase):
         al_data = ima.read_allowlist(allowlist_file)
         self.assertIsNotNone(al_data, "AllowList data is present")
         self.assertIsNotNone(al_data["meta"], "AllowList metadata is present")
-        self.assertEqual(al_data["meta"]["version"], 4, "AllowList metadata version is correct")
+        self.assertEqual(al_data["meta"]["version"], 5, "AllowList metadata version is correct")
         self.assertEqual(al_data["meta"]["generator"], "keylime-legacy-format-upgrade", "AllowList metadata generator is correct")
         self.assertNotIn("checksum", al_data["meta"], "AllowList metadata no checksum")
         self.assertIsNotNone(al_data["hashes"], "AllowList hashes are present")

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -53,6 +53,7 @@ from keylime import secure_mount
 from keylime.tpm import tpm_main
 from keylime.tpm import tpm_abstract
 from keylime import api_version
+from keylime.common import algorithms
 
 
 # Coverage support
@@ -562,7 +563,7 @@ class TestRestful(unittest.TestCase):
                                         json_response["results"]["pubkey"],
                                         json_response["results"]["quote"],
                                         aik_tpm,
-                                        hash_alg=json_response["results"]["hash_alg"])
+                                        hash_alg=algorithms.Hash(json_response["results"]["hash_alg"]))
         self.assertTrue(not failure, "Invalid quote!")
 
     @unittest.skip("Testing of agent's POST /keys/vkey disabled!  (spawned CV should do this already)")
@@ -844,7 +845,7 @@ class TestRestful(unittest.TestCase):
         self.assertIn("hash_alg", json_response["results"], "Malformed response body!")
 
         quote = json_response["results"]["quote"]
-        hash_alg = json_response["results"]["hash_alg"]
+        hash_alg = algorithms.Hash(json_response["results"]["hash_alg"])
 
         failure = tpm_instance.check_quote(tenant_templ.agent_uuid,
                                      nonce,


### PR DESCRIPTION
Modern kernel versions (>= 5.10) hash the IMA entries with all available PCR bank algorithms, but the entry in the IMA log is still the SHA1 entry in most distributions. 
This PR removes the special handling for PCR10 and IMA and just uses the default hash algorithm of the agent.

This also fixes an issue that the hash algorithm for the data PCR might not match between agent and verifier and introduces a new IMA emulator adapter that supports multiple hash algorithms.

Fixes #30, fixes #801 