### PR TITLE
Update .gitignore with more Keylime-specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ test/.auditing-*
 test/NVChip
 NVChip
 test/testdata.sqlite
+cv_data.sqlite
+reg_data.sqlite
+tpmdata.yml


### PR DESCRIPTION
These are generated when using `run_local.sh`.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>