### PR TITLE
ima_emulator: specify sys.argv as the named parameter argv in main()

### DIFF
--- a/keylime/cmd/ima_emulator_adapter.py
+++ b/keylime/cmd/ima_emulator_adapter.py
@@ -49,7 +49,7 @@ def measure_list(file_path, position, hash_alg, search_val=None):
     return position
 
 
-def main(argv):
+def main(argv=sys.argv):
     parser = argparse.ArgumentParser()
     parser.add_argument('-a', '--hash_algs', nargs='*', default=["sha1"],  help='PCR banks hash algorithms')
     args = parser.parse_args(argv[1:])


### PR DESCRIPTION
Fixes the following issue, which followed-up from b0dcaa8:

```
Traceback (most recent call last):
  File "/usr/local/bin/keylime_ima_emulator", line 33, in <module>
    sys.exit(load_entry_point('keylime==0.0.0', 'console_scripts', 'keylime_ima_emulator')())
TypeError: main() missing 1 required positional argument: 'argv'
```

Other utilities under `cmd/` also use this approach.

Signed-off-by: Sergio Correia <scorreia@redhat.com>