### PR TITLE
Fix argv handling in main()

### DIFF
--- a/keylime/cmd/ima_emulator_adapter.py
+++ b/keylime/cmd/ima_emulator_adapter.py
@@ -49,10 +49,10 @@ def measure_list(file_path, position, hash_alg, search_val=None):
     return position
 
 
-def main(argv):
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-a', '--hash_algs', nargs='*', default=["sha1"],  help='PCR banks hash algorithms')
-    args = parser.parse_args(argv[1:])
+    args = parser.parse_args(sys.argv[1:])
 
     if not tpm_instance.is_emulator():
         raise Exception("This stub should only be used with a TPM emulator")


### PR DESCRIPTION
argv is not passed to main from entry_point which leads
to the following traceback:

Traceback (most recent call last):
  File "/usr/local/bin/keylime_ima_emulator", line 33, in <module>
    sys.exit(load_entry_point('keylime==0.0.0', 'console_scripts', 'keylime_ima_emulator')())
TypeError: main() missing 1 required positional argument: 'argv'

argv argument is not necessary as we can access sys.argv
directly.