### PR TITLE
Run existing agent tests against the rust-keylime agent

### DIFF
--- a/.ci/test_wrapper.sh
+++ b/.ci/test_wrapper.sh
@@ -15,6 +15,7 @@ swtpm socket --tpm2 \
      --server type=tcp,port=2321 \
      --daemon
 export TPM2TOOLS_TCTI=tabrmd:
+export TCTI=tabrmd:
 
 # Configure dbus
 sudo rm -rf /var/run/dbus

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -20,6 +20,7 @@ UMODE_OPT=""
 COVERAGE=0
 COVERAGE_DIR=`pwd`
 unset COVERAGE_FILE
+RUST_TEST="${RUST_TEST:-0}"
 
 for opt in "$@"; do
   shift
@@ -163,6 +164,11 @@ echo "==========================================================================
 echo $'\t\t\tInstalling test requirements'
 echo "=================================================================================="
 pip3 install $UMODE_OPT -r $KEYLIME_DIR/test/test-requirements.txt
+if [ "$RUST_TEST" == 1 ]
+then
+    git clone https://github.com/keylime/rust-keylime.git $KEYLIME_DIR/../rust-keylime
+    cargo build --manifest-path $KEYLIME_DIR/../rust-keylime/Cargo.toml --bin keylime_agent
+fi
 
 # Install Keylime
 echo


### PR DESCRIPTION
The current `test_restful.py` test suite runs a number of tests against the Python agent. This pull request adds a number of helper functions and a new set of tests that:

- shut down the Python agent
- start up the Rust agent
- run agent-specific tests against the Rust agent

Currently, one of the tests (`agent_quotes_identity_get`) passes, while others fail (mostly due to missing APIs in `rust-keylime`). I've added skips to the broken tests with documentation on the relevant `rust-keylime` issues blocking them, so it should still pass without fail.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>