### PR TITLE
Mitigations against event type manipulation in UEFI eventlog

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,6 +3,6 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-all
+    - fedora-stable
     - centos-stream-9-x86_64
     skip_build: true


### PR DESCRIPTION
This provides the initial hardening of the example policy against event type manipulation. 
This not directly an issue with Keylime, because the UEFI eventlog does not include the metadata in the hash that is used to extend the PCR. The original issue can be found here: https://github.com/google/go-attestation/blob/master/docs/event-log-disclosure.md

The most effective way to mitigate against that is to reduce the usage of `acceptAll ` and limit how often they can be used.

As discussed with @mpeters we will first update our example policy and then provide documentation on how to write custom policies.