### PR TITLE
Various code improvements for mostly the agent

### DIFF
--- a/keylime/config.py
+++ b/keylime/config.py
@@ -114,9 +114,6 @@ if not REQUIRE_ROOT:
 if not REQUIRE_ROOT:
     print("WARNING: running without root access")
 
-TPM_LIBS_PATH = '/usr/local/lib/'
-TPM_TOOLS_PATH = '/usr/local/bin/'
-
 
 CONFIG_FILE = os.getenv('KEYLIME_CONFIG', '/etc/keylime.conf')
 

--- a/keylime/config.py
+++ b/keylime/config.py
@@ -297,6 +297,16 @@ def valid_regex(regex):
     return True, compiled_regex, None
 
 
+def valid_hex(value: str):
+    if not value.isalnum():
+        return False
+    try:
+        int(value, 16)
+        return True
+    except ValueError:
+        return False
+
+
 if STUB_IMA:
     IMA_ML = '../scripts/ima/ascii_runtime_measurements'
 else:

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -84,6 +84,12 @@ class Handler(BaseHTTPRequestHandler):
                 config.echo_json_response(
                     self, 400, "Bootstrap key not yet available.")
                 return
+            if "challenge" not in rest_params:
+                logger.info('GET key challenge returning 400 response. No challenge provided')
+                config.echo_json_response(
+                    self, 400, "No challenge provided.")
+                return
+
             challenge = rest_params['challenge']
             response = {}
             response['hmac'] = crypto.do_hmac(self.server.K, challenge)

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -76,6 +76,7 @@ class AbstractTPM(metaclass=ABCMeta):
     EXIT_SUCESS = 0
     TPM_IO_ERR = 5
     EMPTYMASK = "1"
+    MAX_NONCE_SIZE = 64
 
     # constructor
     def __init__(self, need_hw_tpm=True):

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -39,9 +39,6 @@ logger = keylime_logging.init_logging('tpm')
 
 def _get_cmd_env():
     env = os.environ.copy()
-    lib_path = ""
-    if 'LD_LIBRARY_PATH' in env:
-        lib_path = env['LD_LIBRARY_PATH']
     if 'TPM2TOOLS_TCTI' not in env:
         # Don't clobber existing setting (if present)
         env['TPM2TOOLS_TCTI'] = 'device:/dev/tpmrm0'
@@ -49,8 +46,6 @@ def _get_cmd_env():
         # Other (not recommended) options are direct emulator and chardev communications:
         # env['TPM2TOOLS_TCTI'] = 'mssim:port=2321'
         # env['TPM2TOOLS_TCTI'] = 'device:/dev/tpm0'
-    env['PATH'] = env['PATH'] + ":%s" % config.TPM_TOOLS_PATH
-    env['LD_LIBRARY_PATH'] = lib_path + ":%s" % config.TPM_LIBS_PATH
     return env
 
 


### PR DESCRIPTION
This fixes various validation issues with the agent and drops `/usr/local` as an included path by default because we do not use a custom patched version of tpm2-tools anymore.