### PR TITLE
ima_ast: fix handling ToMToU errors

### DIFF
--- a/keylime/ima_ast.py
+++ b/keylime/ima_ast.py
@@ -348,6 +348,7 @@ class Entry:
         # https://elixir.bootlin.com/linux/v5.12.12/source/security/integrity/ima/ima_main.c#L101
         if self.ima_template_hash == get_START_HASH(ima_hash_alg):
             self.ima_template_hash = get_FF_HASH(ima_hash_alg)
+            self.pcr_template_hash = get_FF_HASH(pcr_hash_alg)
 
     def invalid(self):
         failure = Failure(Component.IMA, ["validation"])


### PR DESCRIPTION
The handling for ToMToU errors was not extended to handle different hash algorithms correctly.

Fixes #821