### PR TITLE
Drop dataclasses module usage

### DIFF
--- a/keylime/failure.py
+++ b/keylime/failure.py
@@ -5,7 +5,6 @@ Copyright 2021 Thore Sommer
 Tagging of failure events that might cause revocation in Keylime.
 '''
 import ast
-import dataclasses
 import enum
 import functools
 import json
@@ -19,7 +18,6 @@ logger = keylime_logging.init_logging("failure")
 
 
 @functools.total_ordering
-@dataclasses.dataclass(frozen=True)
 class SeverityLabel:
     """
     Severity label that can be attached to an event.
@@ -29,6 +27,10 @@ class SeverityLabel:
     """
     name: str
     severity: int
+
+    def __init__(self, name, severity):
+        self.name = name
+        self.severity = severity
 
     def __lt__(self, other):
         return self.severity < other.severity
@@ -49,7 +51,6 @@ class Component(enum.Enum):
     DEFAULT = "default"
 
 
-@dataclasses.dataclass
 class Event:
     """
     Event that might be the reason for revocation.

--- a/keylime/ima_ast.py
+++ b/keylime/ima_ast.py
@@ -12,7 +12,6 @@ import binascii
 import codecs
 import struct
 import abc
-import dataclasses
 
 from typing import Dict, Callable, Any, Optional
 from keylime import config
@@ -38,9 +37,11 @@ def get_FF_HASH(hash_alg: Hash):
     return codecs.decode(b'f' * (hash_alg.get_size() // 4), 'hex')
 
 
-@dataclasses.dataclass
 class Validator:
     functions: Dict[Any, Callable]
+
+    def __init__(self, functions):
+        self.functions = functions
 
     def get_validator(self, class_type) -> Callable:
         validator = self.functions.get(class_type, None)


### PR DESCRIPTION
Dataclasses module is not present in Python 3.6, an interpreter still
used in some distributions.

Even there is a 3rd party compatibility module, the current usage seems
not properly justified.  For example, in one of the dataclasses there is
an user-provided __init__ constructor.