### PR TITLE
Enable new test in Packit CI

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -11,7 +11,8 @@ discover:
     test: 
      - /setup/configure_tpm_emulator
      - /setup/install_upstream_keylime
-     - functional/basic-attestation-on-localhost
+     - /functional/basic-attestation-on-localhost
+     - /functional/keylime_tenant-commands-on-localhost
 
 execute:
     how: tmt


### PR DESCRIPTION
Enable /functional/keylime_tenant-commands-on-localhost in Packit CI