### PR TITLE
Move all Keylime web components to Tornado

### DIFF
--- a/demo/agent_monitor/tenant_agent_monitor.py
+++ b/demo/agent_monitor/tenant_agent_monitor.py
@@ -24,6 +24,8 @@ import argparse
 import keylime_logging
 import common
 import sys
+
+import keylime.tornado_helpers
 from keylime import json
 sys.path.insert(0, '../../keylime/')
 
@@ -57,14 +59,14 @@ class BaseHandler(tornado.web.RequestHandler):
 
 class MainHandler(tornado.web.RequestHandler):
     def get(self):
-        common.echo_json_response(
+        keylime.tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use /agents/ interface instead")
 
 
 class AgentsHandler(BaseHandler):
     def head(self):
         """HEAD not supported"""
-        common.echo_json_response(self, 405, "HEAD not supported")
+        keylime.tornado_helpers.echo_json_response(self, 405, "HEAD not supported")
 
     def get(self):
         """This method handles the GET requests to retrieve status on agents from the Agent Monitor.
@@ -75,7 +77,7 @@ class AgentsHandler(BaseHandler):
         was not found, it either completed successfully, or failed.  If found, the agent_id is still polling
         to contact the Cloud Agent.
         """
-        common.echo_json_response(self, 405, "GET not supported")
+        keylime.tornado_helpers.echo_json_response(self, 405, "GET not supported")
 
     def delete(self):
         """This method handles the DELETE requests to remove agents from the Agent Monitor.
@@ -83,7 +85,7 @@ class AgentsHandler(BaseHandler):
         Currently, only agents resources are available for DELETEing, i.e. /agents. All other DELETE uri's will return errors.
         agents requests require a single agent_id parameter which identifies the agent to be deleted.
         """
-        common.echo_json_response(self, 405, "DELETE not supported")
+        keylime.tornado_helpers.echo_json_response(self, 405, "DELETE not supported")
 
     def post(self):
         """This method handles the POST requests to add agents to the Agent Monitor.
@@ -96,7 +98,7 @@ class AgentsHandler(BaseHandler):
             rest_params = common.get_restful_params(self.request.path)
 
             if "agents" not in rest_params:
-                common.echo_json_response(self, 400, "uri not supported")
+                keylime.tornado_helpers.echo_json_response(self, 400, "uri not supported")
                 logger.warning(
                     'POST returning 400 response. uri not supported: ' + self.request.path)
                 return
@@ -106,7 +108,7 @@ class AgentsHandler(BaseHandler):
             if agent_id is not None:  # we have to know who phoned home
                 content_length = len(self.request.body)
                 if content_length == 0:
-                    common.echo_json_response(
+                    keylime.tornado_helpers.echo_json_response(
                         self, 400, "Expected non zero content length")
                     logger.warning(
                         'POST returning 400 response. Expected non zero content length.')
@@ -137,15 +139,15 @@ class AgentsHandler(BaseHandler):
                         t = threading.Thread(target=initthread)
                         t.start()
 
-                    common.echo_json_response(self, 200, "Success", json_body)
+                    keylime.tornado_helpers.echo_json_response(self, 200, "Success", json_body)
                     logger.info(
                         'POST returning 200 response for Agent Monitor connection as ' + agent_id)
             else:
-                common.echo_json_response(self, 400, "uri not supported")
+                keylime.tornado_helpers.echo_json_response(self, 400, "uri not supported")
                 logger.warning(
                     "POST returning 400 response. uri not supported")
         except Exception as e:
-            common.echo_json_response(self, 400, "Exception error: %s" % e)
+            keylime.tornado_helpers.echo_json_response(self, 400, "Exception error: %s" % e)
             logger.warning(
                 "POST returning 400 response. Exception error: %s" % e)
             logger.exception(e)
@@ -156,7 +158,7 @@ class AgentsHandler(BaseHandler):
         Currently, only agents resources are available for PUTing, i.e. /agents. All other PUT uri's will return errors.
         agents requests require a json block sent in the body
         """
-        common.echo_json_response(self, 405, "PUT not supported")
+        keylime.tornado_helpers.echo_json_response(self, 405, "PUT not supported")
 
 
 def init_mtls(config):

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -5,17 +5,12 @@ Copyright 2017 Massachusetts Institute of Technology.
 
 import ast
 import base64
-import os
-import ssl
-import socket
 import time
-import sys
 
 from keylime import config
 from keylime import keylime_logging
 from keylime import registrar_client
 from keylime import crypto
-from keylime import ca_util
 from keylime import json
 from keylime import revocation_notifier
 from keylime.agentstates import AgentAttestStates
@@ -41,100 +36,6 @@ def get_tpm_instance():
 
 def get_AgentAttestStates():
     return AgentAttestStates.get_instance()
-
-
-def init_mtls(section='cloud_verifier', generatedir='cv_ca'):
-    if not config.getboolean('general', "enable_tls"):
-        logger.warning(
-            "Warning: TLS is currently disabled, keys will be sent in the clear! This should only be used for testing.")
-        return None
-
-    logger.info("Setting up TLS...")
-    my_cert = config.get(section, 'my_cert')
-    ca_cert = config.get(section, 'ca_cert')
-    my_priv_key = config.get(section, 'private_key')
-    my_key_pw = config.get(section, 'private_key_pw')
-    tls_dir = config.get(section, 'tls_dir')
-
-    if tls_dir == 'generate':
-        if my_cert != 'default' or my_priv_key != 'default' or ca_cert != 'default':
-            raise Exception(
-                "To use tls_dir=generate, options ca_cert, my_cert, and private_key must all be set to 'default'")
-
-        if generatedir[0] != '/':
-            generatedir = os.path.abspath(os.path.join(config.WORK_DIR,
-                                                       generatedir))
-        tls_dir = generatedir
-        ca_path = "%s/cacert.crt" % (tls_dir)
-        if os.path.exists(ca_path):
-            logger.info("Existing CA certificate found in %s, not generating a new one", tls_dir)
-        else:
-            logger.info("Generating a new CA in %s and a client certificate for connecting", tls_dir)
-            logger.info("use keylime_ca -d %s to manage this CA", tls_dir)
-            if not os.path.exists(tls_dir):
-                os.makedirs(tls_dir, 0o700)
-            if my_key_pw == 'default':
-                logger.warning("CAUTION: using default password for CA, please set private_key_pw to a strong password")
-            ca_util.setpassword(my_key_pw)
-            ca_util.cmd_init(tls_dir)
-            ca_util.cmd_mkcert(tls_dir, socket.gethostname())
-            ca_util.cmd_mkcert(tls_dir, 'client')
-
-    if tls_dir == 'CV':
-        if section != 'registrar':
-            raise Exception(
-                "You only use the CV option to tls_dir for the registrar not %s" % section)
-        tls_dir = os.path.abspath(os.path.join(config.WORK_DIR, 'cv_ca'))
-        if not os.path.exists("%s/cacert.crt" % (tls_dir)):
-            raise Exception(
-                "It appears that the verifier has not yet created a CA and certificates, please run the verifier first")
-
-    # if it is relative path, convert to absolute in WORK_DIR
-    if tls_dir[0] != '/':
-        tls_dir = os.path.abspath(os.path.join(config.WORK_DIR, tls_dir))
-
-    if ca_cert == 'default':
-        ca_path = os.path.join(tls_dir, "cacert.crt")
-    elif not os.path.isabs(ca_cert):
-        ca_path = os.path.join(tls_dir, ca_cert)
-    else:
-        ca_path = ca_cert
-
-    if my_cert == 'default':
-        my_cert = os.path.join(tls_dir, f"{socket.gethostname()}-cert.crt")
-    elif not os.path.isabs(my_cert):
-        my_cert = os.path.join(tls_dir, my_cert)
-    else:
-        pass
-
-    if my_priv_key == 'default':
-        my_priv_key = os.path.join(tls_dir,
-                                   f"{socket.gethostname()}-private.pem")
-    elif not os.path.isabs(my_priv_key):
-        my_priv_key = os.path.join(tls_dir, my_priv_key)
-
-    try:
-        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-        if sys.version_info >= (3,7):
-            context.minimum_version = ssl.TLSVersion.TLSv1_2
-        else:
-            context.options &= ~ssl.OP_NO_TLSv1_2
-        context.load_verify_locations(cafile=ca_path)
-        context.load_cert_chain(
-            certfile=my_cert, keyfile=my_priv_key, password=my_key_pw)
-        if (config.has_option(section, 'check_client_cert')
-                and config.getboolean(section, 'check_client_cert')):
-            context.verify_mode = ssl.CERT_REQUIRED
-    except ssl.SSLError as exc:
-        if exc.reason == 'EE_KEY_TOO_SMALL':
-            logger.error('Higher key strength is required for keylime '
-                         'running on this system. If keylime is responsible '
-                         'to generate the certificate, please raise the value '
-                         'of configuration option [ca]cert_bits, remove '
-                         'generated certificate and re-run keylime service')
-        raise exc
-
-    return context
 
 
 def process_quote_response(agent, json_response, agentAttestState) -> Failure:

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -158,23 +158,23 @@ class BaseHandler(tornado.web.RequestHandler):
 class MainHandler(tornado.web.RequestHandler):
 
     def head(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use /agents/ interface instead")
 
     def get(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use /agents/ interface instead")
 
     def delete(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use /agents/ interface instead")
 
     def post(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use /agents/ interface instead")
 
     def put(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use /agents/ interface instead")
 
     def data_received(self, chunk):
@@ -183,17 +183,17 @@ class MainHandler(tornado.web.RequestHandler):
 class VersionHandler(BaseHandler):
 
     def head(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use GET interface instead")
 
     def get(self):
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
-            config.echo_json_response(self, 405, "Not Implemented")
+            tornado_helpers.echo_json_response(self, 405, "Not Implemented")
             return
 
         if "version" not in rest_params:
-            config.echo_json_response(self, 400, "URI not supported")
+            tornado_helpers.echo_json_response(self, 400, "URI not supported")
             logger.warning('GET returning 400 response. URI not supported: %s', self.request.path)
             return
 
@@ -202,18 +202,18 @@ class VersionHandler(BaseHandler):
             "supported_versions": keylime_api_version.all_versions(),
         }
 
-        config.echo_json_response(self, 200, "Success", version_info)
+        tornado_helpers.echo_json_response(self, 200, "Success", version_info)
 
     def delete(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use GET interface instead")
 
     def post(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use GET interface instead")
 
     def put(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use GET interface instead")
 
     def data_received(self, chunk):
@@ -223,7 +223,7 @@ class VersionHandler(BaseHandler):
 class AgentsHandler(BaseHandler):
     def head(self):
         """HEAD not supported"""
-        config.echo_json_response(self, 405, "HEAD not supported")
+        tornado_helpers.echo_json_response(self, 405, "HEAD not supported")
 
     def get(self):
         """This method handles the GET requests to retrieve status on agents from the Cloud Verifier.
@@ -237,16 +237,16 @@ class AgentsHandler(BaseHandler):
         session = get_session()
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
         if not rest_params["api_version"]:
-            config.echo_json_response(self, 400, "API Version not supported")
+            tornado_helpers.echo_json_response(self, 400, "API Version not supported")
             return
 
         if "agents" not in rest_params:
-            config.echo_json_response(self, 400, "uri not supported")
+            tornado_helpers.echo_json_response(self, 400, "uri not supported")
             logger.warning('GET returning 400 response. uri not supported: %s', self.request.path)
             return
 
@@ -261,9 +261,9 @@ class AgentsHandler(BaseHandler):
 
             if agent is not None:
                 response = cloud_verifier_common.process_get_status(agent)
-                config.echo_json_response(self, 200, "Success", response)
+                tornado_helpers.echo_json_response(self, 200, "Success", response)
             else:
-                config.echo_json_response(self, 404, "agent id not found")
+                tornado_helpers.echo_json_response(self, 404, "agent id not found")
         else:
             json_response = None
             if "bulk" in rest_params.keys():
@@ -278,7 +278,7 @@ class AgentsHandler(BaseHandler):
                 for agent in agent_list:
                     json_response[agent.agent_id] = cloud_verifier_common.process_get_status(agent)
 
-                config.echo_json_response(self, 200, "Success", json_response)
+                tornado_helpers.echo_json_response(self, 200, "Success", json_response)
             else:
                 if ("verifier" in rest_params.keys()) and (rest_params["verifier"] != ''):
                     json_response = session.query(VerfierMain.agent_id).filter_by(
@@ -286,7 +286,7 @@ class AgentsHandler(BaseHandler):
                 else:
                     json_response = session.query(VerfierMain.agent_id).all()
 
-                config.echo_json_response(self, 200, "Success", {
+                tornado_helpers.echo_json_response(self, 200, "Success", {
                     'uuids': json_response})
 
             logger.info('GET returning 200 response for agent_id list')
@@ -300,22 +300,22 @@ class AgentsHandler(BaseHandler):
         session = get_session()
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
         if not rest_params["api_version"]:
-            config.echo_json_response(self, 400, "API Version not supported")
+            tornado_helpers.echo_json_response(self, 400, "API Version not supported")
             return
 
         if "agents" not in rest_params:
-            config.echo_json_response(self, 400, "uri not supported")
+            tornado_helpers.echo_json_response(self, 400, "uri not supported")
             return
 
         agent_id = rest_params["agents"]
 
         if agent_id is None:
-            config.echo_json_response(self, 400, "uri not supported")
+            tornado_helpers.echo_json_response(self, 400, "uri not supported")
             logger.warning('DELETE returning 400 response. uri not supported: %s', self.request.path)
             return
 
@@ -326,13 +326,13 @@ class AgentsHandler(BaseHandler):
             logger.error('SQLAlchemy Error: %s', e)
 
         if agent is None:
-            config.echo_json_response(self, 404, "agent id not found")
+            tornado_helpers.echo_json_response(self, 404, "agent id not found")
             logger.info('DELETE returning 404 response. agent id: %s not found.', agent_id)
             return
 
         verifier_id = config.get('cloud_verifier', 'cloudverifier_id', fallback=cloud_verifier_common.DEFAULT_VERIFIER_ID)
         if verifier_id != agent.verifier_id:
-            config.echo_json_response(self, 404, "agent id associated to this verifier")
+            tornado_helpers.echo_json_response(self, 404, "agent id associated to this verifier")
             logger.info('DELETE returning 404 response. agent id: %s not associated to this verifer.', agent_id)
             return
 
@@ -343,7 +343,7 @@ class AgentsHandler(BaseHandler):
                 verifier_db_delete_agent(session, agent_id)
             except SQLAlchemyError as e:
                 logger.error('SQLAlchemy Error: %s', e)
-            config.echo_json_response(self, 200, "Success")
+            tornado_helpers.echo_json_response(self, 200, "Success")
             logger.info('DELETE returning 200 response for agent id: %s', agent_id)
         else:
             try:
@@ -354,7 +354,7 @@ class AgentsHandler(BaseHandler):
                 except SQLAlchemyError as e:
                     logger.error('SQLAlchemy Error: %s', e)
                 session.commit()
-                config.echo_json_response(self, 202, "Accepted")
+                tornado_helpers.echo_json_response(self, 202, "Accepted")
                 logger.info('DELETE returning 202 response for agent id: %s', agent_id)
             except SQLAlchemyError as e:
                 logger.error('SQLAlchemy Error: %s', e)
@@ -369,16 +369,16 @@ class AgentsHandler(BaseHandler):
         try:
             rest_params = config.get_restful_params(self.request.uri)
             if rest_params is None:
-                config.echo_json_response(
+                tornado_helpers.echo_json_response(
                     self, 405, "Not Implemented: Use /agents/ interface")
                 return
 
             if not rest_params["api_version"]:
-                config.echo_json_response(self, 400, "API Version not supported")
+                tornado_helpers.echo_json_response(self, 400, "API Version not supported")
                 return
 
             if "agents" not in rest_params:
-                config.echo_json_response(self, 400, "uri not supported")
+                tornado_helpers.echo_json_response(self, 400, "uri not supported")
                 logger.warning('POST returning 400 response. uri not supported: %s', self.request.path)
                 return
 
@@ -387,7 +387,7 @@ class AgentsHandler(BaseHandler):
             if agent_id is not None:
                 content_length = len(self.request.body)
                 if content_length == 0:
-                    config.echo_json_response(
+                    tornado_helpers.echo_json_response(
                         self, 400, "Expected non zero content length")
                     logger.warning('POST returning 400 response. Expected non zero content length.')
                 else:
@@ -423,7 +423,7 @@ class AgentsHandler(BaseHandler):
 
                     is_valid, err_msg = cloud_verifier_common.validate_agent_data(agent_data)
                     if not is_valid:
-                        config.echo_json_response(self, 400, err_msg)
+                        tornado_helpers.echo_json_response(self, 400, err_msg)
                         logger.warning(err_msg)
                         return
 
@@ -436,7 +436,7 @@ class AgentsHandler(BaseHandler):
                     # don't allow overwriting
 
                     if new_agent_count > 0:
-                        config.echo_json_response(
+                        tornado_helpers.echo_json_response(
                             self, 409, "Agent of uuid %s already exists" % (agent_id))
                         logger.warning("Agent of uuid %s already exists", agent_id)
                     else:
@@ -451,13 +451,13 @@ class AgentsHandler(BaseHandler):
                             agent_data[key] = exclude_db[key]
                         asyncio.ensure_future(
                             process_agent(agent_data, states.GET_QUOTE))
-                        config.echo_json_response(self, 200, "Success")
+                        tornado_helpers.echo_json_response(self, 200, "Success")
                         logger.info('POST returning 200 response for adding agent id: %s', agent_id)
             else:
-                config.echo_json_response(self, 400, "uri not supported")
+                tornado_helpers.echo_json_response(self, 400, "uri not supported")
                 logger.warning("POST returning 400 response. uri not supported")
         except Exception as e:
-            config.echo_json_response(self, 400, "Exception error: %s" % e)
+            tornado_helpers.echo_json_response(self, 400, "Exception error: %s" % e)
             logger.warning("POST returning 400 response. Exception error: %s", e)
             logger.exception(e)
 
@@ -473,23 +473,23 @@ class AgentsHandler(BaseHandler):
         try:
             rest_params = config.get_restful_params(self.request.uri)
             if rest_params is None:
-                config.echo_json_response(
+                tornado_helpers.echo_json_response(
                     self, 405, "Not Implemented: Use /agents/ interface")
                 return
 
             if not rest_params["api_version"]:
-                config.echo_json_response(self, 400, "API Version not supported")
+                tornado_helpers.echo_json_response(self, 400, "API Version not supported")
                 return
 
             if "agents" not in rest_params:
-                config.echo_json_response(self, 400, "uri not supported")
+                tornado_helpers.echo_json_response(self, 400, "uri not supported")
                 logger.warning('PUT returning 400 response. uri not supported: %s', self.request.path)
                 return
 
             agent_id = rest_params["agents"]
 
             if agent_id is None:
-                config.echo_json_response(self, 400, "uri not supported")
+                tornado_helpers.echo_json_response(self, 400, "uri not supported")
                 logger.warning("PUT returning 400 response. uri not supported")
             try:
                 verifier_id = config.get('cloud_verifier', 'cloudverifier_id', fallback=cloud_verifier_common.DEFAULT_VERIFIER_ID)
@@ -499,7 +499,7 @@ class AgentsHandler(BaseHandler):
                 logger.error('SQLAlchemy Error: %s', e)
 
             if agent is None:
-                config.echo_json_response(self, 404, "agent id not found")
+                tornado_helpers.echo_json_response(self, 404, "agent id not found")
                 logger.info('PUT returning 404 response. agent id: %s not found.', agent_id)
                 return
 
@@ -507,7 +507,7 @@ class AgentsHandler(BaseHandler):
                 agent.operational_state = states.START
                 asyncio.ensure_future(
                     process_agent(agent, states.GET_QUOTE))
-                config.echo_json_response(self, 200, "Success")
+                tornado_helpers.echo_json_response(self, 200, "Success")
                 logger.info('PUT returning 200 response for agent id: %s', agent_id)
             elif "stop" in rest_params:
                 # do stuff for terminate
@@ -519,14 +519,14 @@ class AgentsHandler(BaseHandler):
                 except SQLAlchemyError as e:
                     logger.error('SQLAlchemy Error: %s', e)
 
-                config.echo_json_response(self, 200, "Success")
+                tornado_helpers.echo_json_response(self, 200, "Success")
                 logger.info('PUT returning 200 response for agent id: %s', agent_id)
             else:
-                config.echo_json_response(self, 400, "uri not supported")
+                tornado_helpers.echo_json_response(self, 400, "uri not supported")
                 logger.warning("PUT returning 400 response. uri not supported")
 
         except Exception as e:
-            config.echo_json_response(self, 400, "Exception error: %s" % e)
+            tornado_helpers.echo_json_response(self, 400, "Exception error: %s" % e)
             logger.warning("PUT returning 400 response. Exception error: %s", e)
             logger.exception(e)
         self.finish()
@@ -537,7 +537,7 @@ class AgentsHandler(BaseHandler):
 
 class AllowlistHandler(BaseHandler):
     def head(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 400, "Allowlist handler: HEAD Not Implemented")
 
     def get(self):
@@ -548,16 +548,16 @@ class AllowlistHandler(BaseHandler):
 
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None or 'allowlists' not in rest_params:
-            config.echo_json_response(self, 400, "Invalid URL")
+            tornado_helpers.echo_json_response(self, 400, "Invalid URL")
             return
 
         if not rest_params["api_version"]:
-            config.echo_json_response(self, 400, "API Version not supported")
+            tornado_helpers.echo_json_response(self, 400, "API Version not supported")
             return
 
         allowlist_name = rest_params['allowlists']
         if allowlist_name is None:
-            config.echo_json_response(self, 400, "Invalid URL")
+            tornado_helpers.echo_json_response(self, 400, "Invalid URL")
             logger.warning(
                 'GET returning 400 response: ' + self.request.path)
             return
@@ -567,17 +567,17 @@ class AllowlistHandler(BaseHandler):
             allowlist = session.query(VerifierAllowlist).filter_by(
                 name=allowlist_name).one()
         except NoResultFound:
-            config.echo_json_response(self, 404, "Allowlist %s not found" % allowlist_name)
+            tornado_helpers.echo_json_response(self, 404, "Allowlist %s not found" % allowlist_name)
             return
         except SQLAlchemyError as e:
             logger.error(f'SQLAlchemy Error: {e}')
-            config.echo_json_response(self, 500, "Failed to get allowlist")
+            tornado_helpers.echo_json_response(self, 500, "Failed to get allowlist")
             raise
 
         response = {}
         for field in ('name', 'tpm_policy', 'vtpm_policy', 'ima_policy'):
             response[field] = getattr(allowlist, field, None)
-        config.echo_json_response(self, 200, 'Success', response)
+        tornado_helpers.echo_json_response(self, 200, 'Success', response)
 
     def delete(self):
         """Delete an allowlist
@@ -587,16 +587,16 @@ class AllowlistHandler(BaseHandler):
 
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None or 'allowlists' not in rest_params:
-            config.echo_json_response(self, 400, "Invalid URL")
+            tornado_helpers.echo_json_response(self, 400, "Invalid URL")
             return
 
         if not rest_params["api_version"]:
-            config.echo_json_response(self, 400, "API Version not supported")
+            tornado_helpers.echo_json_response(self, 400, "API Version not supported")
             return
 
         allowlist_name = rest_params['allowlists']
         if allowlist_name is None:
-            config.echo_json_response(self, 400, "Invalid URL")
+            tornado_helpers.echo_json_response(self, 400, "Invalid URL")
             logger.warning(
                 'DELETE returning 400 response: ' + self.request.path)
             return
@@ -606,11 +606,11 @@ class AllowlistHandler(BaseHandler):
             session.query(VerifierAllowlist).filter_by(
                 name=allowlist_name).one()
         except NoResultFound:
-            config.echo_json_response(self, 404, "Allowlist %s not found" % allowlist_name)
+            tornado_helpers.echo_json_response(self, 404, "Allowlist %s not found" % allowlist_name)
             return
         except SQLAlchemyError as e:
             logger.error(f'SQLAlchemy Error: {e}')
-            config.echo_json_response(self, 500, "Failed to get allowlist")
+            tornado_helpers.echo_json_response(self, 500, "Failed to get allowlist")
             raise
 
         try:
@@ -619,7 +619,7 @@ class AllowlistHandler(BaseHandler):
             session.commit()
         except SQLAlchemyError as e:
             logger.error(f'SQLAlchemy Error: {e}')
-            config.echo_json_response(self, 500, "Failed to get allowlist")
+            tornado_helpers.echo_json_response(self, 500, "Failed to get allowlist")
             raise
 
         # NOTE(kaifeng) 204 Can not have response body, but current helper
@@ -639,21 +639,21 @@ class AllowlistHandler(BaseHandler):
 
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None or 'allowlists' not in rest_params:
-            config.echo_json_response(self, 400, "Invalid URL")
+            tornado_helpers.echo_json_response(self, 400, "Invalid URL")
             return
 
         if not rest_params["api_version"]:
-            config.echo_json_response(self, 400, "API Version not supported")
+            tornado_helpers.echo_json_response(self, 400, "API Version not supported")
             return
 
         allowlist_name = rest_params['allowlists']
         if allowlist_name is None:
-            config.echo_json_response(self, 400, "Invalid URL")
+            tornado_helpers.echo_json_response(self, 400, "Invalid URL")
             return
 
         content_length = len(self.request.body)
         if content_length == 0:
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 400, "Expected non zero content length")
             logger.warning(
                 'POST returning 400 response. Expected non zero content length.')
@@ -678,7 +678,7 @@ class AllowlistHandler(BaseHandler):
             al_count = session.query(
                 VerifierAllowlist).filter_by(name=allowlist_name).count()
             if al_count > 0:
-                config.echo_json_response(
+                tornado_helpers.echo_json_response(
                     self, 409, "Allowlist with name %s already exists" % allowlist_name)
                 logger.warning(
                     "Allowlist with name %s already exists" % allowlist_name)
@@ -695,11 +695,11 @@ class AllowlistHandler(BaseHandler):
             logger.error(f'SQLAlchemy Error: {e}')
             raise
 
-        config.echo_json_response(self, 201)
+        tornado_helpers.echo_json_response(self, 201)
         logger.info('POST returning 201')
 
     def put(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 400, "Allowlist handler: PUT Not Implemented")
 
     def data_received(self, chunk):

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -24,6 +24,7 @@ from keylime.db.keylime_db import DBEngineManager, SessionManager
 from keylime import keylime_logging
 from keylime import cloud_verifier_common
 from keylime import revocation_notifier
+from keylime import tornado_helpers
 from keylime import tornado_requests
 from keylime import api_version as keylime_api_version
 from keylime.failure import MAX_SEVERITY_LABEL, Failure, Component
@@ -1005,7 +1006,7 @@ def main():
         (r".*", MainHandler),
     ])
 
-    context = cloud_verifier_common.init_mtls()
+    context = tornado_helpers.init_mtls()
 
     sockets = tornado.netutil.bind_sockets(
         int(cloudverifier_port), address=cloudverifier_host)

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -778,7 +778,7 @@ async def invoke_provide_v(agent):
         else:
             # catastrophic error, do not continue
             logger.critical("Unexpected Provide V response error for cloud agent %s, Error: %s", agent['agent_id'], response.status_code)
-            failure.add_event("no_v", {"message": "Unexpected provide V response", "data": response.error}, False)
+            failure.add_event("no_v", {"message": "Unexpected provide V response", "data": response.status_code}, False)
             asyncio.ensure_future(process_agent(agent, states.FAILED, failure))
     else:
         asyncio.ensure_future(process_agent(agent, states.GET_QUOTE))

--- a/keylime/config.py
+++ b/keylime/config.py
@@ -7,11 +7,8 @@ import os.path
 import configparser
 import urllib.parse
 import re
-from http.server import BaseHTTPRequestHandler
-import http.client
 from typing import Optional
 
-import tornado.web
 import yaml
 try:
     from yaml import CSafeLoader as SafeLoader
@@ -171,35 +168,6 @@ def ch_dir(path, logger):
         chownroot(path, logger)
     os.umask(0o077)
     os.chdir(path)
-
-
-def echo_json_response(handler, code, status=None, results=None):
-    """Takes a json package and returns it to the user w/ full HTTP headers"""
-    if handler is None or code is None:
-        return False
-    if status is None:
-        status = http.client.responses[code]
-    if results is None:
-        results = {}
-
-    json_res = {'code': code, 'status': status, 'results': results}
-    json_response = json.dumps(json_res)
-    json_response = json_response.encode('utf-8')
-
-    if isinstance(handler, BaseHTTPRequestHandler):
-        handler.send_response(code)
-        handler.send_header('Content-Type', 'application/json')
-        handler.end_headers()
-        handler.wfile.write(json_response)
-        return True
-    if isinstance(handler, tornado.web.RequestHandler):
-        handler.set_status(code)
-        handler.set_header('Content-Type', 'application/json')
-        handler.write(json_response)
-        handler.finish()
-        return True
-
-    return False
 
 
 def list_to_dict(alist):

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -20,7 +20,6 @@ from cryptography.x509 import load_der_x509_certificate
 
 from keylime.db.registrar_db import RegistrarMain
 from keylime.db.keylime_db import DBEngineManager, SessionManager
-from keylime import cloud_verifier_common
 from keylime import config
 from keylime import crypto
 from keylime import json
@@ -28,6 +27,7 @@ from keylime.tpm import tpm2_objects
 from keylime import keylime_logging
 from keylime.tpm.tpm_main import tpm
 from keylime import api_version as keylime_api_version
+from keylime import tornado_helpers
 
 logger = keylime_logging.init_logging('registrar')
 
@@ -508,8 +508,7 @@ def start(host, tlsport, port):
         logger.info("Loaded %d public keys from database", count)
 
     server = RegistrarServer(serveraddr, ProtectedHandler)
-    context = cloud_verifier_common.init_mtls(section='registrar',
-                                              generatedir='reg_ca')
+    context = tornado_helpers.init_mtls(section='registrar', generatedir='reg_ca')
     if context is not None:
         server.socket = context.wrap_socket(server.socket, server_side=True)
     thread = threading.Thread(target=server.serve_forever)

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -62,11 +62,11 @@ class ProtectedHandler(RequestHandler):
 
     def head(self):
         """HEAD not supported"""
-        config.echo_json_response(self, 405, "HEAD not supported")
+        tornado_helpers.echo_json_response(self, 405, "HEAD not supported")
 
     def patch(self):
         """PATCH not supported"""
-        config.echo_json_response(self, 405, "PATCH not supported")
+        tornado_helpers.echo_json_response(self, 405, "PATCH not supported")
 
     def get(self):
         """This method handles the GET requests to retrieve status on agents from the Registrar Server.
@@ -78,16 +78,16 @@ class ProtectedHandler(RequestHandler):
         session = SessionManager().make_session(engine)
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
         if not rest_params["api_version"]:
-            config.echo_json_response(self, 400, "API Version not supported")
+            tornado_helpers.echo_json_response(self, 400, "API Version not supported")
             return
 
         if "agents" not in rest_params:
-            config.echo_json_response(self, 400, "uri not supported")
+            tornado_helpers.echo_json_response(self, 400, "uri not supported")
             logger.warning('GET returning 400 response. uri not supported: %s', self.request.uri)
             return
 
@@ -101,12 +101,12 @@ class ProtectedHandler(RequestHandler):
                 logger.error('SQLAlchemy Error: %s', e)
 
             if agent is None:
-                config.echo_json_response(self, 404, "agent_id not found")
+                tornado_helpers.echo_json_response(self, 404, "agent_id not found")
                 logger.warning('GET returning 404 response. agent_id %s not found.', agent_id)
                 return
 
             if not agent.active:
-                config.echo_json_response(self, 404, "agent_id not yet active")
+                tornado_helpers.echo_json_response(self, 404, "agent_id not yet active")
                 logger.warning('GET returning 404 response. agent_id %s not yet active.', agent_id)
                 return
 
@@ -122,13 +122,13 @@ class ProtectedHandler(RequestHandler):
             if agent.virtual:
                 response['provider_keys'] = agent.provider_keys
 
-            config.echo_json_response(self, 200, "Success", response)
+            tornado_helpers.echo_json_response(self, 200, "Success", response)
             logger.info('GET returning 200 response for agent_id: %s', agent_id)
         else:
             # return the available registered uuids from the DB
             json_response = session.query(RegistrarMain.agent_id).all()
             return_response = [item[0] for item in json_response]
-            config.echo_json_response(self, 200, "Success", {
+            tornado_helpers.echo_json_response(self, 200, "Success", {
                                       'uuids': return_response})
             logger.info('GET returning 200 response for agent_id list')
 
@@ -136,12 +136,12 @@ class ProtectedHandler(RequestHandler):
 
     def post(self):
         """POST not supported"""
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "POST not supported via TLS interface")
 
     def put(self):
         """PUT not supported"""
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "PUT not supported via TLS interface")
 
     def delete(self):
@@ -153,16 +153,16 @@ class ProtectedHandler(RequestHandler):
         session = SessionManager().make_session(engine)
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
         if not rest_params["api_version"]:
-            config.echo_json_response(self, 400, "API Version not supported")
+            tornado_helpers.echo_json_response(self, 400, "API Version not supported")
             return
 
         if "agents" not in rest_params:
-            config.echo_json_response(self, 400, "URI not supported")
+            tornado_helpers.echo_json_response(self, 400, "URI not supported")
             logger.warning('DELETE agent returning 400 response. uri not supported: %s', self.request.uri)
             return
 
@@ -175,14 +175,14 @@ class ProtectedHandler(RequestHandler):
                     session.commit()
                 except SQLAlchemyError as e:
                     logger.error('SQLAlchemy Error: %s', e)
-                config.echo_json_response(self, 200, "Success")
+                tornado_helpers.echo_json_response(self, 200, "Success")
                 return
 
             # send response
-            config.echo_json_response(self, 404)
+            tornado_helpers.echo_json_response(self, 404)
             return
 
-        config.echo_json_response(self, 404)
+        tornado_helpers.echo_json_response(self, 404)
 
     def data_received(self, chunk: bytes):
         raise NotImplementedError()
@@ -211,11 +211,11 @@ class UnprotectedHandler(RequestHandler):
 
     def head(self):
         """HEAD not supported"""
-        config.echo_json_response(self, 405, "HEAD not supported")
+        tornado_helpers.echo_json_response(self, 405, "HEAD not supported")
 
     def patch(self):
         """PATCH not supported"""
-        config.echo_json_response(self, 405, "PATCH not supported")
+        tornado_helpers.echo_json_response(self, 405, "PATCH not supported")
 
     def get(self):
         """This method handles the GET requests to the unprotected side of the Registrar Server
@@ -224,12 +224,12 @@ class UnprotectedHandler(RequestHandler):
         """
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 405, "Not Implemented: Use /version/ interface")
             return
 
         if "version" not in rest_params:
-            config.echo_json_response(self, 400, "URI not supported")
+            tornado_helpers.echo_json_response(self, 400, "URI not supported")
             logger.warning('GET agent returning 400 response. URI not supported: %s', self.request.uri)
             return
 
@@ -238,7 +238,7 @@ class UnprotectedHandler(RequestHandler):
             "supported_versions": keylime_api_version.all_versions(),
         }
 
-        config.echo_json_response(self, 200, "Success", version_info)
+        tornado_helpers.echo_json_response(self, 200, "Success", version_info)
 
     async def post(self):
         """This method handles the POST requests to add agents to the Registrar Server.
@@ -250,30 +250,30 @@ class UnprotectedHandler(RequestHandler):
         session = SessionManager().make_session(engine)
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
         if not rest_params["api_version"]:
-            config.echo_json_response(self, 400, "API Version not supported")
+            tornado_helpers.echo_json_response(self, 400, "API Version not supported")
             return
 
         if "agents" not in rest_params:
-            config.echo_json_response(self, 400, "uri not supported")
+            tornado_helpers.echo_json_response(self, 400, "uri not supported")
             logger.warning('POST agent returning 400 response. uri not supported: %s', self.request.uri)
             return
 
         agent_id = rest_params["agents"]
 
         if agent_id is None:
-            config.echo_json_response(self, 400, "agent id not found in uri")
+            tornado_helpers.echo_json_response(self, 400, "agent id not found in uri")
             logger.warning('POST agent returning 400 response. agent id not found in uri %s', self.request.uri)
             return
 
         try:
             content_length = int(self.request.headers.get('Content-Length', 0))
             if content_length == 0:
-                config.echo_json_response(
+                tornado_helpers.echo_json_response(
                     self, 400, "Expected non zero content length")
                 logger.warning('POST for %s returning 400 response. Expected non zero content length.', agent_id)
                 return
@@ -312,7 +312,7 @@ class UnprotectedHandler(RequestHandler):
                 base64.b64decode(aik_tpm),
             )
             if aik_attrs != tpm2_objects.AK_EXPECTED_ATTRS:
-                config.echo_json_response(
+                tornado_helpers.echo_json_response(
                     self, 400, "Invalid AK attributes")
                 logger.warning(
                     "Agent %s submitted AIK with invalid attributes! %s (provided) != %s (expected)",
@@ -405,11 +405,11 @@ class UnprotectedHandler(RequestHandler):
             response = {
                 'blob': blob,
             }
-            config.echo_json_response(self, 200, "Success", response)
+            tornado_helpers.echo_json_response(self, 200, "Success", response)
 
             logger.info('POST returning key blob for agent_id: %s', agent_id)
         except Exception as e:
-            config.echo_json_response(self, 400, "Error: %s" % e)
+            tornado_helpers.echo_json_response(self, 400, "Error: %s" % e)
             logger.warning("POST for %s returning 400 response. Error: %s", agent_id, e)
             logger.exception(e)
 
@@ -422,30 +422,30 @@ class UnprotectedHandler(RequestHandler):
         session = SessionManager().make_session(engine)
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
         if not rest_params["api_version"]:
-            config.echo_json_response(self, 400, "API Version not supported")
+            tornado_helpers.echo_json_response(self, 400, "API Version not supported")
             return
 
         if "agents" not in rest_params:
-            config.echo_json_response(self, 400, "uri not supported")
+            tornado_helpers.echo_json_response(self, 400, "uri not supported")
             logger.warning('PUT agent returning 400 response. uri not supported: %s', self.request.uri)
             return
 
         agent_id = rest_params["agents"]
 
         if agent_id is None:
-            config.echo_json_response(self, 400, "agent id not found in uri")
+            tornado_helpers.echo_json_response(self, 400, "agent id not found in uri")
             logger.warning('PUT agent returning 400 response. agent id not found in uri %s', self.request.uri)
             return
 
         try:
             content_length = int(self.request.headers.get('Content-Length', 0))
             if content_length == 0:
-                config.echo_json_response(
+                tornado_helpers.echo_json_response(
                     self, 400, "Expected non zero content length")
                 logger.warning('PUT for %s returning 400 response. Expected non zero content length.', agent_id)
                 return
@@ -491,17 +491,17 @@ class UnprotectedHandler(RequestHandler):
                     raise Exception(
                         f"Auth tag {auth_tag} does not match expected value {ex_mac}")
 
-            config.echo_json_response(self, 200, "Success")
+            tornado_helpers.echo_json_response(self, 200, "Success")
             logger.info('PUT activated: %s', agent_id)
         except Exception as e:
-            config.echo_json_response(self, 400, "Error: %s" % e)
+            tornado_helpers.echo_json_response(self, 400, "Error: %s" % e)
             logger.warning("PUT for %s returning 400 response. Error: %s", agent_id, e)
             logger.exception(e)
             return
 
     def delete(self):
         """DELETE not supported"""
-        config.echo_json_response(self, 405, "DELETE not supported")
+        tornado_helpers.echo_json_response(self, 405, "DELETE not supported")
 
     def data_received(self, chunk: bytes):
         raise NotImplementedError()

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -21,6 +21,7 @@ from keylime import config
 from keylime import json
 from keylime import keylime_logging
 from keylime import tenant
+from keylime import tornado_helpers
 from keylime import api_version as keylime_api_version
 
 
@@ -62,9 +63,9 @@ class BaseHandler(tornado.web.RequestHandler):
             lines = []
             for line in traceback.format_exception(*kwargs["exc_info"]):
                 lines.append(line)
-            config.echo_json_response(self, status_code, self._reason, lines)
+            tornado_helpers.echo_json_response(self, status_code, self._reason, lines)
         else:
-            config.echo_json_response(self, status_code, self._reason)
+            tornado_helpers.echo_json_response(self, status_code, self._reason)
 
     def data_received(self, chunk):
         raise NotImplementedError()
@@ -72,23 +73,23 @@ class BaseHandler(tornado.web.RequestHandler):
 
 class MainHandler(tornado.web.RequestHandler):
     def head(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use /webapp/, /agents/ or /logs/ interface instead")
 
     def get(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use /webapp/, /agents/ or /logs/  interface instead")
 
     def put(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use /webapp/, /agents/ or /logs/  interface instead")
 
     def post(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use /webapp/, /agents/ or /logs/  interface instead")
 
     def delete(self):
-        config.echo_json_response(
+        tornado_helpers.echo_json_response(
             self, 405, "Not Implemented: Use /webapp/, /agents/ or /logs/  interface instead")
 
     def data_received(self, chunk):
@@ -98,7 +99,7 @@ class MainHandler(tornado.web.RequestHandler):
 class WebAppHandler(BaseHandler):
     def head(self):
         """HEAD not supported"""
-        config.echo_json_response(self, 405, "HEAD not supported")
+        tornado_helpers.echo_json_response(self, 405, "HEAD not supported")
 
     def get(self):
         """This method handles the GET requests to retrieve status on agents for all agents in a Web-based GUI.
@@ -325,7 +326,7 @@ class WebAppHandler(BaseHandler):
 class AgentsHandler(BaseHandler):
     def head(self):
         """HEAD not supported"""
-        config.echo_json_response(self, 405, "HEAD not supported")
+        tornado_helpers.echo_json_response(self, 405, "HEAD not supported")
 
     async def get_agent_state(self, agent_id):
         try:
@@ -340,7 +341,7 @@ class AgentsHandler(BaseHandler):
             logger.error("Status command response: %s:%s Unexpected response from Cloud Verifier.",
                 tenant_templ.cloudverifier_ip, tenant_templ.cloudverifier_port)
             logger.exception(e)
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 500, "Unexpected response from Cloud Verifier", str(e))
             logger.error("Unexpected response from Cloud Verifier: %s", e)
             return
@@ -372,7 +373,7 @@ class AgentsHandler(BaseHandler):
 
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 405, "Not Implemented: Use /agents/ or /logs/ interface")
             return
 
@@ -383,12 +384,12 @@ class AgentsHandler(BaseHandler):
             # intercept requests for logs
             with open(keylime_logging.LOGSTREAM, encoding="utf-8") as f:
                 logValue = f.readlines()
-                config.echo_json_response(self, 200, "Success", {
+                tornado_helpers.echo_json_response(self, 200, "Success", {
                                           'log': logValue[offset:]})
             return
         if "agents" not in rest_params:
             # otherwise they must be looking for agent info
-            config.echo_json_response(self, 400, "uri not supported")
+            tornado_helpers.echo_json_response(self, 400, "uri not supported")
             logger.warning('GET returning 400 response. uri not supported: %s', self.request.path)
             return
 
@@ -398,7 +399,7 @@ class AgentsHandler(BaseHandler):
             agents = await self.get_agent_state(agent_id)
             agents["id"] = agent_id
 
-            config.echo_json_response(self, 200, "Success", agents)
+            tornado_helpers.echo_json_response(self, 200, "Success", agents)
             return
 
         # If no agent ID, get list of all agents from Registrar
@@ -414,7 +415,7 @@ class AgentsHandler(BaseHandler):
             logger.error("Status command response: %s:%s Unexpected response from Registrar.",
                 tenant_templ.registrar_ip, tenant_templ.registrar_port)
             logger.exception(e)
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 500, "Unexpected response from Registrar", str(e))
             return
 
@@ -432,7 +433,7 @@ class AgentsHandler(BaseHandler):
 
         agent_list = response_body["results"]["uuids"]
 
-        config.echo_json_response(self, 200, "Success", {
+        tornado_helpers.echo_json_response(self, 200, "Success", {
                                   'uuids': agent_list})
 
     def delete(self):
@@ -444,12 +445,12 @@ class AgentsHandler(BaseHandler):
 
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
         if "agents" not in rest_params:
-            config.echo_json_response(self, 400, "uri not supported")
+            tornado_helpers.echo_json_response(self, 400, "uri not supported")
             logger.warning('DELETE returning 400 response. uri not supported: %s', self.request.path)
             return
 
@@ -460,7 +461,7 @@ class AgentsHandler(BaseHandler):
         mytenant.agent_uuid = agent_id
         mytenant.do_cvdelete()
 
-        config.echo_json_response(self, 200, "Success")
+        tornado_helpers.echo_json_response(self, 200, "Success")
 
     def post(self):
         """This method handles the POST requests to add agents to the Cloud Verifier.
@@ -471,12 +472,12 @@ class AgentsHandler(BaseHandler):
 
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
         if "agents" not in rest_params:
-            config.echo_json_response(self, 400, "uri not supported")
+            tornado_helpers.echo_json_response(self, 400, "uri not supported")
             logger.warning('POST returning 400 response. uri not supported: %s', self.request.path)
             return
 
@@ -515,7 +516,7 @@ class AgentsHandler(BaseHandler):
             if ca_dir_pw == "":
                 ca_dir_pw = 'default'
         else:
-            config.echo_json_response(self, 400, "invalid payload type chosen")
+            tornado_helpers.echo_json_response(self, 400, "invalid payload type chosen")
             logger.warning('POST returning 400 response. malformed query')
             return
 
@@ -569,10 +570,10 @@ class AgentsHandler(BaseHandler):
         except Exception as e:
             logger.exception(e)
             logger.warning('POST returning 500 response. Tenant error: %s', e)
-            config.echo_json_response(self, 500, "Request failure", str(e))
+            tornado_helpers.echo_json_response(self, 500, "Request failure", str(e))
             return
 
-        config.echo_json_response(self, 200, "Success")
+        tornado_helpers.echo_json_response(self, 200, "Success")
 
     def put(self):
         """This method handles the PUT requests to add agents to the Cloud Verifier.
@@ -582,12 +583,12 @@ class AgentsHandler(BaseHandler):
 
         rest_params = config.get_restful_params(self.request.uri)
         if rest_params is None:
-            config.echo_json_response(
+            tornado_helpers.echo_json_response(
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
         if "agents" not in rest_params:
-            config.echo_json_response(self, 400, "uri not supported")
+            tornado_helpers.echo_json_response(self, 400, "uri not supported")
             logger.warning('PUT returning 400 response. uri not supported: %s', self.request.path)
             return
 
@@ -598,7 +599,7 @@ class AgentsHandler(BaseHandler):
         mytenant.agent_uuid = agent_id
         mytenant.do_cvreactivate()
 
-        config.echo_json_response(self, 200, "Success")
+        tornado_helpers.echo_json_response(self, 200, "Success")
 
     def data_received(self, chunk):
         raise NotImplementedError()

--- a/keylime/tornado_helpers.py
+++ b/keylime/tornado_helpers.py
@@ -1,0 +1,112 @@
+import os
+import socket
+import ssl
+import sys
+
+from keylime import config, ca_util
+from keylime.cloud_verifier_common import logger
+
+
+def init_mtls(section='cloud_verifier', generatedir='cv_ca'):
+    """
+    Generates mTLS SSLContext for either the cloud verifier or the registrar.
+    """
+
+    if not config.getboolean('general', "enable_tls"):
+        logger.warning(
+            "Warning: TLS is currently disabled, keys will be sent in the clear! This should only be used for testing.")
+        return None
+
+    logger.info("Setting up TLS...")
+    my_cert = config.get(section, 'my_cert')
+    ca_cert = config.get(section, 'ca_cert')
+    my_priv_key = config.get(section, 'private_key')
+    my_key_pw = config.get(section, 'private_key_pw')
+    tls_dir = config.get(section, 'tls_dir')
+
+    if tls_dir == 'generate':
+        if my_cert != 'default' or my_priv_key != 'default' or ca_cert != 'default':
+            raise Exception(
+                "To use tls_dir=generate, options ca_cert, my_cert, and private_key must all be set to 'default'")
+
+        if generatedir[0] != '/':
+            generatedir = os.path.abspath(os.path.join(config.WORK_DIR,
+                                                       generatedir))
+        tls_dir = generatedir
+        ca_path = "%s/cacert.crt" % (tls_dir)
+        if os.path.exists(ca_path):
+            logger.info("Existing CA certificate found in %s, not generating a new one", tls_dir)
+        else:
+            logger.info("Generating a new CA in %s and a client certificate for connecting", tls_dir)
+            logger.info("use keylime_ca -d %s to manage this CA", tls_dir)
+            if not os.path.exists(tls_dir):
+                os.makedirs(tls_dir, 0o700)
+            if my_key_pw == 'default':
+                logger.warning("CAUTION: using default password for CA, please set private_key_pw to a strong password")
+            ca_util.setpassword(my_key_pw)
+            ca_util.cmd_init(tls_dir)
+            ca_util.cmd_mkcert(tls_dir, socket.gethostname())
+            ca_util.cmd_mkcert(tls_dir, 'client')
+
+    if tls_dir == 'CV':
+        if section != 'registrar':
+            raise Exception(
+                "You only use the CV option to tls_dir for the registrar not %s" % section)
+        tls_dir = os.path.abspath(os.path.join(config.WORK_DIR, 'cv_ca'))
+        if not os.path.exists("%s/cacert.crt" % (tls_dir)):
+            raise Exception(
+                "It appears that the verifier has not yet created a CA and certificates, please run the verifier first")
+
+    # if it is relative path, convert to absolute in WORK_DIR
+    if tls_dir[0] != '/':
+        tls_dir = os.path.abspath(os.path.join(config.WORK_DIR, tls_dir))
+
+    if ca_cert == 'default':
+        ca_path = os.path.join(tls_dir, "cacert.crt")
+    elif not os.path.isabs(ca_cert):
+        ca_path = os.path.join(tls_dir, ca_cert)
+    else:
+        ca_path = ca_cert
+
+    if my_cert == 'default':
+        my_cert = os.path.join(tls_dir, f"{socket.gethostname()}-cert.crt")
+    elif not os.path.isabs(my_cert):
+        my_cert = os.path.join(tls_dir, my_cert)
+    else:
+        pass
+
+    if my_priv_key == 'default':
+        my_priv_key = os.path.join(tls_dir,
+                                   f"{socket.gethostname()}-private.pem")
+    elif not os.path.isabs(my_priv_key):
+        my_priv_key = os.path.join(tls_dir, my_priv_key)
+
+    check_client_cert = (config.has_option(section, 'check_client_cert')
+                         and config.getboolean(section, 'check_client_cert'))
+    context = generate_mtls_context(my_cert, my_priv_key, ca_path, check_client_cert, my_key_pw)
+
+    return context
+
+
+def generate_mtls_context(cert_path, private_key_path, ca_path, verify_client_cert=True, private_key_password=None):
+    try:
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        if sys.version_info >= (3, 7):
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+        else:
+            context.options &= ~ssl.OP_NO_TLSv1_2
+        context.load_verify_locations(cafile=ca_path)
+        context.load_cert_chain(
+            certfile=cert_path, keyfile=private_key_path, password=private_key_password)
+        if verify_client_cert:
+            context.verify_mode = ssl.CERT_REQUIRED
+    except ssl.SSLError as exc:
+        if exc.reason == 'EE_KEY_TOO_SMALL':
+            logger.error('Higher key strength is required for keylime '
+                         'running on this system. If keylime is responsible '
+                         'to generate the certificate, please raise the value '
+                         'of configuration option [ca]cert_bits, remove '
+                         'generated certificate and re-run keylime service')
+        raise exc
+
+    return context

--- a/keylime/tornado_requests.py
+++ b/keylime/tornado_requests.py
@@ -5,13 +5,6 @@ SPDX-License-Identifier: Apache-2.0
 Copyright 2017 Massachusetts Institute of Technology.
 '''
 
-import json
-import yaml
-try:
-    from yaml import CSafeLoader as SafeLoader
-except ImportError:
-    from yaml import SafeLoader
-
 from tornado import httpclient
 
 
@@ -37,40 +30,18 @@ async def request(method, url, params=None, data=None, context=None, headers=Non
 
     except httpclient.HTTPError as e:
         if e.response is None:
-            return tornado_response(500, str(e))
+            return TornadoResponse(500, str(e))
 
-        return tornado_response(e.response.code, e.response.body)
+        return TornadoResponse(e.response.code, e.response.body)
     except ConnectionError as e:
-        return tornado_response(599, "Connection error: %s" % e)
+        return TornadoResponse(599, "Connection error: %s" % e)
     if response is None:
         return None
-    return tornado_response(response.code, response.body)
+    return TornadoResponse(response.code, response.body)
 
 
-def is_refused(e):
-    if hasattr(e, 'strerror'):
-        return "Connection refused" in e.strerror
-
-    return False
-
-
-class tornado_response():
+class TornadoResponse:
 
     def __init__(self, code, body):
         self.status_code = code
         self.body = body
-
-    def json(self):
-        try:
-            retval = json.loads(self.body)
-
-        except Exception as e:
-            retval = [self.body, str(e)]
-        return retval
-
-    def yaml(self):
-        try:
-            retval = yaml.load(self.body, Loader=SafeLoader)
-        except Exception as e:
-            retval = [self.body, str(e)]
-        return retval


### PR DESCRIPTION
We are currently using Tornado for the verifier, but not for the agent and registrar. 
This PR moves the agent and registrar to Tornado and unifies the utilities used for Tornado in the `tornado_helpers` module.