### PR TITLE
ci: disable DeprecationWarning from pylint in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ basepython = python3
 usedevelop = True
 setenv =
    VIRTUAL_ENV={envdir}
-   PYTHONWARNINGS=default::DeprecationWarning
 
 [testenv:pylint]
 deps =


### PR DESCRIPTION
Setting PYTHONWARNINGS to default::DeprecationWarning creates a lot of
noise from pylint itself and makes it harder to read the log.

We can re-enable the setting once pylint does not generate those warnings
anymore.

Signed-off-by: Thore Sommer <mail@thson.de>