### PR TITLE
verifier: use json.loads(..) instead of ast.literal_eval(..)

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -224,14 +224,14 @@ def prepare_get_quote(agent):
 
 
 def process_get_status(agent):
-    allowlist = ast.literal_eval(agent.allowlist)
+    allowlist = json.loads(agent.allowlist)
     if isinstance(allowlist, dict) and 'allowlist' in allowlist:
         al_len = len(allowlist['allowlist'])
     else:
         al_len = 0
 
     try :
-        mb_refstate = ast.literal_eval(agent.mb_refstate)
+        mb_refstate = json.loads(agent.mb_refstate)
     except Exception as e:
         logger.warning('Non-fatal problem ocurred while attempting to evaluate agent attribute "mb_refstate" (%s). Will just consider the value of this attribute to be "None"', e.args)
         mb_refstate = None

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -3,7 +3,6 @@ SPDX-License-Identifier: Apache-2.0
 Copyright 2017 Massachusetts Institute of Technology.
 '''
 
-import ast
 import codecs
 import copy
 import hashlib
@@ -217,7 +216,7 @@ def _process_measurement_list(agentAttestState, lines, hash_alg, lists=None, m2w
 
     if lists is not None:
         if isinstance(lists, str):
-            lists = ast.literal_eval(lists)
+            lists = json.loads(lists)
         allow_list = lists['allowlist']
         exclude_list = lists['exclude']
     else:

--- a/test/test_ima_verification.py
+++ b/test/test_ima_verification.py
@@ -8,6 +8,7 @@ import hashlib
 import os
 import unittest
 
+from keylime import json
 from keylime import ima
 from keylime import ima_file_signatures
 from keylime.agentstates import AgentAttestState
@@ -92,8 +93,8 @@ class TestIMAVerification(unittest.TestCase):
 
         _, failure = ima.process_measurement_list(AgentAttestState('1'), lines, lists_map)
         self.assertTrue(not failure)
-        # test with list as a string
-        _, failure = ima.process_measurement_list(AgentAttestState('1'), lines, str(lists_map))
+        # test with list with JSON
+        _, failure = ima.process_measurement_list(AgentAttestState('1'), lines, json.dumps(lists_map))
         self.assertTrue(not failure)
 
         # No files are in the allowlist -> this should fail
@@ -136,7 +137,7 @@ class TestIMAVerification(unittest.TestCase):
         list_map = ima.process_allowlists(ALLOWLIST, '')
         ima_keyrings = ima_file_signatures.ImaKeyrings()
 
-        self.assertTrue(ima.process_measurement_list(AgentAttestState('1'), KEYRINGS.splitlines(), str(list_map), ima_keyrings=ima_keyrings) is not None)
+        self.assertTrue(ima.process_measurement_list(AgentAttestState('1'), KEYRINGS.splitlines(), json.dumps(list_map), ima_keyrings=ima_keyrings) is not None)
 
     def test_iterative_attestation(self):
         """ Test that the resulting pcr value is as expected by subsequently feeding a measurement list.
@@ -171,7 +172,7 @@ class TestIMAVerification(unittest.TestCase):
         empty_keyring = ima_file_signatures.ImaKeyring()
 
         # every entry is covered by the allowlist and there's no keyring -> this should pass
-        _, failure = ima.process_measurement_list(AgentAttestState('1'), COMBINED.splitlines(), str(lists_map))
+        _, failure = ima.process_measurement_list(AgentAttestState('1'), COMBINED.splitlines(), json.dumps(lists_map))
         self.assertTrue(not failure)
 
         curdir = os.path.dirname(os.path.abspath(__file__))
@@ -193,37 +194,37 @@ class TestIMAVerification(unittest.TestCase):
         self.assertTrue(failure)
 
         # all entries are either covered by allow list or by signature verification -> this should pass
-        _, failure = ima.process_measurement_list(AgentAttestState('1'), COMBINED.splitlines(), str(lists_map), ima_keyrings=ima_keyrings)
+        _, failure = ima.process_measurement_list(AgentAttestState('1'), COMBINED.splitlines(), json.dumps(lists_map), ima_keyrings=ima_keyrings)
         self.assertTrue(not failure)
 
         # the signature is valid but the hash in the allowlist is wrong -> this should fail
-        _, failure = ima.process_measurement_list(AgentAttestState('1'), SIGNATURES.splitlines(), str(lists_map_wrong), ima_keyrings=ima_keyrings)
+        _, failure = ima.process_measurement_list(AgentAttestState('1'), SIGNATURES.splitlines(), json.dumps(lists_map_wrong), ima_keyrings=ima_keyrings)
         self.assertTrue(failure)
 
         # the signature is valid and the file is not in the allowlist -> this should pass
-        _, failure = ima.process_measurement_list(AgentAttestState('1'), SIGNATURES.splitlines(), str(lists_map_empty), ima_keyrings=ima_keyrings)
+        _, failure = ima.process_measurement_list(AgentAttestState('1'), SIGNATURES.splitlines(), json.dumps(lists_map_empty), ima_keyrings=ima_keyrings)
         self.assertTrue(not failure)
 
         # the signature is invalid but the correct hash is in the allowlist -> this should fail
         ima_keyrings.set_tenant_keyring(empty_keyring)
-        _, failure = ima.process_measurement_list(AgentAttestState('1'), SIGNATURES.splitlines(), str(lists_map), ima_keyrings=ima_keyrings)
+        _, failure = ima.process_measurement_list(AgentAttestState('1'), SIGNATURES.splitlines(), json.dumps(lists_map), ima_keyrings=ima_keyrings)
         self.assertTrue(failure)
 
         # the file has no signature but the hash is correct -> this should pass
-        _, failure = ima.process_measurement_list(AgentAttestState('1'), MEASUREMENTS.splitlines(), str(lists_map))
+        _, failure = ima.process_measurement_list(AgentAttestState('1'), MEASUREMENTS.splitlines(), json.dumps(lists_map))
         self.assertTrue(not failure)
 
         # All files are in the exclude list but hashes are invalid -> this should pass
-        _, failure = ima.process_measurement_list(AgentAttestState('1'), MEASUREMENTS.splitlines(), str(lists_map_exclude_wrong))
+        _, failure = ima.process_measurement_list(AgentAttestState('1'), MEASUREMENTS.splitlines(), json.dumps(lists_map_exclude_wrong))
         self.assertTrue(not failure)
 
         # All files are in the exclude list and their signatures are invalid -> this should pass
         ima_keyrings.set_tenant_keyring(tenant_keyring)
-        _, failure = ima.process_measurement_list(AgentAttestState('1'), SIGNATURES.splitlines(), str(lists_map_exclude), ima_keyrings=ima_keyrings)
+        _, failure = ima.process_measurement_list(AgentAttestState('1'), SIGNATURES.splitlines(), json.dumps(lists_map_exclude), ima_keyrings=ima_keyrings)
         self.assertTrue(not failure)
 
         # All files are in the exclude list but hashes or signatures are invalid -> this should pass
-        _, failure = ima.process_measurement_list(AgentAttestState('1'), MEASUREMENTS.splitlines(), str(lists_map_exclude_wrong), ima_keyrings=ima_keyrings)
+        _, failure = ima.process_measurement_list(AgentAttestState('1'), MEASUREMENTS.splitlines(), json.dumps(lists_map_exclude_wrong), ima_keyrings=ima_keyrings)
         self.assertTrue(not failure)
 
     def test_read_allowlist(self):


### PR DESCRIPTION
The data sent via the API is JSON not Python dicts.

This failed once I build more complex policies for IMA or measured boot.

@maugustosilva can you confirm that you also expect it to be JSON and not Python dicts?