### PR TITLE
Fix for Issue #840

### DIFF
--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -911,8 +911,16 @@ class tpm(tpm_abstract.AbstractTPM):
         # Clean up TPM manufacturer information (strip control characters)
         # These strings are supposed to be printable ASCII characters, but
         # some TPM manufacturers put control characters in here
+
+        # TPM manufacturer information can also contain un-escaped
+        # double quotes. Making sure that un-escaped quotes are
+        # replaced before attempting YAML parse.
+
+        def quoterepl(m): return "\"" + m.group(0)[1:-1].replace('"', '\\"') + "\""        
+
         for i, s in enumerate(output):
-            output[i] = re.sub(r"[\x01-\x1F\x7F]", "", s.decode('utf-8')).encode('utf-8')
+            s1 = re.sub(r'(?!".*\\".*")".*".*"', quoterepl, s.decode('utf-8'))
+            output[i] = re.sub(r"[\x01-\x1F\x7F]", "", s1).encode('utf-8')
 
         retyaml = config.yaml_to_dict(output, logger=logger)
         if retyaml is None:

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -911,12 +911,11 @@ class tpm(tpm_abstract.AbstractTPM):
         # Clean up TPM manufacturer information (strip control characters)
         # These strings are supposed to be printable ASCII characters, but
         # some TPM manufacturers put control characters in here
-
+        #
         # TPM manufacturer information can also contain un-escaped
         # double quotes. Making sure that un-escaped quotes are
         # replaced before attempting YAML parse.
-
-        def quoterepl(m): return "\"" + m.group(0)[1:-1].replace('"', '\\"') + "\""        
+        def quoterepl(m): return '"' + m.group(0)[1:-1].replace('"', '\\"') + '"'
 
         for i, s in enumerate(output):
             s1 = re.sub(r'(?!".*\\".*")".*".*"', quoterepl, s.decode('utf-8'))

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -915,7 +915,8 @@ class tpm(tpm_abstract.AbstractTPM):
         # TPM manufacturer information can also contain un-escaped
         # double quotes. Making sure that un-escaped quotes are
         # replaced before attempting YAML parse.
-        def quoterepl(m): return '"' + m.group(0)[1:-1].replace('"', '\\"') + '"'
+        def quoterepl(m):
+            return '"' + m.group(0)[1:-1].replace('"', '\\"') + '"'
 
         for i, s in enumerate(output):
             s1 = re.sub(r'(?!".*\\".*")".*".*"', quoterepl, s.decode('utf-8'))


### PR DESCRIPTION
This is a small fix to proactively fix Issue #840 by identifying non-escaped double quotes in the tpm2-tools output.

The fix is tricky because it is very difficult to test -- I have access to exactly 1 device that shows this error.
In addition, the tpm2-tools have already fixed the defect, so must make sure *escaped* double quotes don't get escaped again in error.


Signed-off-by: George Almasi <gheorghe@us.ibm.com>