### PR TITLE
Add exponential backoff on failing for tpm, tenant and verifier.

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -438,12 +438,16 @@ accept_tpm_hash_algs = sha512,sha384,sha256,sha1
 accept_tpm_encryption_algs = ecc,rsa
 accept_tpm_signing_algs = ecschnorr,rsassa
 
-# How long to wait between failed attempts to connect to a cloud agent, in
-# seconds.  Floating point values accepted here.
-retry_interval = 1
+# Wether or not to use an exponantial backoff algorithm for retries.
+exponential_backoff = True
+
+# Either how long to wait between failed attempts to connect to a cloud agent
+# in seconds, or the base for the exponential backoff algorithm.
+# Floating point values accepted here.
+retry_interval = 2
 
 # Number of retries to connect to a agent before giving up. Must be an integer.
-max_retries = 10
+max_retries = 5
 
 # Tell the tenant whether to require an EK certificate from the TPM.
 # If set to False the tenant will ignore EK certificates entirely.

--- a/keylime.conf
+++ b/keylime.conf
@@ -113,12 +113,16 @@ payload_script=autorun.sh
 # Set to -1 or any negative or out of range PCR value to turn off.
 measure_payload_pcr=-1
 
-# How long to wait between failed attempts to communicate with the TPM in
-# seconds.  Floating point values are accepted here.
-retry_interval = 1
+# Wether or not to use an exponantial backoff algorithm for retries.
+exponential_backoff = True
+
+# Either how long to wait between failed attempts to communicate with the TPM
+# in seconds, or the base for the exponential backoff algorithm.
+# Floating point values accepted here.
+retry_interval = 2
 
 # Integer number of retries to communicate with the TPM before giving up.
-max_retries = 10
+max_retries = 4
 
 # TPM2-specific options, allows customizing default algorithms to use.
 # Specify the default crypto algorithms to use with a TPM2 for this agent.

--- a/keylime.conf
+++ b/keylime.conf
@@ -251,12 +251,16 @@ auto_migrate_db = True
 # Set to "0" to create one worker per processor.
 multiprocessing_pool_num_workers = 0
 
-# How long to wait between failed attempts to connect to a cloud agent, in
-# seconds.  Floating point values accepted here.
-retry_interval = 1
+# Wether or not to use an exponantial backoff algorithm for retries.
+exponential_backoff = True
+
+# Either how long to wait between failed attempts to connect to a cloud agent
+# in seconds, or the base for the exponential backoff algorithm.
+# Floating point values accepted here.
+retry_interval = 2
 
 # Number of retries to connect to an agent before giving up. Must be an integer.
-max_retries = 10
+max_retries = 5
 
 # Time between integrity measurement checks, in seconds.  If set to "0", checks
 # will done as fast as possible.  Floating point values accepted here.

--- a/keylime/common/retry.py
+++ b/keylime/common/retry.py
@@ -1,0 +1,13 @@
+"""
+SPDX-License-Identifier: Apache-2.0
+Copyright 2021 Angelo Ruocco - IBM Research Lab Zurich
+"""
+
+def retry_time(exponential, base, ntries, logger):
+    if exponential:
+        if base > 1:
+            return base**ntries
+        elif logger:
+            logger.warning("Base %f incompatible with exponential backoff", base)
+
+    return abs(base)

--- a/test/test_retry_algo.py
+++ b/test/test_retry_algo.py
@@ -1,0 +1,41 @@
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2021 Angelo Ruocco - IBM Research Lab Zurich
+'''
+
+import unittest
+import random
+
+from keylime.common import retry
+
+def rand_base():
+    return random.uniform(-99, 99)
+
+def rand_base_proper():
+    return random.uniform(1,99)
+
+def rand_ntries():
+    return random.randint(1, 99)
+
+def rand_exp():
+    return random.choice([True, False])
+
+
+class RetryInterval_Test(unittest.TestCase):
+
+    def test_general(self):
+        self.assertTrue(retry.retry_time(rand_exp(), rand_base(), rand_ntries(), None) >= 0)
+
+    def test_linear(self):
+        b = rand_base()
+        self.assertEqual(retry.retry_time(False, b, rand_ntries, None), abs(b))
+
+    def test_exponential(self):
+        b0 = rand_base_proper()
+        b1 = random.random()
+        n = rand_ntries()
+        self.assertEqual(retry.retry_time(True, b0, n, None), b0**n)
+        self.assertEqual(retry.retry_time(True, b1, n, None), abs(b1))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This small patchset adds the option on `keylime.conf`, enabled by default, to use exponential backoff when communication fails (with tpm, tenant and verifier).

Formula is `wait time = base ^ ntries`. With default base value `2`, so that wait times are `1, 2, 4, 8, 16, [...]`, still stopping on max_ntries.