### PR TITLE
Handle missing PCR banks dependent on the hash algorithm correctly

### DIFF
--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -1130,13 +1130,15 @@ class tpm(tpm_abstract.AbstractTPM):
                                                     "data": retout}, False)
             return failure
         if "pcrs" in jsonout:
-            if hash_alg in jsonout["pcrs"]:
+            # The hash algorithm might be in the YAML output but does not contain any data, so we also check that.
+            if hash_alg in jsonout["pcrs"] and jsonout["pcrs"][hash_alg] is not None:
                 alg_size = hash_alg.get_size() // 4
                 for pcrval, hashval in jsonout["pcrs"][hash_alg].items():
                     pcrs.append("PCR " + str(pcrval) + " " + '{0:0{1}x}'.format(hashval, alg_size))
 
         if len(pcrs) == 0:
-            pcrs = None
+            logger.warning("Quote does not contain any PCRs. Make sure that the TPM supports %s PCR banks",
+                           str(hash_alg))
 
         return self.check_pcrs(agentAttestState, tpm_policy, pcrs, data, False, ima_measurement_list, allowlist,
                                ima_keyrings, mb_measurement_list, mb_refstate, hash_alg)


### PR DESCRIPTION
The hash algorithm itself is there as a key in the output, but the value is None.

This happened on a Debian + swtpm system were the `tpm2_pcrread` output looks like the following:
```
sha1:
sha256:
  0 : 0xE21B703EE69C77476BCCB43EC0336A9A1B2914B378944F7B00A10214CA8FEA93
  1 : 0xCB0FD2FC0B87CD3676C1E370DE8446AB4967CF92356B6FCE001CC4F05932FCD6
  2 : 0xE8D71943876AA0BE05CF35E32E451C0435388D3B44FA4586843E4B5227033C87
  3 : 0xE21B703EE69C77476BCCB43EC0336A9A1B2914B378944F7B00A10214CA8FEA93
  4 : 0x5A1C3A55A9E0A037F9FAB97B15C7A71F30DFE362C477957F26671C1165104766
  5 : 0x4D7544A02B1EEB2D34DD93A453EF23385EB378F527B21AB094E78E7BD2F160DC
  6 : 0xE21B703EE69C77476BCCB43EC0336A9A1B2914B378944F7B00A10214CA8FEA93
  7 : 0xE21B703EE69C77476BCCB43EC0336A9A1B2914B378944F7B00A10214CA8FEA93
  8 : 0x0000000000000000000000000000000000000000000000000000000000000000
  9 : 0x0000000000000000000000000000000000000000000000000000000000000000
  10: 0x64BAC4DD70BD36018665AB297E89D8CAF98A0A83E44CCD33800EB18A2ED80405
  11: 0x0000000000000000000000000000000000000000000000000000000000000000
  12: 0x0000000000000000000000000000000000000000000000000000000000000000
  13: 0x0000000000000000000000000000000000000000000000000000000000000000
  14: 0x0000000000000000000000000000000000000000000000000000000000000000
  15: 0x0000000000000000000000000000000000000000000000000000000000000000
  16: 0x0000000000000000000000000000000000000000000000000000000000000000
  17: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
  18: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
  19: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
  20: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
  21: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
  22: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
  23: 0x0000000000000000000000000000000000000000000000000000000000000000
sha384:
sha512:
```