### PR TITLE
WIP: drop support for API version 1.0

### DIFF
--- a/keylime/api_version.py
+++ b/keylime/api_version.py
@@ -8,7 +8,6 @@ from packaging import version
 
 CURRENT_VERSION = "2.0"
 VERSIONS = [
-    "1.0",
     "2.0"
 ]
 LATEST_VERSIONS = {

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -297,6 +297,7 @@ class Tenant():
             # Default to 1.0 if the agent did not send a mTLS certificate
             if self.registrar_data.get("mtls_cert", None) is None:
                 self.supported_version = "1.0"
+                logger.warning("API version 1.0 is most likely not supported anymore!")
             else:
                 # Try to connect to the agent to get supported version
                 with RequestsClient(f"{self.agent_ip}:{self.agent_port}", tls_enabled=True, cert=self.agent_cert,

--- a/test/test_api_version.py
+++ b/test/test_api_version.py
@@ -13,8 +13,8 @@ class APIVersion_Test(unittest.TestCase):
         self.assertEqual(api_version.current_version(), "2.0", "Current version is 2.0")
 
     def test_latest_minor_version(self):
-        self.assertEqual(api_version.latest_minor_version("1.0"), "1.0", "Latest version of 1.0 is 1.0")
-        self.assertEqual(api_version.latest_minor_version("1"), "1.0", "Latest version of 1 is 1.0")
+        self.assertEqual(api_version.latest_minor_version("2.0"), "2.0", "Latest version of 2.0 is 2.0")
+        self.assertEqual(api_version.latest_minor_version("2"), "2.0", "Latest version of 2 is 2.0")
         self.assertEqual(api_version.latest_minor_version("20"), "0", "No latest version of v20")
 
     def test_normalize_version(self):
@@ -33,8 +33,8 @@ class APIVersion_Test(unittest.TestCase):
     def test_is_supported_version(self):
         self.assertTrue(api_version.is_supported_version("2.0"), "2.0 is a supported version")
         self.assertTrue(api_version.is_supported_version("v2.0"), "v2.0 is a supported version")
-        self.assertTrue(api_version.is_supported_version("1.0"), "1.0 is a supported version")
-        self.assertTrue(api_version.is_supported_version("v1.0"), "v1.0 is a supported version")
+        self.assertFalse(api_version.is_supported_version("1.0"), "1.0 is not a supported version")
+        self.assertFalse(api_version.is_supported_version("v1.0"), "v1.0 is not a supported version")
         self.assertFalse(api_version.is_supported_version("0"), "0 is not a supported version")
         self.assertFalse(api_version.is_supported_version("v0"), "v0 is not a supported version")
         self.assertFalse(api_version.is_supported_version("10.0"), "10.0 is not a supported version")

--- a/test/test_web_util.py
+++ b/test/test_web_util.py
@@ -13,9 +13,9 @@ class TestConfig(unittest.TestCase):
     @patch("keylime.web_util.config")
     def test_get_restful_params(self, _):
         """Tests if the parsing of the parameters works"""
-        version_url = "/v1.0/quotes/integrity?nonce=1234567890ABCDEFHIJ&mask=0x408000&vmask=0x808000&partial=0"
+        version_url = "/v2.0/quotes/integrity?nonce=1234567890ABCDEFHIJ&mask=0x408000&vmask=0x808000&partial=0"
         version_params = {
-            "api_version": "1.0",
+            "api_version": "2.0",
             "quotes": "integrity",
             "nonce": "1234567890ABCDEFHIJ",
             "mask": "0x408000",


### PR DESCRIPTION
This drops support for version 1.0 at the verifier and outputs a warning if the tenant wants to add an agent that uses 1.0.