### PR TITLE
Fix LONGTEXT column type migration for MySQL

### DIFF
--- a/keylime/migrations/versions/eeb702f77d7d_allowlist_rename.py
+++ b/keylime/migrations/versions/eeb702f77d7d_allowlist_rename.py
@@ -35,10 +35,10 @@ def downgrade_registrar():
 def upgrade_cloud_verifier():
     # need to use batch_alter_table since SQLite <3.25.0 doesn't do RENAME COLUMN
     with op.batch_alter_table('verifiermain') as batch_op:
-        batch_op.alter_column('ima_whitelist', new_column_name='allowlist', existing_type=sa.Text(), existing_nullable=True)
+        batch_op.alter_column('ima_whitelist', new_column_name='allowlist', existing_type=sa.Text().with_variant(sa.Text(429400000), "mysql"), existing_nullable=True)
 
 
 def downgrade_cloud_verifier():
     # need to use batch_alter_table since SQLite <3.25.0 doesn't do RENAME COLUMN
     with op.batch_alter_table('verifiermain') as batch_op:
-        batch_op.alter_column('allowlist', new_column_name='ima_whitelist', existing_type=sa.Text(), existing_nullable=True)
+        batch_op.alter_column('allowlist', new_column_name='ima_whitelist', existing_type=sa.Text().with_variant(sa.Text(429400000), "mysql"), existing_nullable=True)


### PR DESCRIPTION
Without this fix LONGTEXT column type is converted to TEXT type
which isn't big enough to store large data like allowlist.

Signed-off-by: Karel Srot <ksrot@redhat.com>