### PR TITLE
Unit tests for TPM manufacturer retrieval in tpm_main

### DIFF
--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -108,7 +108,7 @@ class AbstractTPM(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_tpm_manufacturer(self):
+    def get_tpm_manufacturer(self, output=None):
         pass
 
     @abstractmethod

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -895,18 +895,20 @@ class tpm(tpm_abstract.AbstractTPM):
         logger.error("No Root CA matched EK Certificate")
         return False
 
-    def get_tpm_manufacturer(self):
+    def get_tpm_manufacturer(self, output=None):
         vendorStr = None
-        if self.tools_version == "3.2":
-            retDict = self.__run(["tpm2_getcap", "-c", "properties-fixed"])
-        elif self.tools_version in ["4.0", "4.2"]:
-            retDict = self.__run(["tpm2_getcap", "properties-fixed"])
-        output = retDict['retout']
-        reterr = retDict['reterr']
-        code = retDict['code']
+        if not output:
+            if self.tools_version == "3.2":
+                retDict = self.__run(["tpm2_getcap", "-c", "properties-fixed"])
+            elif self.tools_version in ["4.0", "4.2"]:
+                retDict = self.__run(["tpm2_getcap", "properties-fixed"])
+            output = retDict['retout']
+            reterr = retDict['reterr']
+            code = retDict['code']
 
-        if code != tpm_abstract.AbstractTPM.EXIT_SUCESS:
-            raise Exception("get_tpm_manufacturer failed with code " + str(code) + ": " + str(reterr))
+            if code != tpm_abstract.AbstractTPM.EXIT_SUCESS:
+                raise Exception("get_tpm_manufacturer failed with code " + str(code) + ": " + str(reterr))
+
 
         # Clean up TPM manufacturer information (strip control characters)
         # These strings are supposed to be printable ASCII characters, but

--- a/test/test_tpm.py
+++ b/test/test_tpm.py
@@ -13,43 +13,68 @@ tpm_manufacturer_tests = [
     #Infineon Optiga SLB9665'
     {
         'challenge': [
-            b'TPM2_PT_MANUFACTURER:\n', b'  raw: 0x49465800\n', b'  value: "IFX"\n',
-            b'TPM2_PT_VENDOR_STRING_1:\n', b'  raw: 0x534C4239\n', b'  value: "SLB9"\n',
-            b'TPM2_PT_VENDOR_STRING_2:\n', b'  raw: 0x36363500\n', b'  value: "665"\n',
-            b'TPM2_PT_VENDOR_STRING_3:\n', b'  raw: 0x0\n', b'  value: ""\n',
-            b'TPM2_PT_VENDOR_STRING_4:\n', b'  raw: 0x0\n', b'  value: ""\n',
-            b'TPM2_PT_VENDOR_TPM_TYPE:\n', b'  raw: 0x0\n',
+            b'TPM2_PT_MANUFACTURER:\n',
+            b'  aw: 0x49465800\n',
+            b'  value: "IFX"\n',
+            b'TPM2_PT_VENDOR_STRING_1:\n',
+            b'  raw: 0x534C4239\n',
+            b'  value: "SLB9"\n',
+            b'TPM2_PT_VENDOR_STRING_2:\n',
+            b'  raw: 0x36363500\n',
+            b'  value: "665"\n',
+            b'TPM2_PT_VENDOR_STRING_3:\n',
+            b'  raw: 0x0\n',
+            b'  value: ""\n',
+            b'TPM2_PT_VENDOR_STRING_4:\n',
+            b'  raw: 0x0\n',
+            b'  value: ""\n',
+            b'TPM2_PT_VENDOR_TPM_TYPE:\n',
+            b'  raw: 0x0\n',
         ],
         'response': 'SLB9'
     },
     
     # Nuvoton device with a wrinkle: un-escaped double quotes in the manufacturer string
-#    'Nuvoton 75x unfixed': {
-#        'challenge': [
-#            b'TPM2_PT_MANUFACTURER:\n',    b'  raw: 0x4E544300\n', b'  value: "NTC"\n',
-#            b'TPM2_PT_VENDOR_STRING_1:\n', b'  raw: 0x4E504354\n', b'  value: "NPCT"\n',
-#            b'TPM2_PT_VENDOR_STRING_3:\n', b'  raw: 0x22212134\n', b'  value: ""!!4"\n'
-#        ],
-#        'response': 'NPCT'
-#    },
+    #    'Nuvoton 75x unfixed': {
+    #        'challenge': [
+    #            b'TPM2_PT_MANUFACTURER:\n',    b'  raw: 0x4E544300\n', b'  value: "NTC"\n',
+    #            b'TPM2_PT_VENDOR_STRING_1:\n', b'  raw: 0x4E504354\n', b'  value: "NPCT"\n',
+    #            b'TPM2_PT_VENDOR_STRING_3:\n', b'  raw: 0x22212134\n', b'  value: ""!!4"\n'
+    #        ],
+    #        'response': 'NPCT'
+    #    },
 
     # Nuvoton 75x, assuming tpm2-tools has escaped the quote side vendor string 3'
     {
         'challenge': [
-            b'TPM2_PT_MANUFACTURER:\n',    b'  raw: 0x4E544300\n', b'  value: "NTC"\n',
-            b'TPM2_PT_VENDOR_STRING_1:\n', b'  raw: 0x4E504354\n', b'  value: "NPCT"\n',
-            b'TPM2_PT_VENDOR_STRING_3:\n', b'  raw: 0x22212134\n', b'  value: "\\"!!4"\n'
+            b'TPM2_PT_MANUFACTURER:\n',
+            b'  raw: 0x4E544300\n',
+            b'  value: "NTC"\n',
+            b'TPM2_PT_VENDOR_STRING_1:\n',
+            b'  raw: 0x4E504354\n',
+            b'  value: "NPCT"\n',
+            b'TPM2_PT_VENDOR_STRING_3:\n',
+            b'  raw: 0x22212134\n',
+            b'  value: "\\"!!4"\n'
         ],
-    'response': 'NPCT'
+        'response': 'NPCT'
     },
     
     # Standard software TPM
     {
         'challenge': [
-            b'TPM2_PT_VENDOR_STRING_1:\n',  b'  raw: 0x53572020\n',  b'  value: "SW"\n',
-            b'TPM2_PT_VENDOR_STRING_2:\n',  b'  raw: 0x2054504D\n',  b'  value: "TPM"\n',
-            b'TPM2_PT_VENDOR_STRING_3:\n',  b'  raw: 0x0\n',         b'  value: ""\n',
-            b'TPM2_PT_VENDOR_STRING_4:\n',  b'  raw: 0x0\n',         b'  value: ""\n'
+            b'TPM2_PT_VENDOR_STRING_1:\n',
+            b'  raw: 0x53572020\n',
+            b'  value: "SW"\n',
+            b'TPM2_PT_VENDOR_STRING_2:\n',
+            b'  raw: 0x2054504D\n',
+            b'  value: "TPM"\n',
+            b'TPM2_PT_VENDOR_STRING_3:\n',
+            b'  raw: 0x0\n',
+            b'  value: ""\n',
+            b'TPM2_PT_VENDOR_STRING_4:\n',
+            b'  raw: 0x0\n',
+            b'  value: ""\n'
         ],
         'response': 'SW'
     }

--- a/test/test_tpm.py
+++ b/test/test_tpm.py
@@ -1,0 +1,76 @@
+import importlib
+import os
+import unittest
+
+import keylime
+from keylime.tpm import tpm_main
+
+# ############################################################
+# list of input challenges for get_tpm_manufacturer function
+# ############################################################
+tpm_manufacturer_tests = [
+
+    #Infineon Optiga SLB9665'
+    {
+        'challenge': [
+            b'TPM2_PT_MANUFACTURER:\n', b'  raw: 0x49465800\n', b'  value: "IFX"\n',
+            b'TPM2_PT_VENDOR_STRING_1:\n', b'  raw: 0x534C4239\n', b'  value: "SLB9"\n',
+            b'TPM2_PT_VENDOR_STRING_2:\n', b'  raw: 0x36363500\n', b'  value: "665"\n',
+            b'TPM2_PT_VENDOR_STRING_3:\n', b'  raw: 0x0\n', b'  value: ""\n',
+            b'TPM2_PT_VENDOR_STRING_4:\n', b'  raw: 0x0\n', b'  value: ""\n',
+            b'TPM2_PT_VENDOR_TPM_TYPE:\n', b'  raw: 0x0\n',
+        ],
+        'response': 'SLB9'
+    },
+    
+    # Nuvoton device with a wrinkle: un-escaped double quotes in the manufacturer string
+#    'Nuvoton 75x unfixed': {
+#        'challenge': [
+#            b'TPM2_PT_MANUFACTURER:\n',    b'  raw: 0x4E544300\n', b'  value: "NTC"\n',
+#            b'TPM2_PT_VENDOR_STRING_1:\n', b'  raw: 0x4E504354\n', b'  value: "NPCT"\n',
+#            b'TPM2_PT_VENDOR_STRING_3:\n', b'  raw: 0x22212134\n', b'  value: ""!!4"\n'
+#        ],
+#        'response': 'NPCT'
+#    },
+
+    # Nuvoton 75x, assuming tpm2-tools has escaped the quote side vendor string 3'
+    {
+        'challenge': [
+            b'TPM2_PT_MANUFACTURER:\n',    b'  raw: 0x4E544300\n', b'  value: "NTC"\n',
+            b'TPM2_PT_VENDOR_STRING_1:\n', b'  raw: 0x4E504354\n', b'  value: "NPCT"\n',
+            b'TPM2_PT_VENDOR_STRING_3:\n', b'  raw: 0x22212134\n', b'  value: "\\"!!4"\n'
+        ],
+    'response': 'NPCT'
+    },
+    
+    # Standard software TPM
+    {
+        'challenge': [
+            b'TPM2_PT_VENDOR_STRING_1:\n',  b'  raw: 0x53572020\n',  b'  value: "SW"\n',
+            b'TPM2_PT_VENDOR_STRING_2:\n',  b'  raw: 0x2054504D\n',  b'  value: "TPM"\n',
+            b'TPM2_PT_VENDOR_STRING_3:\n',  b'  raw: 0x0\n',         b'  value: ""\n',
+            b'TPM2_PT_VENDOR_STRING_4:\n',  b'  raw: 0x0\n',         b'  value: ""\n'
+        ],
+        'response': 'SW'
+    }
+]
+
+class TestTPM(unittest.TestCase):
+    def setUp(self):
+        self.tpm = keylime.tpm.tpm_main.tpm()
+
+    # basic test:
+    # whatever the underlying TPM is, just ensure get_manufacturer worked.
+    # we cannot predict the output on the test system, so this test merely
+    # ensures that the call to get_tpm_manufacturer succeeds.
+    def test_get_tpm_manufacturer(self):
+        self.tpm.get_tpm_manufacturer()
+
+    # test the challenges in the list `tpm_manufacturer_tests`
+    def test_get_tpm_manufacturer_challenges(self):
+        for test in tpm_manufacturer_tests:
+            response = self.tpm.get_tpm_manufacturer(output=test['challenge'])
+            self.assertEqual(test['response'], response)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is an attempt to add unit tests to tpm_main.py

Since "normal" unit testing assumes that a TPM already exists in the testing infrastructure, the current test substitutes the output of `tpm2_getcap` with challenge strings provided by the test framework. The signature of tpm.get_tpm_manufacturer() is slightly modified to allow the provision of a challenge string instead of asking the TPM device directly.

This PR, if accepted, will form the testing framework for merging PR #848 addressing issue #840 .