### PR TITLE
setup.py and config improvements

### DIFF
--- a/.ci/test_wrapper.sh
+++ b/.ci/test_wrapper.sh
@@ -34,5 +34,13 @@ then
 else
     REPO_DIR="/root/keylime"
 fi
+
+# Move /etc/keylime.conf because there might a old one distributed with the container.
+if [ -f "/etc/keylime.conf" ]
+then
+    echo "Moving /etc/keylime.conf from the container to /etc/keylime.conf.orig"
+    mv /etc/keylime.conf /etc/keylime.conf.orig
+fi
+
 chmod +x $REPO_DIR/test/run_tests.sh
 $REPO_DIR/test/run_tests.sh -s openssl

--- a/keylime/common/retry.py
+++ b/keylime/common/retry.py
@@ -7,7 +7,7 @@ def retry_time(exponential, base, ntries, logger):
     if exponential:
         if base > 1:
             return base**ntries
-        elif logger:
+        if logger:
             logger.warning("Base %f incompatible with exponential backoff", base)
 
     return abs(base)

--- a/keylime/keylime.conf
+++ b/keylime/keylime.conf
@@ -1,0 +1,1 @@
+../keylime.conf

--- a/keylime/keylime_logging.py
+++ b/keylime/keylime_logging.py
@@ -19,9 +19,7 @@ if not config.REQUIRE_ROOT:
 else:
     LOGSTREAM = LOGDIR + '/keylime-stream.log'
 
-for config_file in reversed(config.CONFIG_FILES):
-    if os.path.exists(config_file):
-        logging.config.fileConfig(config_file)
+logging.config.fileConfig(config.get_config())
 
 
 def set_log_func(loglevel, logger):

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ with open('README.md', encoding="utf-8") as fh:
 
 setuptools.setup(
     name='keylime',
+    version='6.3.1',
     description=(
         'TPM-based key bootstrapping and system '
         'integrity measurement system for cloud'),
@@ -36,6 +37,8 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: System :: Hardware',
     ],
     entry_points={
@@ -45,9 +48,6 @@ setuptools.setup(
             'keylime_tenant=keylime.cmd.tenant:main',
             'keylime_userdata_encrypt=keylime.cmd.user_data_encrypt:main',
             'keylime_registrar=keylime.cmd.registrar:main',
-            'keylime_provider_registrar=keylime.cmd.provider_registrar:main',
-            'keylime_provider_platform_init=keylime.cmd.provider_platform_init:main',  # noqa
-            'keylime_provider_vtpm_add=keylime.cmd.provider_vtpm_add:main',
             'keylime_ca=keylime.cmd.ca:main',
             'keylime_ima_emulator=keylime.cmd.ima_emulator_adapter:main',
             'keylime_webapp=keylime.cmd.webapp:main',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,9 @@
 SPDX-License-Identifier: Apache-2.0
 Copyright 2017 Massachusetts Institute of Technology.
 '''
+
 import setuptools
+
 
 with open('README.md', encoding="utf-8") as fh:
     long_description = fh.read()
@@ -52,6 +54,5 @@ setuptools.setup(
             'keylime_migrations_apply=keylime.cmd.migrations_apply:main',
         ],
     },
-    data_files=[('/etc', ['keylime.conf'])],
-    package_data={'keylime': ['migrations/alembic.ini']}
+    package_data={'keylime': ['migrations/alembic.ini', "keylime.conf"]}
 )


### PR DESCRIPTION
The keylime.conf is copied into the package path instead of trying to install it globally into /etc which fails if the user is non root.
We will fallback on this configuration the other potential ones do not exist.
This makes it easier to install Keylime in virtual environments.

Also new Python versions are added and a version for the package is set. 
(I've used 6.4.0 because this will probably the next version.)

Fixes #548