### PR TITLE
Add support for automatic PyPI releases

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,39 @@
+name: pypi-release
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+          .
+
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,57 @@
+[metadata]
+name = keylime
+version = 6.3.1
+description = TPM-based key bootstrapping and system integrity measurement system for cloud
+long_description = file: README.md
+long_description_content_type = text/markdown; charset=UTF-8
+url = https://keylime.dev
+author = Keylime Community
+author_email = keylime@groups.io
+license = Apache-2.0
+license_file = LICENSE
+readme = README.md
+project_urls =
+        Source = https://github.com/keylime/keylime
+        Documentation = https://keylime-docs.readthedocs.io/en/latest/
+
+classifiers =
+        Environment :: Console
+        Intended Audience :: Developers
+        Intended Audience :: Information Technology
+        Intended Audience :: System Administrators
+        License :: OSI Approved :: Apache Software License
+        Operating System :: POSIX :: Linux
+        Programming Language :: Python
+        Programming Language :: Python :: Implementation :: CPython
+        Programming Language :: Python :: 3 :: Only
+        Programming Language :: Python :: 3
+        Programming Language :: Python :: 3.6
+        Programming Language :: Python :: 3.7
+        Programming Language :: Python :: 3.8
+        Programming Language :: Python :: 3.9
+        Programming Language :: Python :: 3.10
+        Topic :: System :: Hardware
+keywords = iot, security, cloud, edge, tpm, ima, attestation, virtualization
+
+[options]
+zip_safe = False
+python_requires = >=3.6
+packages = find:
+
+[options.packages.find]
+exclude = test, test.*
+
+[options.package_data]
+keylime =  migrations/alembic.ini, keylime.conf
+
+[options.entry_points]
+console_scripts =
+        keylime_verifier = keylime.cmd.verifier:main
+        keylime_agent = keylime.cmd.agent:main
+        keylime_tenant = keylime.cmd.tenant:main
+        keylime_userdata_encrypt = keylime.cmd.user_data_encrypt:main
+        keylime_registrar = keylime.cmd.registrar:main
+        keylime_ca = keylime.cmd.ca:main
+        keylime_ima_emulator = keylime.cmd.ima_emulator_adapter:main
+        keylime_webapp = keylime.cmd.webapp:main
+        keylime_migrations_apply = keylime.cmd.migrations_apply:main

--- a/setup.py
+++ b/setup.py
@@ -5,54 +5,5 @@ Copyright 2017 Massachusetts Institute of Technology.
 
 import setuptools
 
-
-with open('README.md', encoding="utf-8") as fh:
-    long_description = fh.read()
-
-
-setuptools.setup(
-    name='keylime',
-    version='6.3.1',
-    description=(
-        'TPM-based key bootstrapping and system '
-        'integrity measurement system for cloud'),
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    author='Keylime Community',
-    author_email='keylime@groups.io',
-    url='https://keylime.dev',
-    python_requires='>=3.6',
-    packages=setuptools.find_packages(exclude=['test*']),
-    classifiers=[
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Information Technology',
-        'Intended Audience :: System Administrators',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Topic :: System :: Hardware',
-    ],
-    entry_points={
-        "console_scripts": [
-            'keylime_verifier=keylime.cmd.verifier:main',
-            'keylime_agent=keylime.cmd.agent:main',
-            'keylime_tenant=keylime.cmd.tenant:main',
-            'keylime_userdata_encrypt=keylime.cmd.user_data_encrypt:main',
-            'keylime_registrar=keylime.cmd.registrar:main',
-            'keylime_ca=keylime.cmd.ca:main',
-            'keylime_ima_emulator=keylime.cmd.ima_emulator_adapter:main',
-            'keylime_webapp=keylime.cmd.webapp:main',
-            'keylime_migrations_apply=keylime.cmd.migrations_apply:main',
-        ],
-    },
-    package_data={'keylime': ['migrations/alembic.ini', "keylime.conf"]}
-)
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
This adds support for automatically pushing releases to PyPI. I've also moved the `setup.py` to `setup.cfg` because we don't require code running during package creation.

@mpeters you'll need to set the secret `PYPI_API_TOKEN` with a PyPI API token, once the name is transferred to us.

Resolves #790 