### PR TITLE
Add iproute tool to Dockerfile

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -36,6 +36,7 @@ git \
 glib2-devel \
 glib2-static \
 gnulib \
+iproute \
 kmod \
 libarchive-devel \
 libselinux-python3 \


### PR DESCRIPTION
Necessary for the `ss` command, to be used in PR https://github.com/keylime/keylime/pull/812.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>