### PR TITLE
agent: allow absolute paths for NK and mTLS certificate and better logging

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -37,9 +37,12 @@ registrar_ip = 127.0.0.1
 registrar_port = 8890
 
 # The name of the RSA key that Keylime should use for protecting shares of U/V.
+# If rsa_keyname is not a absolute path it is relative to /var/lib/keylime/secure.
 rsa_keyname = tci_rsa_key
 
 # The name of the X509 certificate that is used for mTLS. Uses the rsa_keyname as a key.
+# If mtls_cert is not a absolute path it is relative to /var/lib/keylime/secure.
+# This certificate must be self signed.
 mtls_cert = tci_mtls_cert
 
 # The CA that signs the client certificates of the tenant and verifier.

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -399,10 +399,16 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
 
     def __init__(self, server_address, RequestHandlerClass, agent_uuid):
         """Constructor overridden to provide ability to pass configuration arguments to the server"""
+        # Find the locations for the U/V transport and mTLS key and certificate.
+        # They are either relative to secdir (/var/lib/keylime/secure) or absolute paths.
         secdir = secure_mount.mount()
-        keyname = os.path.join(secdir,
-                               config.get('cloud_agent', 'rsa_keyname'))
-        certname = os.path.join(secdir, config.get('cloud_agent', 'mtls_cert'))
+        keyname = config.get('cloud_agent', 'rsa_keyname')
+        if not os.path.isabs(keyname):
+            keyname = os.path.join(secdir, keyname)
+        certname = config.get('cloud_agent', 'mtls_cert')
+        if not os.path.isabs(certname):
+            certname = os.path.join(secdir, certname)
+
         # read or generate the key depending on configuration
         if os.path.isfile(keyname):
             # read in private key

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -412,11 +412,11 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
         # read or generate the key depending on configuration
         if os.path.isfile(keyname):
             # read in private key
-            logger.debug("Using existing key in %s", keyname)
+            logger.info("Using existing key in %s", keyname)
             f = open(keyname, "rb")
             rsa_key = crypto.rsa_import_privkey(f.read())
         else:
-            logger.debug("key not found, generating a new one")
+            logger.info("Key for U/V transport and mTLS certificate not found, generating a new one")
             rsa_key = crypto.rsa_generate(2048)
             with open(keyname, "wb") as f:
                 f.write(crypto.rsa_export_privkey(rsa_key))
@@ -427,11 +427,11 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
             self.rsaprivatekey)
 
         if os.path.isfile(certname):
-            logger.debug("Using existing mTLS cert in %s", certname)
+            logger.info("Using existing mTLS cert in %s", certname)
             with open(certname, "rb") as f:
                 mtls_cert = x509.load_pem_x509_certificate(f.read())
         else:
-            logger.debug("No mTLS certificate found generating a new one")
+            logger.info("No mTLS certificate found, generating a new one")
             with open(certname, "wb") as f:
                 # By default generate a TLS certificate valid for 5 years
                 valid_util = datetime.datetime.utcnow() + datetime.timedelta(days=(360 * 5))


### PR DESCRIPTION
`rsa_keyname` and `mtls_cert` now allow also absolute paths.

The logging level for creation of the keys and mTLS certificate is moved to info.

Related #878 