### PR TITLE
cloud_verifier_tornado: use fork_processes

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -1121,13 +1121,16 @@ def main():
     sockets = tornado.netutil.bind_sockets(
         int(cloudverifier_port), address=cloudverifier_host)
 
+    tornado.process.fork_processes(config.getint(
+        'cloud_verifier', 'multiprocessing_pool_num_workers'))
+
     server = tornado.httpserver.HTTPServer(app, ssl_options=context, max_buffer_size=max_upload_size)
     server.add_sockets(sockets)
 
     signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
 
     try:
-        server.start(config.getint('cloud_verifier', 'multiprocessing_pool_num_workers'))
+        server.start()
         if tornado.process.task_id() == 0:
             # Start the revocation notifier only on one process
             if config.getboolean('cloud_verifier', 'revocation_notifier'):

--- a/keylime/crypto.py
+++ b/keylime/crypto.py
@@ -211,5 +211,5 @@ def generate_selfsigned_cert(name, key, valid_until) -> x509.Certificate:
         .serial_number(x509.random_serial_number())\
         .not_valid_before(datetime.datetime.utcnow())\
         .not_valid_after(valid_until)\
-        .sign(key, hashes.SHA256())
+        .sign(key, hashes.SHA256(), backend=default_backend())
     return cert

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -30,6 +30,7 @@ import subprocess
 import psutil
 
 from cryptography import x509
+from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
 from keylime import config
@@ -423,7 +424,7 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
         if os.path.isfile(certname):
             logger.debug("Using existing mTLS cert in %s", certname)
             with open(certname, "rb") as f:
-                mtls_cert = x509.load_pem_x509_certificate(f.read())
+                mtls_cert = x509.load_pem_x509_certificate(f.read(), backend=default_backend())
         else:
             logger.debug("No mTLS certificate found generating a new one")
             with open(certname, "wb") as f:


### PR DESCRIPTION
If the cloud_verifier/multiprocessing_pool_num_workers is different from
1, the call to the `.start()` process will fails, as previous call to
`.add_stockets()` is already initializing the internal ioloop.

The raised exception will be:

Traceback (most recent call last):
  File "/usr/bin/keylime_verifier", line 11, in <module>
    load_entry_point('keylime==6.3.0', 'console_scripts', 'keylime_verifier')()
  File "/usr/lib/python3.6/site-packages/keylime/cmd/verifier.py", line 21, in main
    cloud_verifier_tornado.main()
  File "/usr/lib/python3.6/site-packages/keylime/cloud_verifier_tornado.py", line 1122, in main
    server.start(config.getint('cloud_verifier', 'multiprocessing_pool_num_workers'))
  File "/usr/lib64/python3.6/site-packages/tornado/tcpserver.py", line 220, in start
    process.fork_processes(num_processes)
  File "/usr/lib64/python3.6/site-packages/tornado/process.py", line 129, in fork_processes
    raise RuntimeError("Cannot run in multiple processes: IOLoop instance "
RuntimeError: Cannot run in multiple processes: IOLoop instance has already been initialized. You cannot call IOLoop.instance() before calling start_processes()

This was introduced in https://github.com/keylime/keylime/commit/50661f8b33f6b7335104cd4c0dfff711705ee96e

This patch revert back to call `.process.fork_processes()` after the
`.bind_sockets()` line, that is happening before the `.start()`, and
drop the optional parameter in the last method call.