### PR TITLE
Add better default repo path for run_local.sh

### DIFF
--- a/.ci/run_local.sh
+++ b/.ci/run_local.sh
@@ -2,8 +2,8 @@
 
 # You can specify the path of the local keylime repository as argument
 # of this script or using the KEYLIME_REPO_PATH environment variable.
-# The default value is /home/${USER}/keylime
-REPO=${KEYLIME_REPO_PATH:-${1:-/home/${USER}/keylime}}
+# The default value is one directory above where this script is located.
+REPO=${KEYLIME_REPO_PATH:-${1:-$(realpath "$(dirname "$(readlink -f "$0")")/../")}}
 
 # keylime images
 tpmimage="quay.io/keylime/keylime-ci"


### PR DESCRIPTION
Previously, using `run_local.sh` required the `KEYLIME_REPO_PATH` env variable to point to the locally checked-out version; otherwise it'd default to `/home/${USER}/keylime`.

This PR changes that default to one directory above where `run_local.sh` is located, which should be the Keylime repo root in nearly all cases. Thus, if the env variable is unset, `run_local.sh` will still work.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>