### PR TITLE
Add config necessary for Python actions in Rust agent

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -110,6 +110,16 @@ revocation_actions=
 # with a working directory of /var/lib/keylime/secure/unzipped.
 payload_script=autorun.sh
 
+# The path to the directory containing the pre-installed revocation action
+# scripts.  Ideally should point to an fixed/immutable location subject to
+# attestation.  The default is /usr/libexec/keylime.
+revocation_actions_dir = /usr/libexec/keylime
+
+# Whether to allow running revocation actions sent as part of the payload.  The
+# default is True and setting as False will limit the revocation actions to the
+# pre-installed ones.
+allow_payload_revocation_actions = True
+
 # Jason @henn made be do it! He wanted a way for Keylime to measure the
 # delivered payload into a pcr of choice.
 # Specify a PCR number to turn it on.


### PR DESCRIPTION
Fixes #887 

This is a direct copy of @ansasaki 's keylime.conf change in the
Rust agent repo in https://github.com/keylime/rust-keylime/pull/321.
We need it here so that when Keylime is installed with ./installer.sh,
these config options are available to the Rust agent - and probably
will be used by the Python agent eventually as part of
https://github.com/keylime/enhancements/blob/master/55_revocation_actions_without_python.md

Signed-off-by: Lily Sturmann <lsturman@redhat.com>
Co-authored-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>