### PR TITLE
Better shutdown of the verifier

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -1058,12 +1058,6 @@ async def activate_agents(verifier_id, verifier_ip, verifier_port, mtls_options)
     except SQLAlchemyError as e:
         logger.error('SQLAlchemy Error: %s', e)
 
-def start_tornado(tornado_server, port):
-    tornado_server.listen(port)
-    print("Starting Torando on port " + str(port))
-    tornado.ioloop.IOLoop.instance().start()
-    print("Tornado finished")
-
 
 def main():
     """Main method of the Cloud Verifier Server.  This method is encapsulated in a function for packaging to allow it to be

--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -13,6 +13,10 @@ discover:
      - /setup/install_upstream_keylime
      - /functional/basic-attestation-on-localhost
      - /functional/keylime_tenant-commands-on-localhost
+     - /functional/tpm_policy-sanity-on-localhost
+     - /functional/db-postgresql-sanity-on-localhost
+     - /functional/db-mariadb-sanity-on-localhost
+     - /functional/db-mysql-sanity-on-localhost
 
 execute:
     how: tmt


### PR DESCRIPTION
device.destroy() seems to block for infinity in some cases, so we kill the process when this happens.

We now first stop the server to not accept new incoming connections and
then wait for all existing connections to be closed.

Instead of forking with tornado.process.fork_processes() we now use
Python's multiprocessing. This allows us to easily attach signal handlers
to the server processes. Note that we now do not restart a process if it
existed unexpectedly.

Fixes #874, #841