### PR TITLE
[minor] Remove last trace of TPM 1.2 (hopefully)

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -433,10 +433,6 @@ ima_excludelist = exclude.txt
 # hashing:    sha512, sha384, sha256 and sha1
 # encryption: ecc and rsa
 # signing:    rsassa, rsapss, ecdsa, ecdaa and ecschnorr
-#
-# Note: the TPM 1.2 standard only supports SHA1 hashing, RSA encryption and
-# RSASSA signing protocols, therefore these are required for agents where a
-# TPM 1.2 is being used.
 accept_tpm_hash_algs = sha512,sha384,sha256,sha1
 accept_tpm_encryption_algs = ecc,rsa
 accept_tpm_signing_algs = ecschnorr,rsassa


### PR DESCRIPTION
A small reference to TPM 1.2 was left in keylime.conf, this removes it.