### PR TITLE
Enable EPEL repo on CentOS Stream in packit.yaml

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -3,6 +3,13 @@ summary: check the changed tests functionality
 prepare:
     how: shell
     script: bash -c 'ln -s $(pwd) /var/tmp/keylime_sources'
+adjust:
+  - when: distro == centos-stream-9
+    prepare+:
+       script: yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  - when: distro == centos-stream-8
+    prepare+:
+       script: yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
 discover:
     how: fmf


### PR DESCRIPTION
To simplify manual test execution on CentOS Stream.
See
  https://github.com/RedHat-SP-Security/keylime-tests/issues/38

Signed-off-by: Karel Srot <ksrot@redhat.com>