### PR TITLE
revocation_notifier: convert the data to str in the notifiers

### DIFF
--- a/keylime/json.py
+++ b/keylime/json.py
@@ -20,16 +20,16 @@ except ModuleNotFoundError:
         pass
 
 
-def __bytes_to_str(data):
+def bytes_to_str(data):
     if isinstance(data, (bytes, bytearray)):
         data = data.decode("utf-8")
     elif isinstance(data, dict):
         for _k, _v in data.items():
-            data[_k] = __bytes_to_str(_v)
+            data[_k] = bytes_to_str(_v)
     elif isinstance(data, tuple(_list_types)):
         _l = list(data)
         for _k, _v in enumerate(_l):
-            _l[_k] = __bytes_to_str(_v)
+            _l[_k] = bytes_to_str(_v)
         data = _l
 
     return data
@@ -41,7 +41,7 @@ def dumps(obj, **kwargs):
     except TypeError:
         # dumps() from the built-it json module does not work with bytes,
         # so let's convert those to str if we get a TypeError exception.
-        ret = json_module.dumps(__bytes_to_str(obj), **kwargs)
+        ret = json_module.dumps(bytes_to_str(obj), **kwargs)
     return ret
 
 

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -80,6 +80,12 @@ def stop_broker():
 
 
 def notify(tosend):
+    # python-requests internally uses either simplejson (preferred) or
+    # the built-in json module, and when it is using the built-in one,
+    # it may encounter difficulties handling bytes instead of strings.
+    # To avoid such issues, let's convert `tosend' to str beforehand.
+    tosend = json.bytes_to_str(tosend)
+
     def worker(tosend):
         context = zmq.Context()
         mysock = context.socket(zmq.PUB)
@@ -111,6 +117,10 @@ def notify_webhook(tosend):
     # Check if a url was specified
     if url == '':
         return
+
+    # Similarly to notify(), let's convert `tosend' to str to prevent
+    # possible issues with json handling by python-requests.
+    tosend = json.bytes_to_str(tosend)
 
     def worker_webhook(tosend, url):
         interval = config.getfloat('cloud_verifier', 'retry_interval')


### PR DESCRIPTION
python-requests will internally use either simplejson (preferred)
or the built-in the json module; when it uses the latter, it may
encounter issues handling bytes instead of strings.

Let's convert the data to str beforand, to avoid this issue.

Resolves: #896 