### PR TITLE
Drop privileges of agent process after startup

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -146,6 +146,13 @@ tpm_signing_alg = rsassa
 # create a new EK upon startup, and neither will it flush the EK upon exit.
 ek_handle = generate
 
+# The user account to switch to to drop privileges when started as root
+# If left empty, the agent will keep running with high privileges.
+# The user and group specified here must allow the user to access the
+# WORK_DIR (typically /var/lib/keylime) and /dev/tpmrm0. Therefore,
+# suggested value for the run_as parameter is keylime:tss.
+run_as =
+
 #=============================================================================
 [cloud_verifier]
 #=============================================================================

--- a/keylime.conf
+++ b/keylime.conf
@@ -151,6 +151,17 @@ ek_handle = generate
 # The user and group specified here must allow the user to access the
 # WORK_DIR (typically /var/lib/keylime) and /dev/tpmrm0. Therefore,
 # suggested value for the run_as parameter is keylime:tss.
+# The following commands should be used to set ownership before running the
+# agent:
+# chown keylime /var/lib/keylime
+#
+# If tpmdata.yml already exists:
+# chown keylime /var/lib/keylime/tpmdata.yml
+#
+# If cv_ca directory exists:
+# chown keylime /var/lib/keylime/cv_ca
+# chown keylime /var/lib/keylime/cv_ca/cacert.crt
+#
 run_as =
 
 #=============================================================================

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -71,7 +71,7 @@ class IMAMeasurementList:
         return best
 
 
-def read_measurement_list(filename, nth_entry):
+def read_measurement_list(ima_log_file, nth_entry):
     """ Read the IMA measurement list starting from a given entry.
         The entry may be of any value 0 <= entry <= entries_in_log where
         entries_in_log + 1 indicates that the client wants to read the next entry
@@ -86,14 +86,13 @@ def read_measurement_list(filename, nth_entry):
     # Try to find the closest entry to the nth_entry
     num_entries, filesize = IMAML.find(nth_entry)
 
-    if not os.path.exists(filename):
+    if not ima_log_file:
         IMAML.reset()
         nth_entry = 0
-        logger.warning("IMA measurement list not available: %s", filename)
+        logger.warning("IMA measurement list not available: %s", config.IMA_ML)
     else:
-        with open(filename, 'r', encoding="utf-8") as f:
-            f.seek(filesize)
-            filedata = f.read()
+        ima_log_file.seek(filesize)
+        filedata = ima_log_file.read()
         # filedata now corresponds to starting list at entry number 'IMAML.num_entries'
         # find n-th entry and determine number of total entries in file now
         offset = 0
@@ -112,7 +111,7 @@ def read_measurement_list(filename, nth_entry):
         # Nothing found? User request beyond next-expected entry.
         # Start over with entry 0. This cannot recurse again.
         if ml is None:
-            return read_measurement_list(filename, 0)
+            return read_measurement_list(ima_log_file, 0)
 
     return ml, nth_entry, num_entries
 

--- a/keylime/ima_test.py
+++ b/keylime/ima_test.py
@@ -16,25 +16,29 @@ class TestIMA(unittest.TestCase):
         tf.write(filedata.encode('utf-8'))
         tf.flush()
 
+        # Open file again to get str on read()
+        ima_log_file = open(tf.name, 'r', encoding="utf-8")
+
         # Request the 2nd entry, which is available
-        ml, nth_entry, num_entries = ima.read_measurement_list(tf.name, 2)
+        ml, nth_entry, num_entries = ima.read_measurement_list(ima_log_file, 2)
         self.assertEqual(num_entries, 3)
         self.assertEqual(nth_entry, 2)
         self.assertTrue(ml.startswith('2-entry'))
 
         # Request the 3rd entry, which is not available yet, thus we get an empty list
-        ml, nth_entry, num_entries = ima.read_measurement_list(tf.name, 3)
+        ml, nth_entry, num_entries = ima.read_measurement_list(ima_log_file, 3)
         self.assertEqual(num_entries, 3)
         self.assertEqual(nth_entry, 3)
         self.assertTrue(ml == '')
 
         # Request the 4th entry, which is beyond the next entry; since this is wrong,
         # we expect the entire list now.
-        ml, nth_entry, num_entries = ima.read_measurement_list(tf.name, 4)
+        ml, nth_entry, num_entries = ima.read_measurement_list(ima_log_file, 4)
         self.assertEqual(num_entries, 3)
         self.assertEqual(nth_entry, 0)
         self.assertTrue(ml.startswith('0-entry'))
 
+        ima_log_file.close()
         tf.close()
 
 if __name__ == '__main__':

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -636,6 +636,9 @@ def main():
             raise RuntimeError('agent_uuid is configured to use dmidecode, '
                                'but it\'s is not found on the system.')
 
+    # initialize the tmpfs partition to store keys if it isn't already available
+    secure_mount.mount()
+
     # Instanitate TPM class
 
     instance_tpm = tpm()
@@ -650,9 +653,6 @@ def main():
     contact_port = os.getenv("KEYLIME_AGENT_CONTACT_PORT", None)
     if contact_port is None and config.has_option('cloud_agent', 'agent_contact_port'):
         contact_port = config.get('cloud_agent', 'agent_contact_port', fallback="invalid")
-
-    # initialize the tmpfs partition to store keys if it isn't already available
-    secure_mount.mount()
 
     # change dir to working dir
     fs_util.ch_dir(config.WORK_DIR)

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -181,7 +181,12 @@ class Handler(BaseHTTPRequestHandler):
                 ima_ml_entry = int(ima_ml_entry)
                 if ima_ml_entry > self.server.next_ima_ml_entry:
                     ima_ml_entry = 0
-                ml, nth_entry, num_entries = ima.read_measurement_list(config.IMA_ML, ima_ml_entry)
+                ima_log_file = None
+                if os.path.exists(config.IMA_ML):
+                    ima_log_file = open(config.IMA_ML, 'r', encoding="utf-8")
+                ml, nth_entry, num_entries = ima.read_measurement_list(ima_log_file, ima_ml_entry)
+                if ima_log_file:
+                    ima_log_file.close()
                 if num_entries > 0:
                     response['ima_measurement_list'] = ml
                     response['ima_measurement_list_entry'] = nth_entry

--- a/keylime/secure_mount.py
+++ b/keylime/secure_mount.py
@@ -4,6 +4,7 @@ Copyright 2017 Massachusetts Institute of Technology.
 '''
 
 import os
+import shutil
 
 from keylime import keylime_logging
 from keylime import cmd_exec
@@ -85,6 +86,12 @@ def mount():
 
 def umount():
     """Umount all the devices mounted by Keylime."""
+
+    # Make sure we leave tmpfs dir empty even if we did not mount it or
+    # if we cannot unmount it. Ignore errors while deleting. The deletion
+    # of the 'secure' directory will result in an error since it's a mount point.
+    shutil.rmtree(mount(), ignore_errors=True)
+
     while _MOUNTED:
         directory = _MOUNTED.pop()
         logger.info("Unmounting %s", directory)

--- a/keylime/user_utils.py
+++ b/keylime/user_utils.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python3
+
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2022 IBM Corporation
+'''
+
+import os
+import grp
+import pwd
+
+from keylime import keylime_logging
+
+# Configure logger
+logger = keylime_logging.init_logging('privileges')
+
+
+def string_to_uidgid(user_and_group):
+    """ Translate the user_and_group string to uid and gid.
+        The userandgroup parameter must be a string of the format '<user>[:[<group>]]'
+        or '[<user>]:gid'
+        User and group can be strings or integers. If no group is given, -1 will be
+        returned for gid.
+        :raises ValueError: if user or group could not be resolved
+    """
+    params = user_and_group.split(':')
+    if len(params) > 2:
+        raise ValueError(f"User and group {user_and_group} are in wrong format. Expected <user>[:[<group>]] or [<user>]:group")
+
+    gid = None
+    if len(params) == 2 and len(params[1]) > 0:
+        if params[1].isnumeric():
+            gid = int(params[1])
+            if gid < 0:
+                raise ValueError(f"User and group {user_and_group} contains an illegal value")
+        else:
+            try:
+                gr = grp.getgrnam(params[1])
+                gid = gr.gr_gid
+            except KeyError as e:
+                raise ValueError(f'Could not resolve group {params[1]}: {e}') from e
+
+    uid = None
+    if len(params[0]) > 0:
+        if params[0].isnumeric():
+            uid = int(params[0])
+            if uid < 0:
+                raise ValueError(f"User and group {user_and_group} contains an illegal value")
+        else:
+            try:
+                passwd = pwd.getpwnam(params[0])
+                uid = passwd.pw_uid
+            except KeyError as e:
+                raise ValueError(f'Could not resolve user {params[0]}: {e}') from e
+
+    if uid is None and gid is None:
+        raise ValueError(f"User and group {user_and_group} are in wrong format. Expected <user>[:[<group>]] or [<user>]:group")
+
+    return uid, gid
+
+
+def change_uidgid(user_and_group):
+    """ Change uid and gid of the current process.
+        The user_and_group parameter must be a string of the format
+        '<user>[:[<group>]]' or [<user>]:<group>. User and group can
+        be strings or integers.
+        :raises ValueError: if user or group could not be resolved
+        :raises RuntimeError: if setting gid or uid did not succeed
+    """
+    uid, gid = string_to_uidgid(user_and_group)
+
+    # First change group and then user
+    if gid is not None:
+        try:
+            os.setgid(gid)
+        except (OSError, PermissionError) as e:
+            raise RuntimeError(f'Could not set gid to {gid}: {e}') from e
+
+    if uid is not None:
+        try:
+            os.setuid(uid)
+        except (OSError, PermissionError) as e:
+            raise RuntimeError(f'Could not set uid to {uid}: {e}') from e
+
+
+def chown(path, user_and_group):
+    """ Change ownership on a given file to the new owner described in
+        user_and_group string.
+        The user_and_group parameter must be a string of the format
+        '<user>[:[<group>]]' or [<user>]:<group>. User and group can
+        be strings or integers.
+        :raises ValueError: if user or group could not be resolved
+    """
+    uid, gid = string_to_uidgid(user_and_group)
+    if uid is None:
+        uid = -1
+    if gid is None:
+        gid = -1
+
+    os.chown(path, uid, gid)

--- a/keylime/user_utils_test.py
+++ b/keylime/user_utils_test.py
@@ -1,0 +1,52 @@
+'''
+SPDX-License-Identifier: Apache-2.0
+Copyright 2022 IBM Corporation
+'''
+
+import unittest
+
+from keylime import user_utils
+
+class TestUserUtils(unittest.TestCase):
+
+    def test_string_to_uidgid(self):
+        uid, gid = user_utils.string_to_uidgid('root')
+        self.assertTrue(isinstance(uid, int))
+        self.assertTrue(gid is None)
+
+        uid, gid = user_utils.string_to_uidgid('root:')
+        self.assertTrue(isinstance(uid, int))
+        self.assertTrue(gid is None)
+
+        uid, gid = user_utils.string_to_uidgid(':root')
+        self.assertTrue(uid is None)
+        self.assertTrue(isinstance(gid, int))
+
+        uid, gid = user_utils.string_to_uidgid('root:root')
+        self.assertTrue(isinstance(uid, int))
+        self.assertTrue(isinstance(gid, int))
+
+        with self.assertRaises(ValueError):
+            uid, gid = user_utils.string_to_uidgid(':')
+
+        uid, gid = user_utils.string_to_uidgid('100')
+        self.assertTrue(uid == 100)
+        self.assertTrue(gid is None)
+
+        uid, gid = user_utils.string_to_uidgid('100:')
+        self.assertTrue(uid == 100)
+        self.assertTrue(gid is None)
+
+        uid, gid = user_utils.string_to_uidgid(':200')
+        self.assertTrue(uid is None)
+        self.assertTrue(gid == 200)
+
+        uid, gid = user_utils.string_to_uidgid('100:200')
+        self.assertTrue(uid == 100)
+        self.assertTrue(gid == 200)
+
+        with self.assertRaises(ValueError):
+            uid, gid = user_utils.string_to_uidgid('-100:200')
+
+        with self.assertRaises(ValueError):
+            uid, gid = user_utils.string_to_uidgid('nobodyever')


### PR DESCRIPTION
This PR modifies the keylime agent in such a way that root-owned files are opened near process start and then the agent process drops privileges by switching to another user specified by the run_as variable in keylime.conf. By default no privileges are dropped since the root user now needs to prepare the filesystem beforehand and give the run_as user access to the WORK_DIR, which is typically /var/lib/keylime.