### PR TITLE
services: add keylime_agent_secure.mount service

### DIFF
--- a/services/keylime_agent_secure.mount
+++ b/services/keylime_agent_secure.mount
@@ -1,0 +1,12 @@
+[Unit]
+Description=Keylime configuration filesystem
+Before=keylime_agent.service
+
+[Mount]
+What=tmpfs
+Where=/var/lib/keylime/secure
+Type=tmpfs
+Options=mode=0700,size=1m,uid=keylime,gid=tss
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add Keylime secure mount for agent from Debian.

Co-authored-by: Utkarsh Gupta <utkarsh@debian.org>
Co-authored-by: Miriam España Acebal <miriam.espana@canonical.com>
Signed-off-by: Alberto Planas <aplanas@suse.com>