### PR TITLE
Enable code coverage measurement for e2e tests in Packit CI

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -1,17 +1,19 @@
-summary: run keylime e2e tests
+/e2e:
 
-prepare:
+  summary: run keylime e2e tests
+
+  prepare:
     how: shell
     script: bash -c 'ln -s $(pwd) /var/tmp/keylime_sources'
-adjust:
-  - when: distro == centos-stream-9
-    prepare+:
+  adjust:
+   - when: distro == centos-stream-9
+     prepare+:
        script: yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-  - when: distro == centos-stream-8
-    prepare+:
+   - when: distro == centos-stream-8
+     prepare+:
        script: yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
-discover:
+  discover:
     how: fmf
     url: https://github.com/RedHat-SP-Security/keylime-tests
     ref: main
@@ -25,5 +27,36 @@ discover:
      - /functional/db-mariadb-sanity-on-localhost
      - /functional/db-mysql-sanity-on-localhost
 
-execute:
+  execute:
+    how: tmt
+
+
+/e2e-patch-coverage:
+
+  summary: measure e2e tests code coverage for changes in pull-request
+
+  prepare:
+    how: shell
+    script: bash -c 'ln -s $(pwd) /var/tmp/keylime_sources'
+  adjust:
+    enabled: false
+    when: distro != fedora-35
+
+  discover:
+    how: fmf
+    url: https://github.com/RedHat-SP-Security/keylime-tests
+    ref: main
+    test:
+     - /setup/configure_tpm_emulator
+     - /setup/install_upstream_keylime
+     - /setup/enable_keylime_coverage
+     - /functional/basic-attestation-on-localhost
+     - /functional/keylime_tenant-commands-on-localhost
+     - /functional/tpm_policy-sanity-on-localhost
+     - /functional/db-postgresql-sanity-on-localhost
+     - /functional/db-mariadb-sanity-on-localhost
+     - /functional/db-mysql-sanity-on-localhost
+     - /setup/generate_coverage_report
+
+  execute:
     how: tmt


### PR DESCRIPTION
This adds a new plan to Packit CI that runs all e2e tests and reports code coverage.