### PR TITLE
Remove tag input from container build workflow

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,11 +9,6 @@ on:
   workflow_dispatch:
     branches:
       - master
-    inputs:
-      tag:
-        type: string
-        description: Tag of release
-        required: true
 
 env:
   REGISTRY: quay.io
@@ -25,8 +20,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v1


### PR DESCRIPTION
Turns out this is already part of the branch selector UI

Signed-off-by: Michael Peters <mpeters@redhat.com>