### PR TITLE
Use lazy string formatting when logging (#535)

### DIFF
--- a/keylime/ca_impl_cfssl.py
+++ b/keylime/ca_impl_cfssl.py
@@ -45,8 +45,8 @@ def post_cfssl(params, data):
                 logger.error(
                     "Quiting after max number of retries to connect to cfssl server")
                 raise e
-            logger.info(
-                "Connection to cfssl refused %d/%d times, trying again in %f seconds..." % (numtries, maxr, retry))
+            logger.info("Connection to cfssl refused %d/%d times, trying again in %f seconds...",
+                        numtries, maxr, retry)
             time.sleep(retry)
             continue
 

--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -130,7 +130,7 @@ def cmd_mkcert(workingdir, name):
             cc.signature_hash_algorithm,
         )
 
-        logger.info(f"Created certificate for name {name} successfully in {workingdir}")
+        logger.info("Created certificate for name %s successfully in %s", name, workingdir)
     except crypto_exceptions.InvalidSignature:
         logger.error("ERROR: Cert does not validate against CA")
     finally:
@@ -194,7 +194,7 @@ def cmd_init(workingdir):
             cac.signature_hash_algorithm,
         )
 
-        logger.info(f"CA certificate created successfully in {workingdir}")
+        logger.info("CA certificate created successfully in %s", workingdir)
     except crypto_exceptions.InvalidSignature:
         logger.error("ERROR: Cert does not self validate")
     finally:
@@ -262,8 +262,8 @@ def cmd_certpkg(workingdir, name, insecure=False):
                 f.writestr('cacrl.der', crl)
                 f.writestr('cacrl.pem', crlpem)
 
-        logger.info("Creating cert package for %s in %s-pkg.zip" %
-                    (name, name))
+        logger.info("Creating cert package for %s in %s-pkg.zip",
+                    name, name)
 
         return pkg, serial, subject
     finally:
@@ -292,7 +292,7 @@ def get_crl_distpoint(cert_path):
 
     except x509.extensions.ExtensionNotFound:
         pass
-    logger.info(f"No CRL distribution points in {cert_path}")
+    logger.info("No CRL distribution points in %s", cert_path)
     return ""
 
 # to check: openssl crl -inform DER -text -noout -in cacrl.der
@@ -377,13 +377,13 @@ def cmd_listen(workingdir, cert_path):
         serveraddr = ('', config.CRL_PORT)
         server = ThreadedCRLServer(serveraddr, CRLHandler)
         if os.path.exists('cacrl.der'):
-            logger.info("Loading existing crl: %s" %
+            logger.info("Loading existing crl: %s",
                         os.path.abspath("cacrl.der"))
             with open('cacrl.der', 'rb') as f:
                 server.setcrl(f.read())
         t = threading.Thread(target=server.serve_forever)
-        logger.info("Hosting CRL on %s:%d" %
-                    (socket.getfqdn(), config.CRL_PORT))
+        logger.info("Hosting CRL on %s:%d",
+                    socket.getfqdn(), config.CRL_PORT)
         t.start()
 
         def check_expiration():
@@ -404,7 +404,7 @@ def cmd_listen(workingdir, cert_path):
                                 in1hour = datetime.datetime.utcnow() + datetime.timedelta(hours=6)
                                 if expire <= in1hour:
                                     logger.info(
-                                        "Certificate to expire soon %s, re-issuing" % expire)
+                                        "Certificate to expire soon %s, re-issuing", expire)
                                     cmd_regencrl(workingdir)
                     # check a little less than every hour
                     time.sleep(3540)
@@ -422,10 +422,10 @@ def cmd_listen(workingdir, cert_path):
             json_meta = json.loads(revocation['meta_data'])
             serial = json_meta['cert_serial']
             if revocation.get('type', None) != 'revocation' or serial is None:
-                logger.error("Unsupported revocation message: %s" % revocation)
+                logger.error("Unsupported revocation message: %s", revocation)
                 return
 
-            logger.info("Revoking certificate: %s" % serial)
+            logger.info("Revoking certificate: %s", serial)
             server.setcrl(cmd_revoke(workingdir, None, serial))
         try:
             while True:
@@ -454,7 +454,7 @@ class ThreadedCRLServer(ThreadingMixIn, HTTPServer):
 
 class CRLHandler(BaseHTTPRequestHandler):
     def do_GET(self):
-        logger.info('GET invoked from ' + str(self.client_address) + ' with uri:' + self.path)
+        logger.info('GET invoked from %s with uri: %s', str(self.client_address), self.path)
 
         if self.server.published_crl is None:
             self.send_response(404)
@@ -505,7 +505,7 @@ def read_private(warn=False):
 
     if warn:
         # file doesn't exist, just invent a salt
-        logger.warning("Private certificate data %s does not exist yet." %
+        logger.warning("Private certificate data %s does not exist yet.",
                        os.path.abspath("private.yml"))
         logger.warning(
             "Keylime will attempt to load private certificate data again when it is needed.")
@@ -528,7 +528,7 @@ def main(argv=sys.argv):
     if args.dir is None:
         if os.getuid() != 0 and config.REQUIRE_ROOT:
             logger.error(
-                "If you don't specify a working directory, this process must be run as root to access %s" % config.WORK_DIR)
+                "If you don't specify a working directory, this process must be run as root to access %s", config.WORK_DIR)
             sys.exit(-1)
         workingdir = config.CA_WORK_DIR
     else:
@@ -563,10 +563,10 @@ def main(argv=sys.argv):
     elif args.command == 'listen':
         if args.name is None:
             args.name = os.path.join(workingdir, 'RevocationNotifier-cert.crt')
-            logger.warning("using default name for revocation cert %s"
-                           % args.name)
+            logger.warning("using default name for revocation cert %s",
+                           args.name)
         cmd_listen(workingdir, args.name)
     else:
-        logger.error("Invalid command: %s" % args.command)
+        logger.error("Invalid command: %s", args.command)
         parser.print_help()
         sys.exit(-1)

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -94,7 +94,7 @@ def process_quote_response(agent, json_response, agentAttestState) -> Failure:
     # Ensure hash_alg is in accept_tpm_hash_alg list
     if not algorithms.is_accepted(hash_alg, agent['accept_tpm_hash_algs'])\
             or not algorithms.Hash.is_recognized(hash_alg):
-        logger.error(f"TPM Quote is using an unaccepted hash algorithm: {hash_alg}")
+        logger.error("TPM Quote is using an unaccepted hash algorithm: %s", hash_alg)
         failure.add_event("invalid_hash_alg",
                           {"message": f"TPM Quote is using an unaccepted hash algorithm: {hash_alg}", "data": hash_alg},
                           False)
@@ -102,7 +102,7 @@ def process_quote_response(agent, json_response, agentAttestState) -> Failure:
 
     # Ensure enc_alg is in accept_tpm_encryption_algs list
     if not algorithms.is_accepted(enc_alg, agent['accept_tpm_encryption_algs']):
-        logger.error(f"TPM Quote is using an unaccepted encryption algorithm: {enc_alg}")
+        logger.error("TPM Quote is using an unaccepted encryption algorithm: %s", enc_alg)
         failure.add_event("invalid_enc_alg",
                           {"message": f"TPM Quote is using an unaccepted encryption algorithm: {enc_alg}", "data": enc_alg},
                           False)
@@ -110,7 +110,7 @@ def process_quote_response(agent, json_response, agentAttestState) -> Failure:
 
     # Ensure sign_alg is in accept_tpm_encryption_algs list
     if not algorithms.is_accepted(sign_alg, agent['accept_tpm_signing_algs']):
-        logger.error(f"TPM Quote is using an unaccepted signing algorithm: {sign_alg}")
+        logger.error("TPM Quote is using an unaccepted signing algorithm: %s", sign_alg)
         failure.add_event("invalid_sign_alg",
                           {"message": f"TPM Quote is using an unaccepted signing algorithm: {sign_alg}", "data": {sign_alg}},
                           False)
@@ -121,8 +121,8 @@ def process_quote_response(agent, json_response, agentAttestState) -> Failure:
     elif ima_measurement_list_entry != agentAttestState.get_next_ima_ml_entry():
         # If we requested a particular entry number then the agent must return either
         # starting at 0 (handled above) or with the requested number.
-        logger.error("Agent did not respond with requested next IMA measurement list entry "
-                     f"{agentAttestState.get_next_ima_ml_entry()} but started at {ima_measurement_list_entry}")
+        logger.error("Agent did not respond with requested next IMA measurement list entry %s but started at %s",
+                     agentAttestState.get_next_ima_ml_entry(), ima_measurement_list_entry)
         failure.add_event("invalid_ima_entry_nb",
                           {"message": "Agent did not respond with requested next IMA measurement list entry",
                            "got": ima_measurement_list_entry, "expected": agentAttestState.get_next_ima_ml_entry()},

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -470,7 +470,7 @@ class AgentsHandler(BaseHandler):
                     if registrar_data is None:
                         web_util.echo_json_response(self, 400,
                                                     f"Data for agent {agent_id} could not be found in registrar!")
-                        logger.warning(f"Data for agent {agent_id} could not be found in registrar!")
+                        logger.warning("Data for agent %s could not be found in registrar!", agent_id)
                         return
 
                     agent_data['mtls_cert'] = registrar_data.get('mtls_cert', None)
@@ -644,7 +644,7 @@ class AllowlistHandler(BaseHandler):
         if allowlist_name is None:
             web_util.echo_json_response(self, 400, "Invalid URL")
             logger.warning(
-                'GET returning 400 response: ' + self.request.path)
+                'GET returning 400 response: %s', self.request.path)
             return
 
         session = get_session()
@@ -655,7 +655,7 @@ class AllowlistHandler(BaseHandler):
             web_util.echo_json_response(self, 404, "Allowlist %s not found" % allowlist_name)
             return
         except SQLAlchemyError as e:
-            logger.error(f'SQLAlchemy Error: {e}')
+            logger.error('SQLAlchemy Error: %s', e)
             web_util.echo_json_response(self, 500, "Failed to get allowlist")
             raise
 
@@ -683,7 +683,7 @@ class AllowlistHandler(BaseHandler):
         if allowlist_name is None:
             web_util.echo_json_response(self, 400, "Invalid URL")
             logger.warning(
-                'DELETE returning 400 response: ' + self.request.path)
+                'DELETE returning 400 response: %s', self.request.path)
             return
 
         session = get_session()
@@ -694,7 +694,7 @@ class AllowlistHandler(BaseHandler):
             web_util.echo_json_response(self, 404, "Allowlist %s not found" % allowlist_name)
             return
         except SQLAlchemyError as e:
-            logger.error(f'SQLAlchemy Error: {e}')
+            logger.error('SQLAlchemy Error: %s', e)
             web_util.echo_json_response(self, 500, "Failed to get allowlist")
             raise
 
@@ -703,7 +703,7 @@ class AllowlistHandler(BaseHandler):
                 name=allowlist_name).delete()
             session.commit()
         except SQLAlchemyError as e:
-            logger.error(f'SQLAlchemy Error: {e}')
+            logger.error('SQLAlchemy Error: %s', e)
             web_util.echo_json_response(self, 500, "Failed to get allowlist")
             raise
 
@@ -713,7 +713,7 @@ class AllowlistHandler(BaseHandler):
         self.set_header('Content-Type', 'application/json')
         self.finish()
         logger.info(
-            'DELETE returning 204 response for allowlist: ' + allowlist_name)
+            'DELETE returning 204 response for allowlist: %s', allowlist_name)
 
     def post(self):
         """Create an allowlist
@@ -766,10 +766,10 @@ class AllowlistHandler(BaseHandler):
                 web_util.echo_json_response(
                     self, 409, "Allowlist with name %s already exists" % allowlist_name)
                 logger.warning(
-                    "Allowlist with name %s already exists" % allowlist_name)
+                    "Allowlist with name %s already exists", allowlist_name)
                 return
         except SQLAlchemyError as e:
-            logger.error(f'SQLAlchemy Error: {e}')
+            logger.error('SQLAlchemy Error: %s', e)
             raise
 
         try:
@@ -777,7 +777,7 @@ class AllowlistHandler(BaseHandler):
             session.add(VerifierAllowlist(**allowlist))
             session.commit()
         except SQLAlchemyError as e:
-            logger.error(f'SQLAlchemy Error: {e}')
+            logger.error('SQLAlchemy Error: %s', e)
             raise
 
         web_util.echo_json_response(self, 201)
@@ -1124,13 +1124,13 @@ def main():
         int(cloudverifier_port), address=cloudverifier_host)
 
     def server_process(task_id):
-        logger.info(f"Starting server of process {task_id}")
+        logger.info("Starting server of process %s", task_id)
         engine.dispose()
         server = tornado.httpserver.HTTPServer(app, ssl_options=context, max_buffer_size=max_upload_size)
         server.add_sockets(sockets)
 
         def server_sig_handler(*_):
-            logger.info(f"Shutting down server {task_id}..")
+            logger.info("Shutting down server %s..", task_id)
             # Stop server to not accept new incoming connections
             server.stop()
 
@@ -1151,7 +1151,7 @@ def main():
             # Reactivate agents
             asyncio.ensure_future(activate_agents(cloudverifier_id, cloudverifier_host, cloudverifier_port, mtls_options))
         tornado.ioloop.IOLoop.current().start()
-        logger.debug(f"Server {task_id} stopped.")
+        logger.debug("Server %s stopped.", task_id)
         sys.exit(0)
 
     processes = []

--- a/keylime/cmd/provider_platform_init.py
+++ b/keylime/cmd/provider_platform_init.py
@@ -85,7 +85,7 @@ def main(argv=sys.argv):
     with open(f"group-{group_num}-{group_uuid}.tpm", 'w', encoding="utf-8") as f:
         yaml.dump(output, f, Dumper=SafeDumper)
 
-    logger.info("Activated VTPM group %d, UUID %s" % (group_num, group_uuid))
+    logger.info("Activated VTPM group %d, UUID %s", group_num, group_uuid)
     if group_num == 0:
         logger.info(
             "WARNING: Group 0 created, repeating activation again to create Group 1")

--- a/keylime/cmd/provider_vtpm_add.py
+++ b/keylime/cmd/provider_vtpm_add.py
@@ -45,7 +45,7 @@ def add_vtpm(inputfile):
     registrar_client.doActivateAgent(
         provider_reg_ip, provider_reg_port, vtpm_uuid, key)
 
-    logger.info("Registered new vTPM with UUID: %s" % (vtpm_uuid))
+    logger.info("Registered new vTPM with UUID: %s", vtpm_uuid)
 
     return vtpm_uuid
 

--- a/keylime/failure.py
+++ b/keylime/failure.py
@@ -108,8 +108,9 @@ class Failure:
             self.recoverable = False
             if event.severity_label != MAX_SEVERITY_LABEL:
                 logger.warning(
-                    f"Irrecoverable Event with id: {event.event_id} has not the highest severity level.\n "
-                    f"Setting it the the highest severity level.")
+                    "Irrecoverable Event with id: %s has not the highest severity level.\n "
+                    "Setting it the the highest severity level.",
+                    event.event_id,)
                 event.severity_label = MAX_SEVERITY_LABEL
 
         if self.highest_severity is None or event.severity_label > self.highest_severity:
@@ -177,7 +178,8 @@ def _eval_severity_config() -> Tuple[List[Callable[[str], Optional[SeverityLabel
             if policy_regex.fullmatch(event_id):
                 policy_label = labels.get(label_str)
                 if policy_label is None:
-                    logger.error(f"Label {label_str} is not a valid label. Defaulting to maximal severity label!")
+                    logger.error("Label %s is not a valid label. Defaulting to maximal severity label!",
+                                 label_str)
                     return label_max
                 return policy_label
             return None
@@ -198,5 +200,6 @@ def _severity_match(event_id: str) -> SeverityLabel:
         match = rule(event_id)
         if match is not None:
             return match
-    logger.warning(f"No rule matched for event_id: {event_id}. Defaulting to max severity label")
+    logger.warning("No rule matched for event_id: %s. Defaulting to max severity label",
+                   event_id)
     return MAX_SEVERITY_LABEL

--- a/keylime/ima.py
+++ b/keylime/ima.py
@@ -126,20 +126,20 @@ def _validate_ima_ng(exclude_regex, allowlist, digest: ima_ast.Digest, path: ima
     failure = Failure(Component.IMA, ["validation", "ima-ng"])
     if allowlist is not None:
         if exclude_regex is not None and exclude_regex.match(path.name):
-            logger.debug("IMA: ignoring excluded path %s" % path)
+            logger.debug("IMA: ignoring excluded path %s", path)
             return failure
 
         accept_list = allowlist[hash_types].get(path.name, None)
         if accept_list is None:
-            logger.warning(f"File not found in allowlist: {path.name}")
+            logger.warning("File not found in allowlist: %s", path.name)
             failure.add_event("not_in_allowlist", f"File not found in allowlist: {path.name}", True)
             return failure
 
         if codecs.encode(digest.hash, 'hex').decode('utf-8') not in accept_list:
-            logger.warning("Hashes for file %s don't match %s not in %s" %
-                           (path.name,
-                            codecs.encode(digest.hash, 'hex').decode('utf-8'),
-                            accept_list))
+            logger.warning("Hashes for file %s don't match %s not in %s",
+                           path.name,
+                           codecs.encode(digest.hash, 'hex').decode('utf-8'),
+                           accept_list)
             failure.add_event(
                 "allowlist_hash",
                 {"message": "Hash not in allowlist found",
@@ -157,16 +157,16 @@ def _validate_ima_sig(exclude_regex, ima_keyrings, allowlist, digest: ima_ast.Di
     if ima_keyrings and signature:
 
         if exclude_regex is not None and exclude_regex.match(path.name):
-            logger.debug(f"IMA: ignoring excluded path {path.name}")
+            logger.debug("IMA: ignoring excluded path %s", path.name)
             return failure
 
         if not ima_keyrings.integrity_digsig_verify(signature.data, digest.hash, digest.algorithm):
-            logger.warning(f"signature for file {path.name} is not valid")
+            logger.warning("signature for file %s is not valid", path.name)
             failure.add_event("invalid_signature", f"signature for file {path.name} is not valid", True)
             return failure
 
         valid_signature = True
-        logger.debug("signature for file %s is good" % path)
+        logger.debug("signature for file %s is good", path)
 
     # If there is also an allowlist verify the file against that but only do this if:
     # - we did not evaluate the signature (valid_siganture = False)
@@ -282,7 +282,7 @@ def _process_measurement_list(agentAttestState, lines, hash_alg, lists=None, m2w
                 # End of list should equal pcr value
                 found_pcr = (running_hash == pcrval_bytes)
                 if found_pcr:
-                    logger.debug('Found match at linenum %s' % (linenum + 1))
+                    logger.debug('Found match at linenum %s', linenum + 1)
                     # We always want to have the very last line for the attestation, so
                     # we keep the previous runninghash, which is not the last one!
                     agentAttestState.update_ima_attestation(int(entry.pcr), running_hash, linenum + 1)
@@ -294,18 +294,18 @@ def _process_measurement_list(agentAttestState, lines, hash_alg, lists=None, m2w
                 m2w.write(f"{hash_value} {path}\n")
         except ima_ast.ParserError:
             failure.add_event("entry", f"Line was not parsable into a valid IMA entry: {line}", True, ["parser"])
-            logger.error(f"Line was not parsable into a valid IMA entry: {line}")
+            logger.error("Line was not parsable into a valid IMA entry: %s", line)
 
     # check PCR value has been found
     if not found_pcr:
-        logger.error(f"IMA measurement list does not match TPM PCR {pcrval}")
+        logger.error("IMA measurement list does not match TPM PCR %s", pcrval)
         failure.add_event("pcr_mismatch", f"IMA measurement list does not match TPM PCR {pcrval}", True)
 
     # Check if any validators failed
     if sum(errors.values()) > 0:
         error_msg = "IMA ERRORS: Some entries couldn't be validated. Number of failures in modes: "
         error_msg += ", ".join([f'{k.__name__ } {v}' for k, v in errors.items()])
-        logger.error(error_msg + ".")
+        logger.error("%s.", error_msg)
 
     return codecs.encode(running_hash, 'hex').decode('utf-8'), failure
 
@@ -496,8 +496,8 @@ def read_excllist(exclude_path=None):
                     continue
                 excl_list.append(line)
 
-        logger.debug("Loaded exclusion list from %s: %s" %
-                     (exclude_path, excl_list))
+        logger.debug("Loaded exclusion list from %s: %s",
+                     exclude_path, excl_list)
 
     return excl_list
 

--- a/keylime/ima_ast.py
+++ b/keylime/ima_ast.py
@@ -46,7 +46,8 @@ class Validator:
     def get_validator(self, class_type) -> Callable:
         validator = self.functions.get(class_type, None)
         if validator is None:
-            logger.warning(f"No validator was implemented for: {class_type} . Using always false validator!")
+            logger.warning("No validator was implemented for: %s. Using always false validator!",
+                           class_type)
             failure = Failure(Component.IMA, ["validation"])
             failure.add_event("no_validator", f"No validator was implemented for: {class_type} . Using always false validator!", True)
             return lambda *_: failure
@@ -354,7 +355,8 @@ class Entry:
     def invalid(self):
         failure = Failure(Component.IMA, ["validation"])
         if self.pcr != str(config.IMA_PCR):
-            logger.warning(f"IMA entry PCR does not match {config.IMA_PCR}. It was: {self.pcr}")
+            logger.warning("IMA entry PCR does not match %s. It was: %s",
+                           config.IMA_PCR, self.pcr)
             failure.add_event("ima_pcr", {"message": "IMA PCR is not the configured one",
                                           "expected": str(config.IMA_PCR), "got": self.pcr}, True)
 

--- a/keylime/ima_file_signatures.py
+++ b/keylime/ima_file_signatures.py
@@ -143,7 +143,7 @@ class ImaKeyring:
             keyidv2 = ImaKeyring._get_keyidv2(pubkey)
         # it's unlikely that two different public keys have the same 32 bit keyidv2
         self.ringv2[keyidv2] = pubkey
-        logger.debug("Added key with keyid: 0x%08x" % keyidv2)
+        logger.debug("Added key with keyid: 0x%08x", keyidv2)
 
     def get_pubkey_by_keyidv2(self, keyidv2):
         """ Get a public key object given its keyidv2 """
@@ -160,7 +160,7 @@ class ImaKeyring:
                 pubbytes = pubkey.public_bytes(encoding=serialization.Encoding.DER,
                                                format=fmt)
             except Exception as ex:
-                logger.error("Could not serialize key: %s" % str(ex))
+                logger.error("Could not serialize key: %s", str(ex))
             lst.append(pubbytes)
 
         obj['pubkeys'] = [base64.b64encode(pubkey).decode('ascii') for pubkey in lst]
@@ -208,7 +208,7 @@ class ImaKeyring:
                 pubkey = serialization.load_der_public_key(der_key, backend=default_be)
                 ima_keyring.add_pubkey(pubkey, keyidv2)
             except Exception as ex:
-                logger.error("Could not load a base64-decoded DER key: %s" % str(ex))
+                logger.error("Could not load a base64-decoded DER key: %s", str(ex))
         return ima_keyring
 
 
@@ -323,12 +323,12 @@ class ImaKeyrings:
 
         hashfunc = HASH_FUNCS.get(hash_algo)
         if not hashfunc:
-            logger.warning("Unsupported hash algo with id '%d'" % hash_algo)
+            logger.warning("Unsupported hash algo with id '%d'", hash_algo)
             return False
 
         if filehash_type != hashfunc().name:
-            logger.warning("Mismatching filehash type %s and ima signature hash used %s" %
-                           (filehash_type, hashfunc().name))
+            logger.warning("Mismatching filehash type %s and ima signature hash used %s",
+                           filehash_type, hashfunc().name)
             return False
 
         # Try all the keyrings until we find one with a key with the given keyidv2
@@ -339,7 +339,7 @@ class ImaKeyrings:
                 break
 
         if not pubkey:
-            logger.warning("No key with id 0x%08x available" % keyidv2)
+            logger.warning("No key with id 0x%08x available", keyidv2)
             return False
 
         try:
@@ -367,7 +367,7 @@ class ImaKeyrings:
         if version == 2:
             return self._asymmetric_verify(signature, filehash, filehash_type)
 
-        logger.warning("Malformed signature: wrong version (%d)" % version)
+        logger.warning("Malformed signature: wrong version (%d)", version)
         return False
 
 

--- a/keylime/migrations/env.py
+++ b/keylime/migrations/env.py
@@ -70,9 +70,9 @@ def run_migrations_offline():
 
     for name in re.split(r",\s*", db_names):
 
-        logger.info("Migrating database %s" % name)
+        logger.info("Migrating database %s", name)
         file_ = "%s.sql" % name
-        logger.info("Writing output to %s" % file_)
+        logger.info("Writing output to %s", file_)
 
         with open(file_, "w", encoding="utf-8") as buffer:
             engine = DBEngineManager().make_engine(name)
@@ -116,7 +116,7 @@ def run_migrations_online():
 
     try:
         for name, rec in engines.items():
-            logger.info("Migrating database %s" % name)
+            logger.info("Migrating database %s", name)
             context.configure(
                 connection=rec["connection"],
                 upgrade_token="%s_upgrades" % name,

--- a/keylime/registrar_client.py
+++ b/keylime/registrar_client.py
@@ -186,7 +186,7 @@ def doActivateAgent(registrar_ip, registrar_port, agent_id, key):
         return True
 
     logger.error(
-        "Error: unexpected http response code from Registrar Server: " + str(response.status_code))
+        "Error: unexpected http response code from Registrar Server: %s", str(response.status_code))
     keylime_logging.log_http_response(logger, logging.ERROR, response_body)
     return False
 

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -273,13 +273,13 @@ class UnprotectedHandler(BaseHTTPRequestHandler, SessionManager):
             initialize_tpm = tpm()
 
             if ekcert is None or ekcert == 'emulator':
-                logger.warning('Agent %s did not submit an ekcert' % agent_id)
+                logger.warning('Agent %s did not submit an ekcert', agent_id)
                 ek_tpm = json_body['ek_tpm']
             else:
                 if 'ek_tpm' in json_body:
                     # This would mean the agent submitted both a non-None ekcert, *and*
                     #  an ek_tpm... We can deal with it by just ignoring the ek_tpm they sent
-                    logger.warning('Overriding ek_tpm for agent %s from ekcert' % agent_id)
+                    logger.warning('Overriding ek_tpm for agent %s from ekcert', agent_id)
                 # If there's an EKCert, we just overwrite their ek_tpm
                 # Note, we don't validate the EKCert here, other than the implicit
                 #  "is it a valid x509 cert" check. So it's still untrusted.
@@ -353,22 +353,25 @@ class UnprotectedHandler(BaseHTTPRequestHandler, SessionManager):
                     # Use parser from the standard library instead of implementing our own
                     ipaddress.ip_address(contact_ip)
                 except ValueError:
-                    logger.warning(f"Contact ip for agent {agent_id} is not a valid ip got: {contact_ip}.")
+                    logger.warning("Contact ip for agent %s is not a valid ip got: %s.", agent_id, contact_ip)
                     contact_ip = None
             if contact_port is not None:
                 try:
                     contact_port = int(contact_port)
                     if contact_port < 1 or contact_port > 65535:
-                        logger.warning(f"Contact port for agent {agent_id} is not a number between 1 and got: {contact_port}.")
+                        logger.warning("Contact port for agent %s is not a number between 1 and got: %s.",
+                                       agent_id, contact_port)
                         contact_port = None
                 except ValueError:
-                    logger.warning(f"Contact port for agent {agent_id} is not a valid number got: {contact_port}.")
+                    logger.warning("Contact port for agent %s is not a valid number got: %s.",
+                                   agent_id, contact_port)
                     contact_port = None
 
             # Check for mTLS cert
             mtls_cert = json_body.get('mtls_cert', None)
             if mtls_cert is None:
-                logger.warning(f"Agent {agent_id} did not sent a mTLS certificate. Most operations will not work!")
+                logger.warning("Agent %s did not send a mTLS certificate. Most operations will not work!",
+                               agent_id)
 
             # Add values to database
             d = {}

--- a/keylime/revocation_actions/update_crl.py
+++ b/keylime/revocation_actions/update_crl.py
@@ -44,11 +44,11 @@ def execute(json_revocation):
 
     updated = False
     for _ in range(10):
-        logger.debug("Getting updated CRL from %s" % dist_path)
+        logger.debug("Getting updated CRL from %s", dist_path)
         response = tornado_requests.request("GET", dist_path, None, None, None)
         if response.status_code != 200:
-            logger.warning("Unable to get updated CRL from %s.  Code %d" %
-                           (dist_path, response.status_code))
+            logger.warning("Unable to get updated CRL from %s.  Code %d",
+                           dist_path, response.status_code)
             time.sleep(1)
             continue
         if response.body == oldcrl:
@@ -57,7 +57,7 @@ def execute(json_revocation):
             continue
 
         # write out the updated CRL
-        logger.debug("Updating CRL in %s/unzipped/cacrl.der" % (secdir))
+        logger.debug("Updating CRL in %s/unzipped/cacrl.der", secdir)
         with open("%s/unzipped/cacrl.der" % (secdir), "wb") as f:
             f.write(response.body)
         ca_util.convert_crl_to_pem(
@@ -66,5 +66,5 @@ def execute(json_revocation):
         break
 
     if not updated:
-        logger.error(
-            "Unable to load new CRL from %s after receiving notice of a revocation" % dist_path)
+        logger.error("Unable to load new CRL from %s after receiving notice of a revocation",
+                     dist_path)

--- a/keylime/secure_mount.py
+++ b/keylime/secure_mount.py
@@ -74,7 +74,7 @@ def mount():
         if not os.path.exists(secdir):
             os.makedirs(secdir, 0o700)
         size = config.get('cloud_agent', 'secure_size')
-        logger.info("mounting secure storage location %s on tmpfs" % secdir)
+        logger.info("mounting secure storage location %s on tmpfs", secdir)
         cmd = ('mount', '-t', 'tmpfs', '-o', 'size=%s,mode=0700' % size,
                'tmpfs', secdir)
         cmd_exec.run(cmd)

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -686,7 +686,7 @@ class Tenant():
                 response['results'][self.agent_uuid]['operational_state'])
             response['results'][self.agent_uuid]['operational_state'] = operational_state
 
-            logger.info("Agent Info:\n%s" % json.dumps(response["results"]))
+            logger.info("Agent Info:\n%s", json.dumps(response["results"]))
 
             return response
 
@@ -764,7 +764,7 @@ class Tenant():
                 response["results"][agent]["operational_state"] = \
                     states.state_to_str(response["results"][agent][
                                             "operational_state"])
-            logger.info("Bulk Agent Info:\n%s" % json.dumps(response["results"]))
+            logger.info("Bulk Agent Info:\n%s", json.dumps(response["results"]))
 
             return response
 
@@ -1353,7 +1353,7 @@ def main(argv=sys.argv):
             response = requests.get(args.allowlist_url, allow_redirects=False)
             if response.status_code == 200:
                 args.allowlist = write_to_namedtempfile(response.content, delete_tmp_files)
-                logger.debug("Allowlist temporarily saved in %s" % args.allowlist)
+                logger.debug("Allowlist temporarily saved in %s", args.allowlist)
             else:
                 raise Exception(f"Downloading allowlist ({args.allowlist_url}) failed with status code {response.status_code}!")
 
@@ -1377,7 +1377,7 @@ def main(argv=sys.argv):
             gpg_key_file = args.ima_sign_verification_key_sig_keys[i]
             gpg.gpg_verify_filesignature(gpg_key_file, key_file, keysig_file, "IMA file signing key")
 
-            logger.info("Signature verification on %s was successful" % key_file)
+            logger.info("Signature verification on %s was successful", key_file)
 
         # verify all the remote keys for which we have a signature URL and key to to verify
         # Append the downloaded key files to args.ima_sign_verification_keys
@@ -1388,7 +1388,7 @@ def main(argv=sys.argv):
             if response.status_code == 200:
                 key_file = write_to_namedtempfile(response.content, delete_tmp_files)
                 args.ima_sign_verification_keys.append(key_file)
-                logger.debug("Key temporarily saved in %s" % key_file)
+                logger.debug("Key temporarily saved in %s", key_file)
             else:
                 raise Exception(f"Downloading key ({key_url}) failed with status code {response.status_code}!")
 
@@ -1400,17 +1400,17 @@ def main(argv=sys.argv):
             if len(args.ima_sign_verification_key_sig_url_keys) == 0:
                 raise UserError("A gpg key is missing for key signature URL '%s'" % keysig_url)
 
-            logger.info("Downloading key signature from %s" % keysig_url)
+            logger.info("Downloading key signature from %s", keysig_url)
             response = requests.get(keysig_url, allow_redirects=False)
             if response.status_code == 200:
                 keysig_file = write_to_namedtempfile(response.content, delete_tmp_files)
-                logger.debug("Key signature temporarily saved in %s" % keysig_file)
+                logger.debug("Key signature temporarily saved in %s", keysig_file)
             else:
                 raise Exception(f"Downloading key signature ({key_url}) failed with status code {response.status_code}!")
 
             gpg_key_file = args.ima_sign_verification_key_sig_url_keys[i]
             gpg.gpg_verify_filesignature(gpg_key_file, key_file, keysig_file, "IMA file signing key")
-            logger.info("Signature verification on %s was successful" % key_url)
+            logger.info("Signature verification on %s was successful", key_url)
 
     if args.command == 'add':
         mytenant.init_add(vars(args))

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -97,7 +97,8 @@ def _stub_command(fprt, lock, cmd, outputpaths):
             else:
                 raise Exception("Command %s is using multiple files unexpectedly!" % fprt)
 
-        logger.debug("TPM call '%s' was stubbed out, with a simulated delay of %f sec" % (fprt, thisTiming))
+        logger.debug("TPM call '%s' was stubbed out, with a simulated delay of %f sec",
+                     fprt, thisTiming)
         time.sleep(thisTiming)
 
         # Package for return
@@ -268,16 +269,16 @@ class tpm(tpm_abstract.AbstractTPM):
         self.tools_version = version_str.split("-")
 
         if StrictVersion(self.tools_version[0]) >= StrictVersion("4.2"):
-            logger.info("TPM2-TOOLS Version: %s" % self.tools_version[0])
+            logger.info("TPM2-TOOLS Version: %s", self.tools_version[0])
             self.tools_version = "4.2"
         elif StrictVersion(self.tools_version[0]) >= StrictVersion("4.0.0"):
-            logger.info("TPM2-TOOLS Version: %s" % self.tools_version[0])
+            logger.info("TPM2-TOOLS Version: %s", self.tools_version[0])
             self.tools_version = "4.0"
         elif StrictVersion(self.tools_version[0]) >= StrictVersion("3.2.0"):
-            logger.info("TPM2-TOOLS Version: %s" % self.tools_version[0])
+            logger.info("TPM2-TOOLS Version: %s", self.tools_version[0])
             self.tools_version = "3.2"
         else:
-            logger.error("TPM2-TOOLS Version %s is not supported." % self.tools_version[0])
+            logger.error("TPM2-TOOLS Version %s is not supported.", self.tools_version[0])
             sys.exit()
 
     def __get_tpm_algorithms(self):
@@ -399,7 +400,8 @@ class tpm(tpm_abstract.AbstractTPM):
                 interval = config.getfloat('cloud_agent', 'retry_interval')
                 exponential_backoff = config.getboolean('cloud_agent', 'exponential_backoff')
                 next_retry = retry.retry_time(exponential_backoff, interval, numtries, logger)
-                logger.info("Failed to get quote %d/%d times, trying again in %f seconds..." % (numtries, maxr, next_retry))
+                logger.info("Failed to get quote %d/%d times, trying again in %f seconds...",
+                            numtries, maxr, next_retry)
                 time.sleep(next_retry)
                 continue
 
@@ -433,7 +435,7 @@ class tpm(tpm_abstract.AbstractTPM):
 
         # clear out old handle before starting again (give idempotence)
         if current_handle is not None and owner_pw is not None:
-            logger.info("Flushing old ek handle: %s" % hex(current_handle))
+            logger.info("Flushing old ek handle: %s", hex(current_handle))
             if self.tools_version == "3.2":
                 retDict = self.__run(["tpm2_getcap", "-c", "handles-persistent"],
                                      raiseOnError=False)
@@ -462,7 +464,8 @@ class tpm(tpm_abstract.AbstractTPM):
                 code = retDict['code']
 
                 if code != tpm_abstract.AbstractTPM.EXIT_SUCESS:
-                    logger.info("Failed to flush old ek handle: %s.  Code %s" % (hex(current_handle), str(code) + ": " + str(reterr)))
+                    logger.info("Failed to flush old ek handle: %s.  Code %s: %s",
+                                hex(current_handle), str(code), str(reterr))
 
                 self._set_tpm_metadata('ek_handle', None)
                 self._set_tpm_metadata('ek_tpm', None)
@@ -510,7 +513,7 @@ class tpm(tpm_abstract.AbstractTPM):
 
     def __use_ek(self, ek_handle, config_pw):
         ek_handle = int(ek_handle, 16)
-        logger.info("Using an already created ek with handle: %s" % hex(ek_handle))
+        logger.info("Using an already created ek with handle: %s", hex(ek_handle))
 
         self._set_tpm_metadata('owner_pw', config_pw)
 
@@ -575,7 +578,7 @@ class tpm(tpm_abstract.AbstractTPM):
                 raise Exception("Owner password unknown, TPM reset required. Code %s" + str(code) + ": " + str(reterr))
 
         self._set_tpm_metadata('owner_pw', owner_pw)
-        logger.info("TPM Owner password confirmed: %s" % owner_pw)
+        logger.info("TPM Owner password confirmed: %s", owner_pw)
 
     def __get_pub_ek(self):  # assumes that owner_pw is correct at this point
         handle = self.get_tpm_metadata('ek_handle')
@@ -613,11 +616,11 @@ class tpm(tpm_abstract.AbstractTPM):
         if self.get_tpm_metadata('aik_handle') is not None:
             aik_handle = self.get_tpm_metadata('aik_handle')
             if self.tools_version == "3.2":
-                logger.info("Flushing old ak handle: %s" % hex(aik_handle))
+                logger.info("Flushing old ak handle: %s", hex(aik_handle))
                 retDict = self.__run(["tpm2_getcap", "-c", "handles-persistent"],
                                      raiseOnError=False)
             elif self.tools_version in ["4.0", "4.2"]:
-                logger.info("Flushing old ak handle: %s" % aik_handle)
+                logger.info("Flushing old ak handle: %s", aik_handle)
                 retDict = self.__run(["tpm2_getcap", "handles-persistent"],
                                      raiseOnError=False)
             output = config.convert(retDict['retout'])
@@ -653,9 +656,11 @@ class tpm(tpm_abstract.AbstractTPM):
 
                 if code != tpm_abstract.AbstractTPM.EXIT_SUCESS:
                     if self.tools_version == "3.2":
-                        logger.info("Failed to flush old ak handle: %s.  Code %s" % (hex(aik_handle), str(code) + ": " + str(reterr)))
+                        logger.info("Failed to flush old ak handle: %s.  Code %s: %s",
+                                    hex(aik_handle), str(code), str(reterr))
                     elif self.tools_version in ["4.0", "4.2"]:
-                        logger.info("Failed to flush old ak handle: %s.  Code %s" % (aik_handle, str(code) + ": " + str(reterr)))
+                        logger.info("Failed to flush old ak handle: %s.  Code %s: %s",
+                                    aik_handle, str(code), str(reterr))
 
                 self._set_tpm_metadata('aik_pw', None)
                 self._set_tpm_metadata('aik_tpm', None)
@@ -736,7 +741,8 @@ class tpm(tpm_abstract.AbstractTPM):
         code = retDict['code']
 
         if code != tpm_abstract.AbstractTPM.EXIT_SUCESS:
-            logger.debug("tpm2_getcap failed with code " + str(code) + ": " + str(errout))
+            logger.debug("tpm2_getcap failed with code %s: %s",
+                         str(code), str(errout))
 
         if self.tools_version == "3.2":
             # output, human-readable -> json
@@ -751,7 +757,7 @@ class tpm(tpm_abstract.AbstractTPM):
             jsonout = {}
         for key in jsonout:
             if str(hex(key)) != self.defaults['ek_handle']:
-                logger.debug("Flushing key handle %s" % hex(key))
+                logger.debug("Flushing key handle %s", hex(key))
                 if self.tools_version == "3.2":
                     self.__run(["tpm2_evictcontrol", "-A", "o", "-H", hex(key), "-P", owner_pw],
                                raiseOnError=False)
@@ -794,7 +800,7 @@ class tpm(tpm_abstract.AbstractTPM):
                        "-s", challengeFile.name, "-n", aik_name, "-o", blobpath]
             self.__run(command, lock=False)
 
-            logger.info("Encrypting AIK for UUID %s" % uuid)
+            logger.info("Encrypting AIK for UUID %s", uuid)
 
             # read in the blob
             f = open(blobpath, "rb")
@@ -805,7 +811,7 @@ class tpm(tpm_abstract.AbstractTPM):
             key = base64.b64encode(challenge).decode("utf-8")
 
         except Exception as e:
-            logger.error("Error encrypting AIK: " + str(e))
+            logger.error("Error encrypting AIK: %s", str(e))
             logger.exception(e)
             raise
         finally:
@@ -867,7 +873,7 @@ class tpm(tpm_abstract.AbstractTPM):
             key = base64.b64encode(fileout)
 
         except Exception as e:
-            logger.error("Error decrypting AIK: " + str(e))
+            logger.error("Error decrypting AIK: %s", str(e))
             logger.exception(e)
             return None
         finally:
@@ -915,7 +921,7 @@ class tpm(tpm_abstract.AbstractTPM):
                 except crypto_exceptions.InvalidSignature:
                     continue
 
-                logger.debug("EK cert matched cert: %s" % cert)
+                logger.debug("EK cert matched cert: %s", cert)
                 return True
         except Exception as e:
             # Log the exception so we don't lose the raw message
@@ -1133,7 +1139,7 @@ class tpm(tpm_abstract.AbstractTPM):
             reterr = retDict['reterr']
             code = retDict['code']
         except Exception as e:
-            logger.error("Error verifying quote: " + str(e))
+            logger.error("Error verifying quote: %s", str(e))
             logger.exception(e)
             return None, False
         finally:
@@ -1145,7 +1151,7 @@ class tpm(tpm_abstract.AbstractTPM):
                     os.remove(fi.name)
 
         if len(retout) < 1 or code != tpm_abstract.AbstractTPM.EXIT_SUCESS:
-            logger.error("Failed to validate signature, output: %s" % reterr)
+            logger.error("Failed to validate signature, output: %s", reterr)
             return None, False
 
         return retout, True
@@ -1231,7 +1237,7 @@ class tpm(tpm_abstract.AbstractTPM):
                 rand = retDict['fileouts'][randpath.name]
             except Exception as e:
                 if not self.tpmrand_warned:
-                    logger.warning("TPM randomness not available: %s" % e)
+                    logger.warning("TPM randomness not available: %s", e)
                     self.tpmrand_warned = True
                 return None
         return rand
@@ -1324,7 +1330,7 @@ class tpm(tpm_abstract.AbstractTPM):
             raise Exception("nv_readvalue failed with code " + str(code) + ": " + str(errout))
 
         if len(output) != config.BOOTSTRAP_KEY_SIZE:
-            logger.debug("Invalid key length from NVRAM: %d" % (len(output)))
+            logger.debug("Invalid key length from NVRAM: %d", len(output))
             return None
         return output
 
@@ -1397,7 +1403,8 @@ class tpm(tpm_abstract.AbstractTPM):
         try:
             from keylime import tpm_bootlog_enrich
         except Exception as e:
-            logger.error("Could not load tpm_bootlog_enrich (which depends on %s): %s" % (config.LIBEFIVAR,str(e)))
+            logger.error("Could not load tpm_bootlog_enrich (which depends on %s): %s",
+                         config.LIBEFIVAR, str(e))
             return None
         #pylint: enable=import-outside-toplevel
         tpm_bootlog_enrich.enrich(log_parsed_data)

--- a/pylintrc
+++ b/pylintrc
@@ -6,3 +6,6 @@ disable=W1509,C0103,C0115,C0116,C0201,C0209,C0301,C0302,C0111,W0102,W0511,W0602,
 
 [TYPECHECK]
 ignored-modules=zmq,alembic.op,alembic.context,M2Crypto.m2,Cryptodome,pylab,matplotlib,numpy,cryptography.hazmat.primitives.asymmetric.rsa
+
+[LOGGING]
+enable=logging


### PR DESCRIPTION
Avoid using formatted message as the format string for logging and use
lazy string formatting instead.  This includes avoiding using f-strings
for logging and prefer the recommended %-string formatting.

The changes include enabling the logging check in pylint to detect
non-recommended strings formatting usage.

Fixes: #535 