### PR TITLE
Fix for database_url parameter with sqlite

### DIFF
--- a/keylime/db/keylime_db.py
+++ b/keylime/db/keylime_db.py
@@ -39,8 +39,9 @@ class DBEngineManager:
         url = config.get(service, 'database_url')
         if url:
             logger.info('database_url is set, using it to establish database connection')
-            engine_args['pool_size'] = int(p_sz)
-            engine_args['max_overflow'] = int(m_ovfl)
+            if not url.count('sqlite:') :
+                engine_args['pool_size'] = int(p_sz)
+                engine_args['max_overflow'] = int(m_ovfl)
 
         else :
             logger.info('database_url is not set, using multi-parameter database configuration options')


### PR DESCRIPTION
After a very contentious PR review, it has been established that
`database_url`, normally set to empty, should always takes precedence
over the other `database_*` parameters. However, due to the use of the
`database_pool_sz_ovfl` by sqlalchemy (default `5,10`), one can end up
in a situation where setting
`database_url=sqlite:////var/lib/keylime/cv_data.sqlite` results in the
following failure:

``` TypeError: Invalid argument(s) 'pool_size','max_overflow' sent to
create_engine(), using configuration
SQLiteDialect_pysqlite/NullPool/Engine.  Please check that the keyword
arguments are appropriate for this combination of components.  ```

This happens because the paramaters `pool_size` and `max_overflow`,
automatically added to the sqlalchemy engine object prior to its
creation, are not supported in case of sqlite. This minimalistic fix
solves this problems.