### PR TITLE
setup: add static assets for webapp

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ packages = find:
 exclude = test, test.*
 
 [options.package_data]
-keylime =  migrations/alembic.ini, keylime.conf
+keylime =  migrations/alembic.ini, keylime.conf, static/**/*
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
We now include the static assets folder in the Python package.

Fixes #519