### PR TITLE
Registrar Client and Tenant validate CA certificates

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -226,7 +226,7 @@ registrar_tls_dir = CV
 
 # The following three options set the filenames where the CA certificate,
 # client certificate, and client private key file are, relative to the 'tls_dir'.
-# If 'tls_dir = default', then default values will be used for 'ca_cert = cacert.pem',
+# If 'tls_dir = default', then default values will be used for 'ca_cert = cacert.crt',
 # 'my_cert = client-cert.crt', and 'private_key = client-private.pem'.
 registrar_ca_cert = default
 registrar_my_cert = default
@@ -369,7 +369,7 @@ tls_dir = default
 
 # The following three options set the filenames where the CA certificate,
 # client certificate, and client private key file are, relative to the 'tls_dir'.
-# If 'tls_dir = default', then default values will be used for 'ca_cert = cacert.pem',
+# If 'tls_dir = default', then default values will be used for 'ca_cert = cacert.crt',
 # 'my_cert = client-cert.crt', and 'private_key = client-private.pem'.
 ca_cert = default
 my_cert = default
@@ -403,7 +403,7 @@ registrar_tls_dir = CV
 
 # The following three options set the filenames where the registrar CA certificate,
 # client certificate, and client private key file are, relative to the 'tls_dir'.
-# if 'tls_dir = default', then default values will be used for 'ca_cert = cacert.pem',
+# if 'tls_dir = default', then default values will be used for 'ca_cert = cacert.crt',
 # 'my_cert = client-cert.crt', and 'private_key = client-private.pem'.
 registrar_ca_cert = default
 registrar_my_cert = default

--- a/keylime/requests_client.py
+++ b/keylime/requests_client.py
@@ -18,7 +18,7 @@ class RequestsClient:
         else:
             self.base_url = f'http://{base_url}'
         self.session = requests.Session()
-        if ignore_hostname:
+        if ignore_hostname and tls_enabled:
             self.session.mount("http://", HostNameIgnoreAdapter())
             self.session.mount("https://", HostNameIgnoreAdapter())
         self.verify_custom = verify_custom

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -27,7 +27,7 @@ from keylime import api_version as keylime_api_version
 
 logger = keylime_logging.init_logging('tenant_webapp')
 tenant_templ = tenant.Tenant()
-(my_cert, my_priv_key), agent_cert = tenant_templ.get_tls_context()
+(my_cert, my_priv_key), agent_cert, _ = tenant_templ.get_tls_context()
 cert = (my_cert, my_priv_key)
 if config.getboolean('general', "enable_tls"):
     tls_enabled = True

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -188,7 +188,7 @@ def setUpModule():
     tenant_templ.agent_base_url = f'{tenant_templ.cloudagent_ip}:{tenant_templ.cloudagent_port}'
     tenant_templ.supported_version = "2.0"
     # Set up TLS
-    tenant_templ.cert, tenant_templ.agent_cert = tenant_templ.get_tls_context()
+    tenant_templ.cert, tenant_templ.agent_cert, _ = tenant_templ.get_tls_context()
 
 
 # Destroy everything on teardown


### PR DESCRIPTION
This removes all `verify=False` from requests calls outside of the tests and webapp.

Fixes #681