### PR TITLE
Restores the option to use keylime agents without mTLS

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -40,6 +40,11 @@ registrar_port = 8890
 # If rsa_keyname is not a absolute path it is relative to /var/lib/keylime/secure.
 rsa_keyname = tci_rsa_key
 
+# Enable mTLS communication between agent, verifier and tenant.
+# Details on why setting it to "False" is generally considered insecure can be found
+# on https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
+mtls_cert_enabled = True
+
 # The name of the X509 certificate that is used for mTLS. Uses the rsa_keyname as a key.
 # If mtls_cert is not a absolute path it is relative to /var/lib/keylime/secure.
 # This certificate must be self signed.
@@ -109,6 +114,13 @@ revocation_actions=
 # cloud-init lite =)  Keylime will run it with a /bin/sh environment and
 # with a working directory of /var/lib/keylime/secure/unzipped.
 payload_script=autorun.sh
+
+# In case mTLS for the agent is disabled and the use of payloads is still
+# required, this option has to be set to "True" in order to allow the agent 
+# to start. Details on why this configuration (mTLS disabled and payload enabled)
+# is generally considered insecure can be found on 
+# https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
+enable_insecure_payload = False
 
 # Jason @henn made be do it! He wanted a way for Keylime to measure the
 # delivered payload into a pcr of choice.
@@ -239,6 +251,9 @@ registrar_private_key = default
 registrar_private_key_pw = default
 
 # mTLS configuration for connecting to the agent.
+# Details on why setting it to "False" is generally considered insecure can be found
+# on https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
+agent_mtls_cert_enabled = True
 # Set 'agent_mtls_cert' to 'CV' for using the CV CA for the connections.
 agent_mtls_cert = CV
 agent_mtls_private_key =
@@ -375,8 +390,10 @@ ca_cert = default
 my_cert = default
 private_key = default
 
-
 # mTLS configuration for connecting to the agent.
+# Details on why setting it to "False" is generally considered insecure can be found
+# on https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
+agent_mtls_cert_enabled = True
 # Set 'agent_mtls_cert' to 'CV' for using the CV CA for the connections.
 agent_mtls_cert = CV
 agent_mtls_private_key =

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -514,12 +514,11 @@ class AgentsHandler(BaseHandler):
                             agent_data[key] = val
 
                         # Prepare SSLContext for mTLS connections
-                        # TODO: drop special handling after initial upgrade
+                        agent_mtls_cert_enabled = config.getboolean('cloud_verifier', 'agent_mtls_cert_enabled', fallback=False)
                         mtls_cert = registrar_data.get('mtls_cert', None)
                         agent_data['ssl_context'] = None
-                        if mtls_cert:
-                            agent_data['ssl_context'] = web_util.generate_agent_mtls_context(mtls_cert,
-                                                                                             self.mtls_options)
+                        if agent_mtls_cert_enabled and mtls_cert:
+                            agent_data['ssl_context'] = web_util.generate_agent_mtls_context(mtls_cert, self.mtls_options)
 
                         if agent_data['ssl_context'] is None:
                             logger.warning('Connecting to agent without mTLS: %s', agent_id)


### PR DESCRIPTION
This is a minimalistic set of code changes to allow agents to be
accessed without any TLS. This gives Keylime operators the power to
decide, based on the internal characteristics of their security policies
and processes, if agent identification via TLS certificates is
necessary.

Following the same model used for other features, such as
`revocation_notifier` and `revocation_notifier_webhook`, a couple of new
boolean configuration options, `mtls_cert_enabled` (agent-specific) and
`agent_mtls_cert_enabled` (verifer and tenant) are introduced. While the
use of mTLS for communication with agents is kept as the default
behavior, these three values can be set to "False" to fully disable the
communication with agents via TLS.

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>