### PR TITLE
Add type hints and initial Mypy configuration

### DIFF
--- a/keylime/common/algorithms.py
+++ b/keylime/common/algorithms.py
@@ -5,10 +5,10 @@ Copyright 2020 Kaifeng Wang
 import enum
 import hashlib
 
-from typing import Optional
+from typing import Optional, List, Any
 
 
-def is_accepted(algorithm, accepted):
+def is_accepted(algorithm: str, accepted: List[Any]) -> bool:
     """Check whether algorithm is accepted
 
     @param algorithm: algorithm to be checked
@@ -25,7 +25,7 @@ class Hash(str, enum.Enum):
     SM3_256 = 'sm3_256'
 
     @staticmethod
-    def is_recognized(algorithm):
+    def is_recognized(algorithm: str) -> bool:
         try:
             Hash(algorithm)
             return True
@@ -50,10 +50,10 @@ class Hash(str, enum.Enum):
 
         return None
 
-    def get_size(self):
+    def get_size(self) -> Optional[int]:
         return _HASH_SIZE.get(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
 
@@ -63,7 +63,7 @@ class Encrypt:
     supported_algorithms = (RSA, ECC)
 
     @staticmethod
-    def is_recognized(algorithm):
+    def is_recognized(algorithm: str) -> bool:
         return algorithm in Encrypt.supported_algorithms
 
 
@@ -76,7 +76,7 @@ class Sign:
     supported_algorithms = (RSASSA, RSAPSS, ECDSA, ECDAA, ECSCHNORR)
 
     @staticmethod
-    def is_recognized(algorithm):
+    def is_recognized(algorithm: str) -> bool:
         return algorithm in Sign.supported_algorithms
 
 

--- a/keylime/config.py
+++ b/keylime/config.py
@@ -125,7 +125,7 @@ if "KEYLIME_CONFIG" in os.environ:
     CONFIG_FILES.insert(0, os.environ["KEYLIME_CONFIG"])
 
 
-def get_config():
+def get_config() -> configparser.RawConfigParser:
     """Read configuration files and merge them together."""
     if not getattr(get_config, "config", None):
         # Use RawConfigParser, so we can also use it as the logging config

--- a/keylime/json.py
+++ b/keylime/json.py
@@ -5,6 +5,9 @@ Copyright 2021 Sergio Correia (scorreia@redhat.com), Red Hat, Inc.
 
 import json as json_module
 
+from typing import Any, Dict, List, Union, IO
+
+JSONType = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
 
 _list_types = [list, tuple]
 try:
@@ -20,7 +23,7 @@ except ModuleNotFoundError:
         pass
 
 
-def bytes_to_str(data):
+def bytes_to_str(data: Any) -> Any:
     if isinstance(data, (bytes, bytearray)):
         data = data.decode("utf-8")
     elif isinstance(data, dict):
@@ -35,7 +38,7 @@ def bytes_to_str(data):
     return data
 
 
-def dumps(obj, **kwargs):
+def dumps(obj: JSONType, **kwargs: Any) -> str:
     try:
         ret = json_module.dumps(obj, **kwargs)
     except TypeError:
@@ -45,20 +48,20 @@ def dumps(obj, **kwargs):
     return ret
 
 
-def dump(obj, fp, **kwargs):
+def dump(obj: JSONType, fp: IO[str], **kwargs: Any) -> None:
     try:
         json_module.dump(obj, fp, **kwargs)
     except TypeError:
         # dump() from the built-it json module does not work with bytes,
         # so let's convert those to str if we get a TypeError exception.
-        json_module.dump(obj, fp, **kwargs)
+        json_module.dump(bytes_to_str(obj), fp, **kwargs)
 
 
-def load(fp, **kwargs):
+def load(fp: Any, **kwargs: Any) -> Any:
     return json_module.load(fp, **kwargs)
 
 
-def loads(s, **kwargs):
+def loads(s: Union[str, bytes], **kwargs: Any) -> Any:
     return json_module.loads(s, **kwargs)
 
 
@@ -70,12 +73,12 @@ class JSONPickler:
     dumps with extra positional parameters"""
 
     @classmethod
-    def dumps(cls, value, *args, **kwargs):
+    def dumps(cls, value: JSONType, *_args: Any, **_kwargs: Any) -> str:
         # pylint: disable=unused-argument
         """Dumps the python value into a JSON string"""
         return dumps(value)
 
     @classmethod
-    def loads(cls, value):
+    def loads(cls, value: Union[str, bytes]) -> Any:
         """Parses the JSON string and returns the corresponding python value"""
         return loads(value)

--- a/keylime/keylime_logging.py
+++ b/keylime/keylime_logging.py
@@ -4,8 +4,10 @@ Copyright 2017 Massachusetts Institute of Technology.
 """
 
 import os
+import logging
 
-import logging.config
+from typing import Any, Callable, Dict
+from logging import Logger, config as logging_config
 
 from keylime import config
 
@@ -19,10 +21,10 @@ if not config.REQUIRE_ROOT:
 else:
     LOGSTREAM = LOGDIR + '/keylime-stream.log'
 
-logging.config.fileConfig(config.get_config())
+logging_config.fileConfig(config.get_config())
 
 
-def set_log_func(loglevel, logger):
+def set_log_func(loglevel: int, logger: Logger) -> Callable[..., None]:
     log_func = logger.info
 
     if loglevel == logging.CRITICAL:
@@ -39,7 +41,7 @@ def set_log_func(loglevel, logger):
     return log_func
 
 
-def log_http_response(logger, loglevel, response_body):
+def log_http_response(logger: Logger, loglevel: int, response_body: Dict[str, Any]) -> bool:
     """Takes JSON response payload and logs error info"""
     if None in [response_body, logger]:
         return False
@@ -57,7 +59,7 @@ def log_http_response(logger, loglevel, response_body):
     return True
 
 
-def init_logging(loggername):
+def init_logging(loggername: str) -> Logger:
     logger = logging.getLogger("keylime.%s" % loggername)
     logging.getLogger("requests").setLevel(logging.WARNING)
     mainlogger = logging.getLogger("keylime")

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+plugins = sqlmypy
+strict = True
+follow_imports = silent
+ignore_missing_imports = True
+


### PR DESCRIPTION
This PR adds full type hints to:
- `ima_ast.py`
- `failure.py`
- `algorithms.py`
- `keylime_loggin.py`
- `json.py`

I also added a Mypy configuration with `strict` set to true which should enable most of the Mypy checks.

Once more parts of Keylime have type hints I will add this to the tox configuration.

Part of #929 