### PR TITLE
Full allowlist processing when not adding host

### DIFF
--- a/keylime/cmd/tenant.py
+++ b/keylime/cmd/tenant.py
@@ -12,13 +12,13 @@ logger = keylime_logging.init_logging('tenant')
 
 
 def main():
-    tenant.main()
-
-
-if __name__ == "__main__":
     try:
-        main()
+        tenant.main()
     except tenant.UserError as ue:
         logger.error(str(ue))
     except Exception as e:
         logger.exception(e)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This fixes bug #928 so that full allowlist processing (url, sig, checksum)
are also done when we are not adding a new host but a named allowlist.

Also handles misc exceptions that weren't correctly turned into user
friendly exceptions in the tenant.

Signed-off-by: Michael Peters <mpeters@redhat.com>