### PR TITLE
keylime_tenant non-zero exit code on error

### DIFF
--- a/keylime/cmd/tenant.py
+++ b/keylime/cmd/tenant.py
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 Copyright 2017 Massachusetts Institute of Technology.
 '''
 
+import sys
+
 from keylime import keylime_logging
 from keylime import tenant
 
@@ -16,8 +18,10 @@ def main():
         tenant.main()
     except tenant.UserError as ue:
         logger.error(str(ue))
+        sys.exit(1)
     except Exception as e:
         logger.exception(e)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -10,7 +10,7 @@
     how: fmf
     url: https://github.com/RedHat-SP-Security/keylime-tests
     ref: main
-    test: 
+    test:
      - /setup/configure_tpm_emulator
      - /setup/install_upstream_keylime
      - /setup/enable_keylime_coverage
@@ -21,6 +21,7 @@
      - /functional/db-postgresql-sanity-on-localhost
      - /functional/db-mariadb-sanity-on-localhost
      - /functional/db-mysql-sanity-on-localhost
+     - /functional/tenant-allowlist-sanity
      - /setup/generate_coverage_report
 
   adjust:


### PR DESCRIPTION
Now that we are catching errors and making them more user-friendly
we still need to exit with a non-zero exit code so that other
programs can tell when something went wrong

Signed-off-by: Michael Peters <mpeters@redhat.com>