### PR TITLE
Fix prepare step adjustments in packit-ci.fmf plan

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -25,13 +25,17 @@
 
   adjust:
    # prepare step adjustments
-   - when: distro == centos-stream-9
-     prepare+:
-       script: yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+   - prepare:
+       script:
+        - bash -c 'ln -s $(pwd) /var/tmp/keylime_sources'
+        - yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+     when: distro == centos-stream-9
 
-   - when: distro == centos-stream-8
-     prepare+:
-       script: yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+   - prepare:
+       script:
+        - bash -c 'ln -s $(pwd) /var/tmp/keylime_sources'
+        - yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+     when: distro == centos-stream-8
 
    # discover step adjustments
    # disable code coverage measurement everywhere except F35


### PR DESCRIPTION
This should address an issue on CentOS Stream 8 and 9 where only one prepare
step was executed, symbolic link hasn't been created and as a results we were
testing upstream code instead of the PR one.

Signed-off-by: Karel Srot <ksrot@redhat.com>