### PR TITLE
general: drop support for API version 1.0

### DIFF
--- a/keylime/api_version.py
+++ b/keylime/api_version.py
@@ -8,11 +8,9 @@ from packaging import version
 
 CURRENT_VERSION = "2.0"
 VERSIONS = [
-    "1.0",
     "2.0"
 ]
 LATEST_VERSIONS = {
-    "1": "1.0",
     "2": "2.0"
 }
 DEPRECATED_VERSIONS = ["1.0"]

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -152,8 +152,7 @@ def process_quote_response(agent, json_response, agentAttestState) -> Failure:
         algorithms.Hash(hash_alg),
         ima_keyrings,
         mb_measurement_list,
-        agent['mb_refstate'],
-        compressed=(agent['supported_version'] == "1.0"))  # TODO: change this to always False after initial update
+        agent['mb_refstate'])
     failure.merge(quote_validation_failure)
 
     if not failure:

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -552,8 +552,7 @@ class Tenant():
             return False
 
         failure = self.tpm_instance.check_quote(AgentAttestState(self.agent_uuid), self.nonce, public_key, quote,
-                                                self.registrar_data['aik_tpm'], hash_alg=hash_alg,
-                                                compressed=(self.supported_version == "1.0"))
+                                                self.registrar_data['aik_tpm'], hash_alg=hash_alg)
         if failure:
             if self.registrar_data['regcount'] > 1:
                 logger.error("WARNING: This UUID had more than one ek-ekcert registered to it! This might indicate that your system is misconfigured or a malicious host is present. Run 'regdelete' for this agent and restart")

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -156,7 +156,7 @@ class AbstractTPM(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def check_quote(self, agentAttestState, nonce, data, quote, aikTpmFromRegistrar, tpm_policy=None, ima_measurement_list=None, allowlist=None, hash_alg=None, ima_keyrings=None, mb_measurement_list=None, mb_refstate=None, compressed=False):
+    def check_quote(self, agentAttestState, nonce, data, quote, aikTpmFromRegistrar, tpm_policy=None, ima_measurement_list=None, allowlist=None, hash_alg=None, ima_keyrings=None, mb_measurement_list=None, mb_refstate=None):
         pass
 
     def START_HASH(self, algorithm=None):

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -883,13 +883,12 @@ class tpm(tpm_abstract.AbstractTPM):
         retDict = self.__run(command, lock=False)
         return retDict
 
-    def _tpm2_checkquote(self, aikTpmFromRegistrar, quote, nonce, hash_alg, compressed):
+    def _tpm2_checkquote(self, aikTpmFromRegistrar, quote, nonce, hash_alg):
         """Write the files from data returned from tpm2_quote for running tpm2_checkquote
         :param aikTpmFromRegistrar: AIK used to generate the quote and is needed for verifying it now.
         :param quote: quote data in the format 'r<b64-compressed-quoteblob>:<b64-compressed-sigblob>:<b64-compressed-pcrblob>
         :param nonce: nonce that was used to create the quote
         :param hash_alg: the hash algorithm that was used
-        :param compressed: if the quote data is compressed with zlib or not
         :returns: Returns the 'retout' from running tpm2_checkquote and True in case of success, None and False in case of error.
         This function throws an Exception on bad input.
         """
@@ -911,13 +910,6 @@ class tpm(tpm_abstract.AbstractTPM):
         quoteblob = base64.b64decode(quote_tokens[0])
         sigblob = base64.b64decode(quote_tokens[1])
         pcrblob = base64.b64decode(quote_tokens[2])
-
-        if compressed:
-            logger.warning("Decompressing quote data which is unsafe!")
-            quoteblob = zlib.decompress(quoteblob)
-            sigblob = zlib.decompress(sigblob)
-            pcrblob = zlib.decompress(pcrblob)
-
 
         qfd = sfd = pfd = afd = -1
         quoteFile = None
@@ -969,7 +961,7 @@ class tpm(tpm_abstract.AbstractTPM):
 
     def check_quote(self, agentAttestState, nonce, data, quote, aikTpmFromRegistrar, tpm_policy=None,
                     ima_measurement_list=None, allowlist=None, hash_alg=None, ima_keyrings=None,
-                    mb_measurement_list=None, mb_refstate=None, compressed=False) -> Failure:
+                    mb_measurement_list=None, mb_refstate=None) -> Failure:
         if tpm_policy is None:
             tpm_policy = {}
         if allowlist is None:
@@ -979,7 +971,7 @@ class tpm(tpm_abstract.AbstractTPM):
         if hash_alg is None:
             hash_alg = self.defaults['hash']
 
-        retout, success = self._tpm2_checkquote(aikTpmFromRegistrar, quote, nonce, hash_alg, compressed)
+        retout, success = self._tpm2_checkquote(aikTpmFromRegistrar, quote, nonce, hash_alg)
         if not success:
             # If the quote validation fails we will skip all other steps therefore this failure is irrecoverable.
             failure.add_event("quote_validation", {"message": "Quote validation using tpm2-tools", "data": retout}, False)

--- a/test/test_api_version.py
+++ b/test/test_api_version.py
@@ -13,18 +13,18 @@ class APIVersion_Test(unittest.TestCase):
         self.assertEqual(api_version.current_version(), "2.0", "Current version is 2.0")
 
     def test_latest_minor_version(self):
-        self.assertEqual(api_version.latest_minor_version("1.0"), "1.0", "Latest version of 1.0 is 1.0")
-        self.assertEqual(api_version.latest_minor_version("1"), "1.0", "Latest version of 1 is 1.0")
+        self.assertEqual(api_version.latest_minor_version("2.0"), "2.0", "Latest version of 2.0 is 2.0")
+        self.assertEqual(api_version.latest_minor_version("2"), "2.0", "Latest version of 2 is 2.0")
         self.assertEqual(api_version.latest_minor_version("20"), "0", "No latest version of v20")
 
     def test_normalize_version(self):
-        self.assertEqual(api_version.normalize_version(1), "1.0", "1 (int) normalizes to 1")
-        self.assertEqual(api_version.normalize_version("1"), "1.0", "1 (str) normalizes to 1")
+        self.assertEqual(api_version.normalize_version(1), "1", "1 (int) normalizes to 1")
+        self.assertEqual(api_version.normalize_version("1"), "1", "1 (str) normalizes to 1")
         self.assertEqual(api_version.normalize_version(1.0), "1.0", "1.0 (float) normalizes to 1.0")
         self.assertEqual(api_version.normalize_version(1.2), "1.2", "1.2 (float) normalizes to 1.2")
         self.assertEqual(api_version.normalize_version("1.2"), "1.2", "1.2 (string) normalizes to 1.2")
         self.assertEqual(api_version.normalize_version("v3.4"), "3.4", "v3.4 normalizes to 3.4")
-        self.assertEqual(api_version.normalize_version("v1a"), "1.0", "v1a normalizes to 1.0")
+        self.assertEqual(api_version.normalize_version("v1a"), "1", "v1a normalizes to 1")
         self.assertEqual(api_version.normalize_version(0), "0", "0 (int) normalizes to 0")
         self.assertEqual(api_version.normalize_version("v12.03"), "12.3", "v12.03 normalizes to 12.3")
         self.assertEqual(api_version.normalize_version("v13.40"), "13.40", "v13.40 normalizes to 13.40")
@@ -33,8 +33,8 @@ class APIVersion_Test(unittest.TestCase):
     def test_is_supported_version(self):
         self.assertTrue(api_version.is_supported_version("2.0"), "2.0 is a supported version")
         self.assertTrue(api_version.is_supported_version("v2.0"), "v2.0 is a supported version")
-        self.assertTrue(api_version.is_supported_version("1.0"), "1.0 is a supported version")
-        self.assertTrue(api_version.is_supported_version("v1.0"), "v1.0 is a supported version")
+        self.assertFalse(api_version.is_supported_version("1.0"), "1.0 is not a supported version")
+        self.assertFalse(api_version.is_supported_version("v1.0"), "v1.0 is not a supported version")
         self.assertFalse(api_version.is_supported_version("0"), "0 is not a supported version")
         self.assertFalse(api_version.is_supported_version("v0"), "v0 is not a supported version")
         self.assertFalse(api_version.is_supported_version("10.0"), "10.0 is not a supported version")

--- a/test/test_web_util.py
+++ b/test/test_web_util.py
@@ -13,9 +13,9 @@ class TestConfig(unittest.TestCase):
     @patch("keylime.web_util.config")
     def test_get_restful_params(self, _):
         """Tests if the parsing of the parameters works"""
-        version_url = "/v1.0/quotes/integrity?nonce=1234567890ABCDEFHIJ&mask=0x408000&vmask=0x808000&partial=0"
+        version_url = "/v2.0/quotes/integrity?nonce=1234567890ABCDEFHIJ&mask=0x408000&vmask=0x808000&partial=0"
         version_params = {
-            "api_version": "1.0",
+            "api_version": "2.0",
             "quotes": "integrity",
             "nonce": "1234567890ABCDEFHIJ",
             "mask": "0x408000",


### PR DESCRIPTION
API version 1.0 is considered insecure and should therefore no longer be used.
We included support for it in 6.3.0 to support updating the server side first,
but future versions will no longer include support for 1.0.

Agent mTLS connections can still be manually disabled, but this is highly
discouraged for normal installations. More details:
https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r