### PR TITLE
tenant: Handle 404 error from registrar gracefully

### DIFF
--- a/keylime/registrar_client.py
+++ b/keylime/registrar_client.py
@@ -87,6 +87,11 @@ def getData(registrar_ip, registrar_port, agent_id):
         response = client.get(f'/v{api_version}/agents/{agent_id}', cert=tls_cert_info, verify=ca_cert)
         response_body = response.json()
 
+        if response.status_code == 404:
+            logger.critical("Error: could not get agent %s data from Registrar Server: %s", agent_id, response.status_code)
+            keylime_logging.log_http_response(logger, logging.CRITICAL, response_body)
+            return None
+
         if response.status_code != 200:
             logger.critical("Error: unexpected http response code from Registrar Server: %s", response.status_code)
             keylime_logging.log_http_response(logger, logging.CRITICAL, response_body)

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -90,13 +90,13 @@ class ProtectedHandler(BaseHTTPRequestHandler, SessionManager):
                 logger.error('SQLAlchemy Error: %s', e)
 
             if agent is None:
-                web_util.echo_json_response(self, 404, "agent_id not found")
-                logger.warning('GET returning 404 response. agent_id %s not found.', agent_id)
+                web_util.echo_json_response(self, 404, f"agent {agent_id} not found")
+                logger.warning('GET returning 404 response. agent %s not found.', agent_id)
                 return
 
             if not bool(agent.active):
-                web_util.echo_json_response(self, 404, "agent_id not yet active")
-                logger.warning('GET returning 404 response. agent_id %s not yet active.', agent_id)
+                web_util.echo_json_response(self, 404, f"agent {agent_id} not yet active")
+                logger.warning('GET returning 404 response. agent %s not yet active.', agent_id)
                 return
 
             response = {

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -277,6 +277,9 @@ class Tenant():
         registrar_client.init_client_tls("tenant")
         self.registrar_data = registrar_client.getData(self.registrar_ip, self.registrar_port, self.agent_uuid)
 
+        if self.registrar_data is None:
+            raise UserError(f"Agent ${self.agent_uuid} data not found in the Registrar.")
+
         # try to get the port or ip from the registrar if it is missing
         if (self.agent_ip is None or self.agent_port is None) and self.registrar_data is not None:
             if self.agent_ip is None:


### PR DESCRIPTION
When the tenant tries do add an agent which is not registered to the registrar or is registered but not active yet, it crashes and gives a traceback similar to:
```
2022-03-25 15:07:44.658 - keylime.registrar - WARNING - GET returning 404 response. agent_id d432fbb3-d2f1-4a97-9ef7-75bd81c00000 not found.
2022-03-25 15:07:44.659 - keylime.registrar_client - CRITICAL - Error: unexpected http response code from Registrar Server: 404
2022-03-25 15:07:44.659 - keylime.registrar_client - CRITICAL - Response code 404: agent_id not found
2022-03-25 15:07:44.659 - keylime.tenant - ERROR - 'NoneType' object has no attribute 'get'
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/keylime-6.3.1-py3.10.egg/keylime/cmd/tenant.py", line 18, in main
    tenant.main()
  File "/usr/local/lib/python3.10/site-packages/keylime-6.3.1-py3.10.egg/keylime/tenant.py", line 1437, in main
    mytenant.init_add(vars(args))
  File "/usr/local/lib/python3.10/site-packages/keylime-6.3.1-py3.10.egg/keylime/tenant.py", line 306, in init_add
    if self.registrar_data.get("mtls_cert", None) is None:
AttributeError: 'NoneType' object has no attribute 'get'
```
This makes the tenant to gracefully handle 404 errors returned from the registrar instead of crashing.