### PR TITLE
Verify identity quote before adding agent to the verifier

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -1138,6 +1138,7 @@ class Tenant():
                     do_verify = RequestsClient(cloudagent_base_url, tls_enabled=False)
                     response = do_verify.get(f'/v{self.supported_version}/keys/verify?challenge={challenge}')
 
+                response_body = response.json()
             except Exception as e:
                 if response.status_code in (503, 504):
                     numtries += 1
@@ -1155,7 +1156,6 @@ class Tenant():
                     continue
                 self.do_cvstop()
                 raise e
-            response_body = response.json()
             if response.status_code == 200:
                 if "results" not in response_body or 'hmac' not in response_body['results']:
                     logger.critical("Error: unexpected http response body from Cloud Agent: %s", response.status_code)

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -1436,16 +1436,16 @@ def main(argv=sys.argv):  #pylint: disable=dangerous-default-value
     if args.command == 'add':
         mytenant.init_add(vars(args))
         mytenant.preloop()
-        mytenant.do_cv()
         mytenant.do_quote()
+        mytenant.do_cv()
         if args.verify:
             mytenant.do_verify()
     elif args.command == 'update':
         mytenant.init_add(vars(args))
         mytenant.do_cvdelete(args.verifier_check)
         mytenant.preloop()
-        mytenant.do_cv()
         mytenant.do_quote()
+        mytenant.do_cv()
         if args.verify:
             mytenant.do_verify()
     elif args.command == 'delete':

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -584,8 +584,8 @@ class AgentsHandler(BaseHandler):
             mytenant.agent_uuid = agent_id
             mytenant.init_add(args)
             mytenant.preloop()
-            mytenant.do_cv()
             mytenant.do_quote()
+            mytenant.do_cv()
         except Exception as e:
             logger.exception(e)
             logger.warning('POST returning 500 response. Tenant error: %s', e)


### PR DESCRIPTION
This implements the enhancement proposed in https://github.com/keylime/enhancements/blob/master/66_quote_before_register.md

Swap the order of `do_cv()` and `do_quote()` calls in the tenant.

Fixes: #680 