### PR TITLE
Implement verifier-side signature check for the addallowlist tenant command

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -360,6 +360,11 @@ severity_policy = [{"event_id": ".*", "severity_label": "emergency"}]
 # Set to True to treat ToMToU entries as errors.
 tomtou_errors = False
 
+# If set to true, the verifier will require associated signatures and private
+# keys when getting an allowlist, and will check the allowlist against those
+# signatures before returning the requested allowlist.
+enforce_allow_list_signatures = False
+
 #=============================================================================
 [tenant]
 #=============================================================================


### PR DESCRIPTION
This PR is a first prototype of verifier-side allowlist signature verification.

Previously, the only time allowlist signatures were validated was when the tenant read an allowlist from disk as part of the `add` or `addallowlist` commands. Ideally, this would be expanded to include a similar check in the verifier once the allowlist had been sent over.

There is a significant complicating factor to this idea, however: once an allowlist is read and verified, the tenant performs significant pre-processing on the payload it eventually sends to the the verifier, to the point where the "allowlist" sent to the verifier could be vastly different from the artifact that was validated on the tenant. (For example, if the allowlist is of an older non-JSON format, the tenant will automatically convert it to JSON.) This makes signature validation impossible. There are a few solutions to this problem, the most obvious of which is to perform any allowlist processing after any signature validation steps have happened.

This PR implements a possible first step towards adding the second, verifier-side signing step by augmenting the `addallowlist` command. As it turns out, the cloud verifier's `addallowlist` handler doesn't actually use anything from the allowlist payload sent over by the tenant - meaning the tenant can send over an unprocessed version of the allowlist, which can then be validated on the verifier. This PR does exactly that by collecting the signing materials on the tenant, sending them over to the verifier, and performing an additional signature check on the verifier with those materials. No other functionality should be impacted by the new validation.

Very open to feedback/discussion on the best way to proceed.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>