### PR TITLE
Enable SQL query cache for JSONPickleType

### DIFF
--- a/keylime/config.py
+++ b/keylime/config.py
@@ -202,3 +202,7 @@ BOOTSTRAP_KEY_SIZE = 32
 CA_IMPL = get_config().get('general', 'ca_implementation', fallback='openssl')
 
 CRL_PORT = 38080
+
+# Enable DB debugging via environment variable DEBUG_DB
+# This is only effective when INSECURE_DEBUG is also True
+DEBUG_DB = environ_bool('DEBUG_DB', False)

--- a/keylime/db/keylime_db.py
+++ b/keylime/db/keylime_db.py
@@ -83,6 +83,10 @@ class DBEngineManager:
                 engine_args['pool_size'] = int(p_sz)
                 engine_args['max_overflow'] = int(m_ovfl)
 
+        # Enable DB debugging
+        if config.DEBUG_DB and config.INSECURE_DEBUG:
+            engine_args['echo'] = True
+
         engine = create_engine(url, **engine_args)
         return engine
 

--- a/keylime/db/registrar_db.py
+++ b/keylime/db/registrar_db.py
@@ -14,6 +14,7 @@ Base = declarative_base()
 
 class JSONPickleType(PickleType):  # pylint: disable=abstract-method
     impl = Text
+    cache_ok = True
 
 
 class RegistrarMain(Base):

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -15,6 +15,7 @@ Base = declarative_base()
 
 class JSONPickleType(PickleType):  # pylint: disable=abstract-method
     impl = Text
+    cache_ok = True
 
 
 class VerfierMain(Base):


### PR DESCRIPTION
Add the cache_ok = True flag to the JSONPickleType classes to supress SQLAlchemy warnings and enable query caching for improved performance.

It should be safe to enable caching for the JSONPickleType as it does not include additional state attributes which affects how it renders SQL.

This also adds an option to enable debugging the SQL queries and caching via `DEBUG_DB` environment variable which is only effective when `INSECURE_DEBUG` is also enabled.

See:
- https://docs.sqlalchemy.org/en/14/faq/performance.html
- https://docs.sqlalchemy.org/en/14/core/custom_types.html