### PR TITLE
tpm_emulator: use tpm2-abrmd as resource manager

### DIFF
--- a/ima_stub_service/ima_emulator.service
+++ b/ima_stub_service/ima_emulator.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=IMA emulator for Keylime
-After=network.target tpm_emulator.service
-Requires=tpm_emulator.service
+After=network.target tpm_emulator_rm.service
+Requires=tpm_emulator_rm.service
 
 [Service]
-Environment=TPM2TOOLS_TCTI="mssim:port=2321"
+Environment=TPM2TOOLS_TCTI=tabrmd:bus_name=dev.keylime.tss2.Tabrmd
 ExecStart=/usr/bin/bash -c "keylime_ima_emulator"
 
 [Install]

--- a/ima_stub_service/installer.sh
+++ b/ima_stub_service/installer.sh
@@ -14,8 +14,13 @@ if [[ -n `systemctl 2>&1 > /dev/null` ]]; then
 	exit 1
 fi
 
+cp tpm2-abrmd-emulator.conf /etc/dbus-1/system.d/tpm2-abrmd-emulator.conf
+
+systemctl daemon-reload
+systemctl reload dbus.service
+
 # create services and socket
-for service in "tpm_emulator.service" "ima_emulator.service"; do
+for service in "tpm_emulator.service" "tpm_emulator_rm.service" "ima_emulator.service"; do
   cp  ${service} /etc/systemd/system
   chmod 644 /etc/systemd/system/${service}
   systemctl enable ${service}

--- a/ima_stub_service/tpm2-abrmd-emulator.conf
+++ b/ima_stub_service/tpm2-abrmd-emulator.conf
@@ -1,0 +1,15 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <!-- ../system.conf have denied everything, so we just punch some holes -->
+  <policy user="tss">
+    <allow own="dev.keylime.tss2.Tabrmd"/>
+  </policy>
+  <policy user="root">
+    <allow own="dev.keylime.tss2.Tabrmd"/>
+  </policy>
+  <policy context="default">
+    <allow send_destination="dev.keylime.tss2.Tabrmd"/>
+    <allow receive_sender="dev.keylime.tss2.Tabrmd"/>
+  </policy>
+</busconfig>

--- a/ima_stub_service/tpm_emulator_rm.service
+++ b/ima_stub_service/tpm_emulator_rm.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Resource Manager for emulated TPM
+After=network.target tpm_emulator.service
+Requires=tpm_emulator.service
+
+[Service]
+Type=dbus
+BusName=dev.keylime.tss2.Tabrmd
+ExecStart=/bin/bash -c "tpm2-abrmd --allow-root -t 'mssim:port=2321' --dbus-name=dev.keylime.tss2.Tabrmd"
+
+[Install]
+WantedBy=default.target

--- a/installer.sh
+++ b/installer.sh
@@ -68,6 +68,7 @@ case "$ID" in
             PYTHON_DEPS+=" libefivar-dev"
         fi
         BUILD_TOOLS="build-essential libtool automake pkg-config m4 libgcrypt20-dev uthash-dev autoconf autoconf-archive libcurl4-gnutls-dev gnulib doxygen libdbus-1-dev uuid-dev libjson-c-dev"
+        TPM2_ABRMD_PKGS="tpm2-abrmd"
         $PACKAGE_MGR update
         case "${VERSION_ID}" in
           # Ubuntu 18.04, Debian 9 and 10 don't ship with a new enough version of tpm2-tools/tpm2-tss
@@ -95,6 +96,7 @@ case "$ID" in
                 BUILD_TOOLS="openssl-devel file libtool make automake m4 libgcrypt-devel autoconf autoconf-archive libcurl-devel libstdc++-devel uriparser-devel dbus-devel gnulib-devel doxygen libuuid-devel json-c-devel"
                 NEED_BUILD_TOOLS=1
                 CENTOS7_TSS_FLAGS="--enable-esapi=no --disable-doxygen-doc"
+                TPM2_ABRMD_PKGS="tpm2-abrmd"
             ;;
             8*)
                 echo "${ID} ${VERSION_ID} selected."
@@ -110,6 +112,7 @@ case "$ID" in
                 NEED_BUILD_TOOLS=1
                 NEED_PYTHON_DIR=1
                 POWERTOOLS="--enablerepo=PowerTools install autoconf-archive"
+                TPM2_ABRMD_PKGS="tpm2-abrmd"
             ;;
             *)
                 echo "Version ${VERSION_ID} of ${ID} not supported"
@@ -126,6 +129,7 @@ case "$ID" in
             PYTHON_DEPS+=" efivar-devel"
         fi
         BUILD_TOOLS="openssl-devel libtool make automake pkg-config m4 libgcrypt-devel autoconf autoconf-archive libcurl-devel libstdc++-devel uriparser-devel dbus-devel gnulib-devel doxygen libuuid-devel json-c-devel"
+        TPM2_ABRMD_PKGS="tpm2-abrmd"
         GOPKG="golang"
         if [[ ${VERSION_ID} -ge 30 ]] ; then
         # if fedora 30 or greater, then using TPM2 tool packages
@@ -506,6 +510,14 @@ if [[ "$TPM_SOCKET" -eq "1" ]] ; then
     install -c tpm_server /usr/local/bin/tpm_server
 
     popd # tpm/swtpm2
+
+    if [[ ! -z $TPM2_ABRMD_PKGS ]]; then
+      $PACKAGE_MGR install -y $TPM2_ABRMD_PKGS
+      if [[ $? > 0 ]] ; then
+          echo "ERROR: Package(s) failed to install properly!"
+          exit 1
+      fi
+    fi
 fi
 
 
@@ -575,7 +587,7 @@ if [[ "$TPM_SOCKET" -eq "1" ]] ; then
 
     echo "=================================================================================="
     echo $'\tWARNING: Please set the env var for accessing the TPM:'
-    echo $'\tTPM2TOOLS_TCTI="mssim:port=2321"'
+    echo $'\tTPM2TOOLS_TCTI=tabrmd:bus_name=dev.keylime.tss2.Tabrmd'
     echo "=================================================================================="
 
     # disable ek cert checking


### PR DESCRIPTION
Talking directly to the TPM causes problems with transient objects, so we use tpm2-abrmd as a resource manager.

I have only validated those changes on Fedora 35.