### PR TITLE
Fix tpm import in test_tpm.py

### DIFF
--- a/test/test_tpm.py
+++ b/test/test_tpm.py
@@ -1,5 +1,5 @@
 import unittest
-import keylime
+from keylime.tpm.tpm_main import tpm
 
 # ############################################################
 # list of input challenges for get_tpm_manufacturer function
@@ -76,7 +76,7 @@ tpm_manufacturer_tests = [
 
 class TestTPM(unittest.TestCase):
     def setUp(self):
-        self.tpm = keylime.tpm.tpm_main.tpm()
+        self.tpm = tpm()
 
     # basic test:
     # whatever the underlying TPM is, just ensure get_manufacturer worked.


### PR DESCRIPTION
This fixes a problem with running the test through the
"coverage run". Currently, it fails due to the following error:

  AttributeError: module 'keylime' has no attribute 'tpm'

Signed-off-by: Karel Srot <ksrot@redhat.com>