### PR TITLE
Change GH reviewers to be from developer group

### DIFF
--- a/.github/workflows/keylime-bot.yml
+++ b/.github/workflows/keylime-bot.yml
@@ -53,5 +53,5 @@ jobs:
       - uses: actions-automation/pull-request-responsibility@main
         with:
           actions: "request,assign,copy-labels-linked"
-          reviewers: "core"
-          num_to_request: 3
+          reviewers: "developer"
+          num_to_request: 4


### PR DESCRIPTION
This group is more geared towards trigage and review
so it's a better group for this automation.

Signed-off-by: Michael Peters <mpeters@redhat.com>