### PR TITLE
general: bump Keylime version to 6.3.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = keylime
-version = 6.3.1
+version = 6.3.2
 description = TPM-based key bootstrapping and system integrity measurement system for cloud
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8


### PR DESCRIPTION
Before we make a new release we should increase the version number.