### PR TITLE
pypi: add notice that the Python API is unstable

### DIFF
--- a/_pypi-notice.md
+++ b/_pypi-notice.md
@@ -1,0 +1,1 @@
+**Note: Keylime Python modules do not have a stable API and might change without notice!**

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = keylime
 version = 6.3.1
 description = TPM-based key bootstrapping and system integrity measurement system for cloud
-long_description = file: README.md
+long_description= file: _pypi-notice.md, README.md
 long_description_content_type = text/markdown; charset=UTF-8
 url = https://keylime.dev
 author = Keylime Community


### PR DESCRIPTION
We will not guarantee that the exported functions in Python modules are stable.

Fixes https://github.com/keylime/keylime/issues/899