### PR TITLE
Workaround for mock_open not supporting iteration in Python 3.6

### DIFF
--- a/keylime/secure_mount.py
+++ b/keylime/secure_mount.py
@@ -21,7 +21,11 @@ def check_mounted(secdir):
     """Inspect mountinfo to detect if a directory is mounted."""
     secdir_escaped = secdir.replace(" ", r"\040")
     with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
-        for line in f:
+        # because of tests we use readlines() and avoid using iterator
+        # since mocked open cannot use iterator on Python 3.6
+        # see https://code-examples.net/en/q/17a1c75
+        #     https://bugs.python.org/issue21258
+        for line in f.readlines():
             # /proc/[pid]/mountinfo have 10+ elements separated with
             # spaces (check proc (5) for a complete description)
             #

--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -22,6 +22,7 @@
      - /functional/db-mariadb-sanity-on-localhost
      - /functional/db-mysql-sanity-on-localhost
      - /functional/tenant-allowlist-sanity
+     - /upstream/run_keylime_tests
      - /setup/generate_coverage_report
 
   adjust:


### PR DESCRIPTION
In Python 3.6 mock_open does not support iteration around text
files. This is causing test failures in test_secure_mount.py
which is using mock_open. We workaround the issue by not using
iterator.

For more details see:
  https://code-examples.net/en/q/17a1c75
  https://bugs.python.org/issue21258

Signed-off-by: Karel Srot <ksrot@redhat.com>