### PR TITLE
Deprecate API version 1.0

### DIFF
--- a/keylime/api_version.py
+++ b/keylime/api_version.py
@@ -15,6 +15,7 @@ LATEST_VERSIONS = {
     "1": "1.0",
     "2": "2.0"
 }
+DEPRECATED_VERSIONS = ["1.0"]
 
 def current_version():
     return CURRENT_VERSION
@@ -35,6 +36,10 @@ def all_versions():
 def is_supported_version(v):
     v_obj = version.parse(str(v))
     return v_obj.base_version in VERSIONS
+
+def is_deprecated_version(v):
+    v_obj = version.parse(str(v))
+    return is_supported_version(v) and v_obj.base_version in DEPRECATED_VERSIONS
 
 def normalize_version(v):
     v = str(v)
@@ -59,6 +64,8 @@ def log_api_versions(logger):
     versions.remove(CURRENT_VERSION)
     if versions:
         logger.info('Supported older API versions: ' + ", ".join(versions))
+    if DEPRECATED_VERSIONS:
+        logger.info("Deprecated API versions (soon to be removed): " + ", ".join(DEPRECATED_VERSIONS))
 
 
 def validate_version(v: str) -> bool:

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -259,8 +259,7 @@ class AgentsHandler(BaseHandler):
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
-        if not rest_params["api_version"]:
-            web_util.echo_json_response(self, 400, "API Version not supported")
+        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
             return
 
         if "agents" not in rest_params:
@@ -329,8 +328,7 @@ class AgentsHandler(BaseHandler):
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
-        if not rest_params["api_version"]:
-            web_util.echo_json_response(self, 400, "API Version not supported")
+        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
             return
 
         if "agents" not in rest_params:
@@ -405,8 +403,7 @@ class AgentsHandler(BaseHandler):
                     self, 405, "Not Implemented: Use /agents/ interface")
                 return
 
-            if not rest_params["api_version"]:
-                web_util.echo_json_response(self, 400, "API Version not supported")
+            if not web_util.validate_api_version(self, rest_params["api_version"], logger):
                 return
 
             if "agents" not in rest_params:
@@ -547,8 +544,7 @@ class AgentsHandler(BaseHandler):
                     self, 405, "Not Implemented: Use /agents/ interface")
                 return
 
-            if not rest_params["api_version"]:
-                web_util.echo_json_response(self, 400, "API Version not supported")
+            if not web_util.validate_api_version(self, rest_params["api_version"], logger):
                 return
 
             if "agents" not in rest_params:
@@ -633,8 +629,7 @@ class AllowlistHandler(BaseHandler):
             web_util.echo_json_response(self, 400, "Invalid URL")
             return
 
-        if not rest_params["api_version"]:
-            web_util.echo_json_response(self, 400, "API Version not supported")
+        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
             return
 
         allowlist_name = rest_params['allowlists']
@@ -672,8 +667,7 @@ class AllowlistHandler(BaseHandler):
             web_util.echo_json_response(self, 400, "Invalid URL")
             return
 
-        if not rest_params["api_version"]:
-            web_util.echo_json_response(self, 400, "API Version not supported")
+        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
             return
 
         allowlist_name = rest_params['allowlists']
@@ -724,8 +718,7 @@ class AllowlistHandler(BaseHandler):
             web_util.echo_json_response(self, 400, "Invalid URL")
             return
 
-        if not rest_params["api_version"]:
-            web_util.echo_json_response(self, 400, "API Version not supported")
+        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
             return
 
         allowlist_name = rest_params['allowlists']

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -63,8 +63,7 @@ class ProtectedHandler(BaseHTTPRequestHandler, SessionManager):
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
-        if not rest_params["api_version"]:
-            web_util.echo_json_response(self, 400, "API Version not supported")
+        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
             return
 
         if "agents" not in rest_params:
@@ -146,8 +145,7 @@ class ProtectedHandler(BaseHTTPRequestHandler, SessionManager):
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
-        if not rest_params["api_version"]:
-            web_util.echo_json_response(self, 400, "API Version not supported")
+        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
             return
 
         if "agents" not in rest_params:
@@ -232,8 +230,7 @@ class UnprotectedHandler(BaseHTTPRequestHandler, SessionManager):
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
-        if not rest_params["api_version"]:
-            web_util.echo_json_response(self, 400, "API Version not supported")
+        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
             return
 
         if "agents" not in rest_params:
@@ -419,8 +416,7 @@ class UnprotectedHandler(BaseHTTPRequestHandler, SessionManager):
                 self, 405, "Not Implemented: Use /agents/ interface")
             return
 
-        if not rest_params["api_version"]:
-            web_util.echo_json_response(self, 400, "API Version not supported")
+        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
             return
 
         if "agents" not in rest_params:

--- a/keylime/web_util.py
+++ b/keylime/web_util.py
@@ -190,6 +190,16 @@ def get_restful_params(urlstring):
     return path_params
 
 
+def validate_api_version(handler, version, logger):
+    if not version or not keylime_api_version.is_supported_version(version):
+        echo_json_response(handler, 400, "API Version not supported")
+        return False
+
+    if keylime_api_version.is_deprecated_version(version):
+        logger.warning('Client request to API version %s is deprecated and will be removed in future versions.', version)
+    return True
+
+
 def _list_to_dict(alist):
     """Convert list into dictionary via grouping [k0,v0,k1,v1,...]"""
     params = {}


### PR DESCRIPTION
Adding new capability to mark API versions as "deprecated" which will
be displayed when verifier and registrar start and a warning is issued
anytime a client (agent or tenant) uses a deprecated API.

This will allow us to mark APIs as deprecated before they are fully removed.

Signed-off-by: Michael Peters <mpeters@redhat.com>