### PR TITLE
Bump required packaging module version to 20.0

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -4,7 +4,9 @@
 
   prepare:
     how: shell
-    script: bash -c 'ln -s $(pwd) /var/tmp/keylime_sources'
+    script:
+     - rm -f /etc/yum.repos.d/tag-repository.repo
+     - ln -s $(pwd) /var/tmp/keylime_sources
 
   discover:
     how: fmf
@@ -27,15 +29,13 @@
 
   adjust:
    # prepare step adjustments
-   - prepare:
-       script:
-        - bash -c 'ln -s $(pwd) /var/tmp/keylime_sources'
+   - prepare+:
+       script+:
         - yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
      when: distro == centos-stream-9
 
-   - prepare:
-       script:
-        - bash -c 'ln -s $(pwd) /var/tmp/keylime_sources'
+   - prepare+:
+       script+:
         - yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
      when: distro == centos-stream-8
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ requests>=2.6 # Apache-2.0
 sqlalchemy>=1.3 # MIT
 alembic>=1.1.0 # MIT
 python-gnupg>=0.4.6 # BSD
-packaging>=16.0 #BSD
+packaging>=20.0 #BSD
 psutil>=5.4.2 # BSD


### PR DESCRIPTION
We are already consuming attributes such as 'minor'
and 'major' introduced by this version in api_version.py.

Signed-off-by: Karel Srot <ksrot@redhat.com>