### PR TITLE
remove REQUIRE_ROOT environment option

### DIFF
--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -524,9 +524,10 @@ def main(argv=sys.argv):  #pylint: disable=dangerous-default-value
     args = parser.parse_args(argv[1:])
 
     if args.dir is None:
-        if os.getuid() != 0 and config.REQUIRE_ROOT:
+        if not os.access(config.WORK_DIR, os.R_OK + os.W_OK):
             logger.error(
-                "If you don't specify a working directory, this process must be run as root to access %s", config.WORK_DIR)
+                "If you don't specify a working directory, this process must be run as a user with access to %s",
+                config.WORK_DIR)
             sys.exit(-1)
         workingdir = config.CA_WORK_DIR
     else:

--- a/keylime/config.py
+++ b/keylime/config.py
@@ -48,34 +48,28 @@ def environ_bool(env_name, default):
         f"{val} (use either on/true/1 or off/false/0)")
 
 
-# set to False to enable keylime to run from the CWD and not require
-# root access.  for testing purposes only
-# all processes will log to the CWD in keylime-all.log
-REQUIRE_ROOT = environ_bool('KEYLIME_REQUIRE_ROOT', True)
-
 # enable printing of keys and other info for debug purposes
 INSECURE_DEBUG = False
 
 # allow the emuatlor to not have an ekcert even if check ekcert is true
 DISABLE_EK_CERT_CHECK_EMULATOR = False
 
-# allow testing mode
-TEST_MODE = os.getenv('KEYLIME_TEST', 'False')
-if TEST_MODE.upper() == 'TRUE':
-    print("WARNING: running keylime in testing mode.\nkeylime will not run as root and ekcert checking for the TPM emulator is disabled")
-    REQUIRE_ROOT = False
-    DISABLE_EK_CERT_CHECK_EMULATOR = True
-
 # whether to use tpmfs or not
 MOUNT_SECURE = True
 
+DEFAULT_WORK_DIR = '/var/lib/keylime'
+WORK_DIR = os.getenv('KEYLIME_DIR', DEFAULT_WORK_DIR)
 
-if not REQUIRE_ROOT:
+# allow testing mode
+TEST_MODE = environ_bool('KEYLIME_TEST', False)
+if TEST_MODE:
+    print("WARNING: running keylime in testing mode.\nKeylime will:\n"
+          "- Not check the ekcert for the TPM emulator\n"
+          "- Not create a secure mount\n"
+          "- Change the KEYLIME_DIR to CWD")
+    DISABLE_EK_CERT_CHECK_EMULATOR = True
     MOUNT_SECURE = False
-
-if not REQUIRE_ROOT:
-    print("WARNING: running without root access")
-
+    WORK_DIR = os.getcwd()
 
 # Config files can be merged together, reading from the system to the
 # user.
@@ -116,12 +110,6 @@ getint = get_config().getint
 getboolean = get_config().getboolean
 getfloat = get_config().getfloat
 has_option = get_config().has_option
-
-if not REQUIRE_ROOT:
-    DEFAULT_WORK_DIR = os.path.abspath(".")
-else:
-    DEFAULT_WORK_DIR = '/var/lib/keylime'
-WORK_DIR = os.getenv('KEYLIME_DIR', DEFAULT_WORK_DIR)
 
 CA_WORK_DIR = f'{WORK_DIR}/ca/'
 

--- a/keylime/keylime_logging.py
+++ b/keylime/keylime_logging.py
@@ -16,10 +16,7 @@ LOG_TO_FILE = ['registrar', 'provider_registrar', 'cloudverifier']
 LOG_TO_STREAM = ['tenant_webapp']
 LOGDIR = os.getenv('KEYLIME_LOGDIR', '/var/log/keylime')
 # not clear that this works right.  console logging may not work
-if not config.REQUIRE_ROOT:
-    LOGSTREAM = './keylime-stream.log'
-else:
-    LOGSTREAM = LOGDIR + '/keylime-stream.log'
+LOGSTREAM = os.path.join(LOGDIR, 'keylime-stream.log')
 
 logging_config.fileConfig(config.get_config())
 

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -105,8 +105,6 @@ class Tenant():
         self.registrar_ip = config.get('tenant', 'registrar_ip')
         self.registrar_port = config.get('tenant', 'registrar_port')
         self.webapp_port = config.getint('webapp', 'webapp_port')
-        if not config.REQUIRE_ROOT and self.webapp_port < 1024:
-            self.webapp_port += 2000
         self.webapp_ip = config.get('webapp', 'webapp_ip')
 
         self.api_version = keylime_api_version.current_version()

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -693,10 +693,6 @@ def main():
 
     webapp_port = config.getint('webapp', 'webapp_port')
 
-    if not config.REQUIRE_ROOT and webapp_port < 1024:
-        webapp_port += 2000
-        logger.warning("Running without root, changing port to %d", webapp_port)
-
     logger.info('Starting Tenant WebApp (tornado) on port %d use <Ctrl-C> to stop', webapp_port)
 
     # Figure out where our static files are located

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -134,8 +134,6 @@ class AbstractTPM(metaclass=ABCMeta):
             return {}
 
     def __write_tpm_data(self):
-        if os.geteuid() != 0 and config.REQUIRE_ROOT:
-            logger.warning("Creating tpm metadata file without root. Sensitive trust roots may be at risk!")
         with os.fdopen(os.open("tpmdata.yml", os.O_WRONLY | os.O_CREAT, 0o600), "w", encoding="utf-8") as f:
             yaml.dump(self.global_tpmdata, f, Dumper=SafeDumper)
 

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -88,8 +88,8 @@ def cmp(a, b):
 
 
 # Ensure this is run as root
-if os.geteuid() != 0 and config.REQUIRE_ROOT:
-    sys.exit("Tests need to be run with root privileges, or set env KEYLIME_TEST=True!")
+if os.geteuid() != 0:
+    sys.exit("Tests need to be run with root privileges")
 
 # Force sorting tests alphabetically
 unittest.TestLoader.sortTestMethodsUsing = lambda _, x, y: cmp(x, y)


### PR DESCRIPTION
Keylime no longer requires to be run as root (except the agent on startup).
The KEYLIME_TEST option is extended to disable tmpfs and change the WORK_DIR to CWD.

