### PR TITLE
config, webapp: remove tls_check_hostnames option

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -5,9 +5,6 @@
 # Turn on or off TLS Keylime wide.
 enable_tls = True
 
-# Turn on or off DNS hostname checking for TLS certificates.
-tls_check_hostnames = False
-
 # Set which provider you want for the generation of certificates.
 # Valid values are "cfssl" or "openssl". For cfssl to work, you must have the
 # go binary installed in your path or in /usr/local/.

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -669,8 +669,7 @@ def get_tls_context():
     context.load_cert_chain(
         certfile=my_tls_cert, keyfile=my_tls_priv_key)
     context.verify_mode = ssl.CERT_REQUIRED
-    context.check_hostname = config.getboolean(
-        'general', 'tls_check_hostnames')
+    context.check_hostname = False
     return context
 
 
@@ -704,7 +703,6 @@ def main():
 
     # WebApp Server TLS
     server_context = get_tls_context()
-    server_context.check_hostname = False  # config.getboolean('general', 'tls_check_hostnames')
     server_context.verify_mode = ssl.CERT_NONE  # ssl.CERT_REQUIRED
 
     # Set up server


### PR DESCRIPTION
This was only used in the tenant webapp code, but not used. No other part of Keylime uses it, so we remove the tls_check_hostnames from the general section of the keylime.conf

