### PR TITLE
ci: only run CodeQL on the keylime directory and disable it for the webapp

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,4 @@
+paths:
+  - keylime
+paths-ignore:
+  - keylime/tenant_webapp.py # The webapp is currently mostly unused and introduces too much false positives

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
+        config-file: ./.github/codeql-config.yml
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.


### PR DESCRIPTION
The webapp is responsible for most of the warning which are false positives.