### PR TITLE
Defer loading PyZMQ to avoid optional dependency

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -49,3 +49,40 @@
 
   execute:
     how: tmt
+
+/e2e-without-revocation:
+
+  summary: run keylime e2e tests without revocation support
+
+  environment:
+    KEYLIME_TEST_DISABLE_REVOCATION: 1
+
+  prepare:
+    how: shell
+    script:
+     - rm -f /etc/yum.repos.d/tag-repository.repo
+     - ln -s $(pwd) /var/tmp/keylime_sources
+
+  discover:
+    how: fmf
+    url: https://github.com/RedHat-SP-Security/keylime-tests
+    ref: main
+    test:
+     - /setup/configure_tpm_emulator
+     - /setup/install_upstream_keylime
+     - "/functional/basic-attestation.*"
+
+  adjust:
+   # prepare step adjustments
+   - prepare+:
+       script+:
+        - yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+     when: distro == centos-stream-9
+
+   - prepare+:
+       script+:
+        - yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+     when: distro == centos-stream-8
+
+  execute:
+    how: tmt


### PR DESCRIPTION
Importing the Python module zmq brings in quite a few system
dependencies through libzmq, including cryptographic libraries, while
the revocation notification feature in Keylime is not always desired.
This patch changes the top-level import of zmq to local imports at the
actual usage.

Signed-off-by: Daiki Ueno <dueno@redhat.com>