### PR TITLE
Unify log messages about deleting agent from CV

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -827,7 +827,7 @@ class Tenant():
                     break
                 time.sleep(.4)
             if deleted:
-                logger.info("CV completed deletion of agent %s", self.agent_uuid)
+                logger.info("Agent %s deleted from the CV", self.agent_uuid)
                 return response.json()
             logger.error("Timed out waiting for delete of agent %s to complete at CV", self.agent_uuid)
             return response.json()


### PR DESCRIPTION
Unify log messages to make log parsing a bit easier.

Signed-off-by: Karel Srot <ksrot@redhat.com>