### PR TITLE
Refactor allowlist reading/sending to enable verifier-side signature checks

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -107,9 +107,9 @@ revocation_actions=
 payload_script=autorun.sh
 
 # In case mTLS for the agent is disabled and the use of payloads is still
-# required, this option has to be set to "True" in order to allow the agent 
+# required, this option has to be set to "True" in order to allow the agent
 # to start. Details on why this configuration (mTLS disabled and payload enabled)
-# is generally considered insecure can be found on 
+# is generally considered insecure can be found on
 # https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
 enable_insecure_payload = False
 
@@ -326,6 +326,11 @@ severity_policy = [{"event_id": ".*", "severity_label": "emergency"}]
 # By default we ignore those entries and only print a warning.
 # Set to True to treat ToMToU entries as errors.
 tomtou_errors = False
+
+# If enabled, the Keylime verifier will require that a file signature and
+# associated key be sent alongside newly-created allowlists, and will perform a
+# signature check before storing them in the database.
+require_allow_list_signatures = False
 
 #=============================================================================
 [tenant]

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -186,19 +186,12 @@ class Tenant:
             # Auto-enable IMA (or-bit mask)
             self.tpm_policy["mask"] = hex(int(self.tpm_policy["mask"], 0) | (1 << config.IMA_PCR))
 
-            if isinstance(args["allowlist"], str):
-                if args["allowlist"] == "default":
-                    args["allowlist"] = config.get("tenant", "allowlist")
-                try:
-                    al_data = ima.read_allowlist(
-                        args["allowlist"], args["allowlist_checksum"], args["allowlist_sig"], args["allowlist_sig_key"]
-                    )
-                except Exception as ima_e:
-                    raise UserError(str(ima_e)) from ima_e
-            elif isinstance(args["allowlist"], list):
-                al_data = args["allowlist"]
-            else:
-                raise UserError("Invalid allowlist provided")
+            try:
+                al_data = ima.read_allowlist(
+                    args["allowlist"], args["allowlist_checksum"], args["allowlist_sig"], args["allowlist_sig_key"]
+                )
+            except Exception as ima_e:
+                raise UserError(str(ima_e)) from ima_e
 
         # Read command-line path string IMA exclude list
         excl_data = None
@@ -215,7 +208,8 @@ class Tenant:
         # Set up IMA
         if TPM_Utilities.check_mask(self.tpm_policy["mask"], config.IMA_PCR):
             # Process allowlists
-            self.allowlist = ima.process_allowlists(al_data, excl_data)
+            al_data["excllist"] = excl_data
+            self.allowlist = al_data
 
         # Read command-line path string TPM event log (measured boot) reference state
         mb_refstate_data = None
@@ -632,7 +626,7 @@ class Tenant:
             "cloudagent_ip": self.cv_cloudagent_ip,
             "cloudagent_port": self.agent_port,
             "tpm_policy": json.dumps(self.tpm_policy),
-            "allowlist": json.dumps(self.allowlist),
+            "ima_policy_bundle": json.dumps(self.allowlist),
             "mb_refstate": json.dumps(self.mb_refstate),
             "ima_sign_verification_keys": json.dumps(self.ima_sign_verification_keys),
             "metadata": json.dumps(self.metadata),


### PR DESCRIPTION
This PR refactors how allowlists are read and processed by the tenant and verifier, enabling verifier-side signature checks.

Now, instead of all allowlist processing being done tenant-side, the tenant sends the raw allowlist artifact along with any provided validation artifacts (checksum, signature, signing key) as a bundle to the verifier. (Note that the existing tenant-side signature check is preserved.)

The verifier will then unbundle everything and perform its own signature validation step before performing the final processing step and storing the formatted allowlist in the database as before.

This enhances security by thwarting compromised tenant attacks - prior to this, Keylime's security model relied on a trusted tenant; however, if a malicious tenant sent a bad payload (ex. one that did not pass signature checks), the verifier would blindly accept it. The new verifier-side signature check makes this attack impossible.

Verifier-side signature validation can be controlled via a new configuration option in `keylime.conf`. By default, signatures are not enforced, but setting `enforce_allow_list_signatures` to `True` will require that check.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>