### PR TITLE
List tests in Packit-CI plan explicitly

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -1,4 +1,4 @@
-/e2e:
+/e2e-with-revocation:
 
   summary: run keylime e2e tests
 
@@ -71,7 +71,9 @@
     test:
      - /setup/configure_tpm_emulator
      - /setup/install_upstream_keylime
-     - "/functional/basic-attestation.*"
+     - /functional/basic-attestation-on-localhost
+     - /functional/basic-attestation-without-mtls
+     - /functional/basic-attestation-with-unpriviledged-agent
 
   adjust:
    # prepare step adjustments


### PR DESCRIPTION
By using regular expressions we are pulling in tests that are not
intended to run in CI environment.
Also, rename a test plan to ease pattern matching.

Signed-off-by: Karel Srot <ksrot@redhat.com>