### PR TITLE
Fixes #996, by properly catching exceptions resulting from network   problems on the verifier.

### DIFF
--- a/keylime/tornado_requests.py
+++ b/keylime/tornado_requests.py
@@ -45,6 +45,8 @@ async def request(method, url, params=None, data=None, context=None, headers=Non
         return TornadoResponse(599, f"Connection error: {str(e)}")
     except ssl.SSLError as e:
         return TornadoResponse(599, f"SSL connection error: {str(e)}")
+    except OSError as e:
+        return TornadoResponse(599, f"TCP/IP Connection error: {str(e)}")
     if response is None:
         return None
     return TornadoResponse(response.code, response.body)


### PR DESCRIPTION
Assume that "OS Error" will be related to lack of network connectivity
(" No route to host") catch it, and return it as a TornadoResponse

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>