### PR TITLE
ima_dm: enable support for dm_target_update events

### DIFF
--- a/keylime/ima/ima_dm.py
+++ b/keylime/ima/ima_dm.py
@@ -61,7 +61,14 @@ class DeviceState:
 
 
 class DmIMAValidator:
-    valid_names = ["dm_table_load", "dm_device_resume", "dm_device_remove", "dm_table_clear", "dm_device_rename"]
+    valid_names = [
+        "dm_table_load",
+        "dm_device_resume",
+        "dm_device_remove",
+        "dm_table_clear",
+        "dm_device_rename",
+        "dm_target_update",
+    ]
     policies: dict
     devices: Dict[str, DeviceState]
 


### PR DESCRIPTION
This event is currently not supported in upstream kernels, but we already have
experimental support for it. Adding it to the list of valid names enables full
support for this event.

