### PR TITLE
Simplify GitHub Actions used for code coverage processing

### DIFF
--- a/.github/workflows/submit-HEAD-coverage.yaml
+++ b/.github/workflows/submit-HEAD-coverage.yaml
@@ -7,15 +7,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Submit code coverage from merged PR
-    defaults:
-      run:
-        working-directory: scripts
     steps:
     - uses: actions/checkout@v3
+    - name: Install testing-farm script
+      run: pip3 -v install tft-cli
+    - name: Run tests on Testing Farm
+      run: testing-farm request --context distro=fedora-35 --arch x86_64 --compose Fedora-35 --plan '/e2e-with-revocation' -e UPLOAD_COVERAGE=1 2>&1 | tee tt_output
+      env:
+        TESTING_FARM_API_TOKEN: ${{ secrets.TESTING_FARM_API_TOKEN }}
     - name: Find PR Packit tests to finish and download coverage.xml file
-      run: ./download_packit_coverage.sh ${{ github.event.pull_request.head.sha }} || exit 0
+      run: grep -q 'tests passed' tt_output && sleep 10 && scripts/download_packit_coverage.sh --testing-farm-log tt_output
       env:
         MAX_DURATION: 120
         SLEEP_DELAY: 20

--- a/.github/workflows/submit-PR-coverage.yaml
+++ b/.github/workflows/submit-PR-coverage.yaml
@@ -12,12 +12,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Wait for Packit tests to finish and download coverage.xml file
-      run: ./download_packit_coverage.sh ${{ github.event.pull_request.head.sha }}
+      run: ./download_packit_coverage.sh
       env:
         MAX_DURATION: 5400
         SLEEP_DELAY: 120
     - name: List downloaded files
-      run: ls
+      run: ls coverage*
     - name: Upload coverage.unittests.xml report to Codecov with GitHub Action
       uses: codecov/codecov-action@v2
       with:

--- a/scripts/download_packit_coverage.sh
+++ b/scripts/download_packit_coverage.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 
+# There are 3 options how to tell this script where to start
+# --artifacts-url - Testing Farm artifacts URL, provided by testing-farm script
+# --testing-farm-log - Log of 'testing-farm request' command from where artifacts URL will be parsed
+# --github-sha - PR merge commit provided by GitHub, here we will try to get artifacts URL using GitHub API
+
+if [ "$1" == "--artifacts-url" -a -n "$2" ]; then
+    TF_ARTIFACTS_URL="$2"
+elif [ "$1" == "--testing-farm-log" -a -n "$2" ]; then
+    TT_LOG="$2"
+elif [ "$1" == "--github-sha" -a -n "$2" ]; then
+    GITHUB_SHA="$2"
+elif [ -n "$GITHUB_SHA" ]; then
+    :
+else
+    echo "Neither --github-sha nor --artifacts-url nor --testing-farm-log arguments were provided"
+    exit 1
+fi
+
 ##############################################
 # initial configuration, adjust when necessary
 ##############################################
@@ -11,55 +29,30 @@ MAX_DURATION="${MAX_DURATION:-5400}"  # 90 minutes
 # should not be too short not to exceed GitHub API quota
 SLEEP_DELAY="${SLEEP_DELAY:-120}"
 
+# github user/project we are going to work with
+PROJECT="keylime/keylime"
+#PROJECT="keylimecov/keylime"
+
 # TF_JOB_DESC points to a Testing farm job that does code coverage measurement and 
 # uploads coverage XML files to a web drive
 # currently we are doing that in a job running tests on Fedora-35
 TF_JOB_DESC="testing-farm:fedora-35-x86_64"
-
-# TF_TEST_OUTPUT points to a file with test output containing URLs to a web drive
-# we are going to parse the output to get those URL and download coverage XML files
 TF_TEST_OUTPUT="/setup/generate_coverage_report/output.txt"
+TF_ARTIFACTS_URL_PREFIX="https://artifacts.dev.testing-farm.io"
 
-# TF_ARTIFACTS_URL is URL prefix of Testing farm test artifacts
-TF_ARTIFACTS_URL="https://artifacts.dev.testing-farm.io"
+GITHUB_API_PREFIX_URL="https://api.github.com/repos/${PROJECT}"
 
-# WEBDRIVE_URL points to a web page that stores coverage XML files
-WEBDRIVE_URL="https://transfer.sh"
+WEBDRIVE_URL="https://(transfer.sh|free.keep.sh)"
 
 ##################################
 # no need to change anything below
 ##################################
 
-# COMMIT is necessary so we can access the GITHUB API URL to read check runs status
-if [ -z "$GITHUB_SHA" -a -z "$1" ]; then
-  echo "Commit SHA is required as an argument or in GITHUB_SHA environment variable"
-  exit 1
-fi
-COMMIT="${GITHUB_SHA}"
-[ -n "$1" ] && COMMIT="$1"
-echo "COMMIT=${COMMIT}"
-
-# github project is also necessary so we can build API URL
-if [ -z "${GITHUB_REPOSITORY}" -a -z "$2" ]; then
-  echo "GitHub repository name USER/PROJECT is required as an argument or in GITHUB_REPOSITORY environment variable"
-  exit 1
-fi
-PROJECT="${GITHUB_REPOSITORY}"
-[ -n "$2" ] && PROJECT="$2"
-echo "PROJECT=${PROJECT}"
-
 # build GITHUB_API_URLs
-GITHUB_API_PREFIX_URL="https://api.github.com/repos/${PROJECT}"
 GITHUB_API_COMMIT_URL="${GITHUB_API_PREFIX_URL}/commits"
-
-# meassure approx. task duration
 DURATION=0
 
 TMPFILE=$( mktemp )
-
-####################################
-# some functions we are going to use
-####################################
 
 # run API call and parse the required value
 # repeat until we get the value or exceed job duration
@@ -98,128 +91,59 @@ function do_GitHub_API_call() {
     echo $VALUE
 }
 
-######################################
-# now start with the actual processing
-######################################
 
-# First we need to check if we are processing PR or a merged commit
-# let's try to find some open PRs
+# if the GitHub Action has been triggered by a PR, 
+# we need to find Testing farm test results through GitHub API
+if [ -n "${GITHUB_SHA}" -a -z "${TF_ARTIFACTS_URL}" -a -z "${TT_LOG}" ]; then
 
-# On GitHub commit always changes when doing rebase and merge
-# and therefore commit differs between the PR branch and master branch
-# Here we try to find the commit from PR branch since this is the commit
-# for which tests have been run.
+    echo "Trying to find Testing Farm / Packig CI test results using GitHub API"
 
-OPEN_PULLS=$( mktemp )
-do_GitHub_API_call "${GITHUB_API_PREFIX_URL}/pulls" \
-                   '.[] | .head.sha, .base.sha, .url, .head.repo.full_name' \
-| tr ' ' '\n' > ${OPEN_PULLS}
+    echo "Fist I need to find the respective PR commit"
+    GITHUB_API_SHA_URL="${GITHUB_API_COMMIT_URL}/${GITHUB_SHA}"
 
-if grep -q ${COMMIT} ${OPEN_PULLS}; then
-    # we are processing PR.
-    echo "We are processing PR"
-    PR_HEAD_COMMIT=${COMMIT}
-    PR_BASE_COMMIT=$( grep -A 1 "${COMMIT}" ${OPEN_PULLS} | tail -1 )
-    GITHUB_API_PR_URL=$( grep -A 2 "${COMMIT}" ${OPEN_PULLS} | tail -1 )
-    PR_PROJECT=$( grep -A 3 "${COMMIT}" ${OPEN_PULLS} | tail -1 )
-else
-    # we are processing merged commit
-    echo "We are processing merged commit"
-    GITHUB_API_PR_URL="${GITHUB_API_COMMIT_URL}/${COMMIT}/pulls"
-    PR_HEAD_COMMIT=$( do_GitHub_API_call "${GITHUB_API_PR_URL}" \
-                                         ".[0].head.sha" \
-                                         "Failed to get PR HEAD commit from ${GITHUB_API_PR_URL}, trying again after ${SLEEP_DELAY} seconds..." )
+    # Now we try to parse URL of Testing farm job from GITHUB_API_RUNS_URL page
+    GITHUB_PR_SHA=$( do_GitHub_API_call "${GITHUB_API_SHA_URL}" \
+                                     ".parents[1].sha" \
+                                     "Failed to parse PR commit from ${GITHUB_API_RUNS_URL}, trying again after ${SLEEP_DELAY} seconds..." )
+    echo "GITHUB_PR_SHA=${GITHUB_PR_SHA}"
 
-    PR_PROJECT=$( do_GitHub_API_call "-" \
-                                     ".[0].head.repo.full_name" \
-                                     "Failed to get PR HEAD repo name from ${GITHUB_API_PR_URL}, trying again after ${SLEEP_DELAY} seconds..." )
+    echo "Now we read check-runs details"
+    # build GITHUB_API_RUNS_URL using the COMMIT
+    GITHUB_API_RUNS_URL="${GITHUB_API_COMMIT_URL}/${GITHUB_PR_SHA}/check-runs?check_name=${TF_JOB_DESC}"
+    echo "GITHUB_API_RUNS_URL=${GITHUB_API_RUNS_URL}"
 
-    PR_BASE_COMMIT=$( do_GitHub_API_call "-" \
-                                         ".[0].base.sha" )
-fi
+    # Now we try to parse URL of Testing farm job from GITHUB_API_RUNS_URL page
+    TF_ARTIFACTS_URL=$( do_GitHub_API_call "${GITHUB_API_RUNS_URL}" \
+                                     ".check_runs[0] | .output.summary | match(\"${TF_ARTIFACTS_URL_PREFIX}[^ ]*\") | .string" \
+                                     "Failed to parse Testing Farm job ${TF_JOB_DESC} URL from ${GITHUB_API_RUNS_URL}, trying again after ${SLEEP_DELAY} seconds..." )
+    echo "TF_ARTIFACTS_URL=${TF_ARTIFACTS_URL}"
 
-echo "GITHUB_API_PR_URL=${GITHUB_API_PR_URL}"
-echo "PR_HEAD_COMMIT=${PR_HEAD_COMMIT}"
-echo "PR_PROJECT=${PR_PROJECT}"
-echo "PR_BASE_COMMIT=${PR_BASE_COMMIT}"
-
-
-# now if PR_HEAD_COMMIT and COMMIT differ, it means we are processing merge to master branch
-# in this case we can use PR code coverage only if the parent and base commit are equal,
-# i.e. there were no other commits added to master branch in the meantime
-if [ "${PR_HEAD_COMMIT}" != "${COMMIT}" ]; then
-
-    echo "Provided commit ${COMMIT} differs from PR commit ${PR_HEAD_COMMIT}"
-    echo "Need to verify that there were no other change merged in the mean time"
-    echo "and point to the original PR project and commit"
-
-    # now we need to check that there were no other changes merged, otherwise
-    # code coverage data would be outdated and we should not use them
-    # we do that by checking that all commits between PR HEAD and base refer to the same PR
-    TMP_COMMIT=${COMMIT}
-    PR_LIST=$( mktemp )
-    while [ "$TMP_COMMIT" != "${PR_BASE_COMMIT}" ]; do
-        PR=$( do_GitHub_API_call "${GITHUB_API_COMMIT_URL}/${TMP_COMMIT}/pulls" \
-                                 '.[0].url' \
-                                 "Cannot get PR URL for commit ${TMP_COMMIT} from ${GITHUB_API_COMMIT_URL}/${TMP_COMMIT}/pulls, trying again in ${SLEEP_DELAY} seconds..." )
-        echo ${PR} >> ${PR_LIST}
-        # now move to the parent commit
-        TMP_COMMIT=$( do_GitHub_API_call "${GITHUB_API_COMMIT_URL}/${TMP_COMMIT}" \
-                                 ' .parents[0].sha ' \
-                                 "Cannot get parent commit for commit ${TMP_COMMIT} from ${GITHUB_API_COMMIT_URL}/${TMP_COMMIT}, trying again in ${SLEEP_DELAY} seconds..." )
-    done
-
-    echo "PRs merged since commit ${COMMIT} PR base ${PR_BASE_COMMIT}:"
-    cat ${PR_LIST}
-    # now check the list to confirm there is just a single PR listed
-    if [ $( sort ${PR_LIST} | wc -l ) -gt 1 ]; then
-        echo "Error: There were other PR's merged in the mean time, coverage data cannot be re-used"
-        exit 5
-    fi
-    rm ${PR_LIST}
+    # now we wait for the Testing farm job to finish
+    TF_STATUS=$( do_GitHub_API_call "${GITHUB_API_RUNS_URL}" \
+                                    '.check_runs[0] | .status' \
+                                    "Testing Farm job ${TF_JOB_DESC} hasn't completed yet, trying again after ${SLEEP_DELAY} seconds..." \
+                                    "completed" )
+    echo "TF_STATUS=${TF_STATUS}"
 
 fi
 
-# build GITHUB_API_RUNS_URL using the COMMIT
-GITHUB_API_RUNS_URL="${GITHUB_API_COMMIT_URL}/${PR_HEAD_COMMIT}/check-runs?check_name=${TF_JOB_DESC}"
-echo "GITHUB_API_RUNS_URL=${GITHUB_API_RUNS_URL}"
-
-# Now we try to parse URL of Testing farm job from GITHUB_API_RUNS_URL page
-TF_BASEURL=$( do_GitHub_API_call "${GITHUB_API_RUNS_URL}" \
-                                 ".check_runs[0] | .output.summary | match(\"${TF_ARTIFACTS_URL}/[^ ]*\") | .string" \
-                                 "Failed to parse Testing Farm job ${TF_JOB_DESC} URL from ${GITHUB_API_RUNS_URL}, trying again after ${SLEEP_DELAY} seconds..." )
-echo "TF_BASEURL=${TF_BASEURL}"
-
-# now we wait for the Testing farm job to finish
-TF_STATUS=$( do_GitHub_API_call "${GITHUB_API_RUNS_URL}" \
-                                 '.check_runs[0] | .status' \
-                                 "Testing Farm job ${TF_JOB_DESC} hasn't completed yet, trying again after ${SLEEP_DELAY} seconds..." \
-                                 "completed" )
-echo "TF_STATUS=${TF_STATUS}"
-                                
-# check test results - we won't proceed if test failed since coverage data may be incomplete,
-# see https://docs.codecov.com/docs/comparing-commits#commits-with-failed-ci
-TF_RESULT=$( do_GitHub_API_call "-" \
-                                '.check_runs[0] | .conclusion' \
-                                "Cannot get Testing Farm job ${TF_JOB_DESC} result, trying again after ${SLEEP_DELAY} seconds..." )
-echo TF_RESULT=${TF_RESULT}
-
-if [ "${TF_RESULT}" != "success" ]; then
-    echo "Testing Farm tests failed, we won't be uploading coverage data since they may be incomplete"
-    exit 3
+# if we were provided with testing-farm command log
+# we will parse artifacts from the log
+if [ -n "${TT_LOG}" ]; then
+    cat ${TT_LOG}
+    TF_ARTIFACTS_URL=$( egrep -o "${TF_ARTIFACTS_URL_PREFIX}[^ ]*" ${TT_LOG} )
 fi
 
-# wait a bit since there could be some timing issue
-sleep 10
+# now we have TF_ARTIFACTS_URL so we can proceed with the download
+echo "TF_ARTIFACTS_URL=${TF_ARTIFACTS_URL}"
 
-# now we read the actual test log URL
-TF_TESTLOG=$( curl -s ${TF_BASEURL}/results.xml | egrep -o "${TF_ARTIFACTS_URL}.*${TF_TEST_OUTPUT}" )
+TF_TESTLOG=$( curl -s ${TF_ARTIFACTS_URL}/results.xml | egrep -o "${TF_ARTIFACTS_URL}.*${TF_TEST_OUTPUT}" )
 echo "TF_TESTLOG=${TF_TESTLOG}"
 
 # parse the URL of coverage XML file on WEBDRIVE_URL and download it
 curl -s "${TF_TESTLOG}" &> ${TMPFILE}
 for REPORT in coverage.packit.xml coverage.testsuite.xml coverage.unittests.xml; do
-    COVERAGE_URL=$( grep "$REPORT report is available at" ${TMPFILE} | grep -o "${WEBDRIVE_URL}.*\.xml" )
+    COVERAGE_URL=$( grep "$REPORT report is available at" ${TMPFILE} | egrep -o "${WEBDRIVE_URL}.*\.xml" )
     echo "COVERAGE_URL=${COVERAGE_URL}"
 
     if [ -z "${COVERAGE_URL}" ]; then
@@ -228,6 +152,6 @@ for REPORT in coverage.packit.xml coverage.testsuite.xml coverage.unittests.xml;
     fi
 
     # download the file
-    curl -O ${COVERAGE_URL}
+    curl -L -O ${COVERAGE_URL}
 done
 rm ${TMPFILE}


### PR DESCRIPTION
Requires configured GitHub secrect TESTING_FARM_API_TOKEN
Run test job again for a merged pull-request directly through Testing Farm.
This would ensure that there is a baseline for all pull-requests and make
overall code coverage report creation more stable.
Additionally, due to this new approach dowload_packit_coverage.sh was
simplified significantly.

Signed-off-by: Karel Srot <ksrot@redhat.com>