### PR TITLE
elchecking: error if policy name is invalid, change default to reject-all

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -30,6 +30,7 @@ from keylime.agentstates import AgentAttestStates
 from keylime.common import retry, states, validators
 from keylime.db.keylime_db import DBEngineManager, SessionManager
 from keylime.db.verifier_db import VerfierMain, VerifierAllowlist
+from keylime.elchecking import policies
 from keylime.failure import MAX_SEVERITY_LABEL, Component, Failure
 
 logger = keylime_logging.init_logging("cloudverifier")
@@ -1056,6 +1057,11 @@ def main():
     cloudverifier_id = config.get(
         "cloud_verifier", "cloudverifier_id", fallback=cloud_verifier_common.DEFAULT_VERIFIER_ID
     )
+
+    # Check if measured boot was configured correctly
+    if policies.get_policy(config.MEASUREDBOOT_POLICYNAME) is None:
+        logger.error('Measued boot policy "%s" could not be found!', config.MEASUREDBOOT_POLICYNAME)
+        raise Exception(f'Measued boot policy "{config.MEASUREDBOOT_POLICYNAME}" could not be found!')
 
     # allow tornado's max upload size to be configurable
     max_upload_size = None

--- a/keylime/elchecking/policies.py
+++ b/keylime/elchecking/policies.py
@@ -48,6 +48,16 @@ class AcceptAll(Policy):
         return tests.AcceptAll()
 
 
+class RejectAll(Policy):
+    """Policy that rejects all eventlogs"""
+
+    def get_relevant_pcrs(self) -> typing.FrozenSet[int]:
+        return set()
+
+    def refstate_to_test(self, refstate: RefState) -> tests.Test:
+        return tests.RejectAll("reject all")
+
+
 def _mkreg() -> typing.Mapping[str, Policy]:
     return {}
 
@@ -61,6 +71,7 @@ def register(name: str, policy: Policy):
 
 
 register("accept-all", AcceptAll())
+register("reject-all", RejectAll())
 
 
 def get_policy_names() -> typing.Tuple[str, ...]:

--- a/keylime/measured_boot.py
+++ b/keylime/measured_boot.py
@@ -51,10 +51,11 @@ def get_policy(mb_refstate_str):
 
         # pylint: enable=import-outside-toplevel
         mb_policy = eventlog_policies.get_policy(mb_policy_name)
+        # Should not happen in the verifier because we check on startup if the policy exists
         if mb_policy is None:
-            logger.warning("Invalid measured boot policy name %s -- using accept-all instead.", mb_policy_name)
-            mb_policy_name = "accept-all"
-            mb_policy = eventlog_policies.AcceptAll()
+            logger.warning("Invalid measured boot policy name %s -- using reject-all instead.", mb_policy_name)
+            mb_policy_name = "reject-all"
+            mb_policy = eventlog_policies.RejectAll()
 
         mb_pcrs_config = frozenset(config.MEASUREDBOOT_PCRS)
         mb_pcrs_policy = mb_policy.get_relevant_pcrs()


### PR DESCRIPTION
The old behavior was that if the policy name was not found in the registry
the "accept-all" policy was chosen. This might make the user believe that
their setup was correctly because measured boot still works.

The behavior is changed to error on startup if the policy was misconfigured
and now instead of "accept-all" "reject-all" is used to have a more secure
default.

Fixes: #1002