### PR TITLE
config: change libefivar.so to libefivar.so.1

### DIFF
--- a/keylime/config.py
+++ b/keylime/config.py
@@ -143,7 +143,7 @@ MEASUREDBOOT_ML = "/sys/kernel/security/tpm0/binary_bios_measurements"
 MEASUREDBOOT_IMPORTS = get_config().get("cloud_verifier", "measured_boot_imports", fallback="").split(",")
 MEASUREDBOOT_POLICYNAME = get_config().get("cloud_verifier", "measured_boot_policy_name", fallback="accept-all")
 
-LIBEFIVAR = "libefivar.so"  # formerly "/usr/lib/x86_64-linux-gnu/libefivar.so"
+LIBEFIVAR = "libefivar.so.1"  # formerly "/usr/lib/x86_64-linux-gnu/libefivar.so"
 
 # this is where data will be bound to a quote, MUST BE RESETABLE!
 TPM_DATA_PCR = 16


### PR DESCRIPTION
The unversioned library is only found in the -dev packages in most distributions.

Closes: https://github.com/keylime/keylime/issues/1006
