### PR TITLE
tpm_main: fix temp file handling in parse_binary_bootlog(..)

### DIFF
--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -1472,6 +1472,7 @@ class tpm(tpm_abstract.AbstractTPM):
         The output is the result of parsing and applying other conveniences."""
         with tempfile.NamedTemporaryFile() as log_bin_file:
             log_bin_file.write(log_bin)
+            log_bin_file.seek(0)
             log_bin_filename = log_bin_file.name
             retDict_tpm2 = self.__run(["tpm2_eventlog", "--eventlog-version=2", log_bin_filename])
         log_parsed_strs = retDict_tpm2["retout"]


### PR DESCRIPTION
This caused the following error:

```
Exception: Command: ['tpm2_eventlog', '--eventlog-version=2', '/tmp/tmpdtbwirrz'] returned 1, expected 0, output [], stderr [b'ERROR: Unable to run tpm2_eventlog\n']
```

I only have seen this in our Docker containers. I have no idea why the e2e test never ran into this issue.
