### PR TITLE
RFC: Use python3-gpg instead of python3-gnupg

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -58,7 +58,7 @@ case "$ID" in
         echo "${ID} selected."
         PACKAGE_MGR=$(command -v apt-get)
         PYTHON_PREIN="git patch"
-        PYTHON_DEPS="python3 python3-pip python3-dev python3-setuptools python3-zmq python3-tornado python3-cryptography python3-requests python3-psutil gcc g++ libssl-dev swig python3-yaml python3-gnupg python3-lark wget python3-alembic" 
+        PYTHON_DEPS="python3 python3-pip python3-dev python3-setuptools python3-zmq python3-tornado python3-cryptography python3-requests python3-psutil gcc g++ libssl-dev swig python3-yaml python3-gpg python3-lark wget python3-alembic"
         if [ "$(uname -m)" = "x86_64" ]; then
             PYTHON_DEPS+=" libefivar-dev"
         fi
@@ -96,7 +96,7 @@ case "$ID" in
                 PACKAGE_MGR=$(command -v dnf)
                 NEED_EPEL=1
                 PYTHON_PREIN="python3 python3-devel python3-setuptools python3-pip"
-                PYTHON_DEPS="gcc gcc-c++ openssl-devel python3-yaml python3-requests swig python3-cryptography wget git python3-tornado python3-zmq python3-gnupg python3-psutil"
+                PYTHON_DEPS="gcc gcc-c++ openssl-devel python3-yaml python3-requests swig python3-cryptography wget git python3-tornado python3-zmq python3-gpg python3-psutil"
                 if [ "$(uname -m)" = "x86_64" ]; then
                     PYTHON_DEPS+=" efivar-libs"
                 fi
@@ -116,7 +116,7 @@ case "$ID" in
         echo "${ID} selected."
         PACKAGE_MGR=$(command -v dnf)
         PYTHON_PREIN="python3 python3-devel python3-setuptools git wget patch"
-        PYTHON_DEPS="python3-pip gcc gcc-c++ openssl-devel swig python3-pyyaml python3-zmq python3-cryptography python3-tornado python3-requests python3-gnupg yaml-cpp-devel procps-ng python3-psutil python3-lark-parser python3-alembic"
+        PYTHON_DEPS="python3-pip gcc gcc-c++ openssl-devel swig python3-pyyaml python3-zmq python3-cryptography python3-tornado python3-requests python3-gpg yaml-cpp-devel procps-ng python3-psutil python3-lark-parser python3-alembic"
         if [ "$(uname -m)" = "x86_64" ]; then
             PYTHON_DEPS+=" efivar-devel"
         fi

--- a/pylintrc
+++ b/pylintrc
@@ -5,7 +5,7 @@ jobs=0
 disable=C0103,C0111,C0115,C0116,C0301,C0302,W0511,W0603,W0703,R0801,R0902,R0903,R0904,R0911,R0912,R0913,R0914,R0915
 
 [TYPECHECK]
-ignored-modules=zmq,alembic.op,alembic.context,Cryptodome,pylab,matplotlib,numpy,cryptography.hazmat.primitives.asymmetric.rsa
+ignored-modules=zmq,alembic.op,alembic.context,Cryptodome,pylab,matplotlib,numpy,cryptography.hazmat.primitives.asymmetric.rsa,gpg
 
 [LOGGING]
 enable=logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ pyyaml>=3.11 # MIT
 requests>=2.6 # Apache-2.0
 sqlalchemy>=1.3 # MIT
 alembic>=1.1.0 # MIT
-python-gnupg>=0.4.6 # BSD
 packaging>=20.0 #BSD
 psutil>=5.4.2 # BSD
 # Note that lark was renamed from lark-parser with 1.0.0 release


### PR DESCRIPTION
The former uses GPGME and is the recommended way of using GnuPG from
applications, by the GnuPG initiative, as it provides a better
documented API [1][2].

python-gpg is also already present in some distros, e.g. Fedora and
CentOS Stream, as it is a dependency of their package manager (dnf).

It is also available in other major distros such as Debian, Ubuntu,
OpenSUSE, so no disruptions are to be expected regarding packaging.

[1] https://gnupg.org/software/gpgme/index.html
[2] https://wiki.python.org/moin/GnuPrivacyGuard