### PR TITLE
Better failure tagging for measured boot and fail agent on exception

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -812,6 +812,10 @@ async def invoke_get_quote(agent, need_pubkey):
 
         except Exception as e:
             logger.exception(e)
+            failure.add_event(
+                "exception", {"context": "Agent caused the verifier to throw an exception", "data": str(e)}, False
+            )
+            asyncio.ensure_future(process_agent(agent, states.FAILED, failure))
 
 
 async def invoke_provide_v(agent):
@@ -1021,6 +1025,10 @@ async def process_agent(agent, new_operational_state, failure=Failure(Component.
     except Exception as e:
         logger.error("Polling thread error: %s", e)
         logger.exception(e)
+        failure.add_event(
+            "exception", {"context": "Agent caused the verifier to throw an exception", "data": str(e)}, False
+        )
+        await process_agent(agent, states.FAILED, failure)
 
 
 async def activate_agents(verifier_id, verifier_ip, verifier_port, mtls_options):

--- a/scripts/create_mb_refstate
+++ b/scripts/create_mb_refstate
@@ -137,7 +137,7 @@ def main():
     args = parser.parse_args()
     log_bin = args.eventlog_file.read()
     tpm = tpm_main.tpm()
-    log_data = tpm.parse_binary_bootlog(log_bin)
+    _, log_data = tpm.parse_binary_bootlog(log_bin)
     events = log_data["events"]
     mb_refstate = {
         "scrtm_and_bios": [


### PR DESCRIPTION
- tpm_main: add failure tagging to measured boot parsing
- verifier: ensure that execptions caused by the agent result in a failure
