### PR TITLE
ci: Run lint with Python 3.6 as well

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,6 @@ jobs:
     - name: Install build dependencies
       run: sudo dnf -y install swig
     - name: Install Python dependencies
-      run: python3 -m pip install tox
+      run: sudo dnf -y install python3.6 tox
     - name: Run lints
-      run: tox -vv -epylint
+      run: tox -vv -e 'pylint,pylint36'

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -72,9 +72,9 @@ def stop_broker():
         logger.info("Stopping revocation notifier...")
         broker_proc.terminate()
         broker_proc.join(5)
-        if broker_proc.is_alive():
+        if broker_proc.is_alive() and sys.version_info >= (3, 7):
             logger.debug("Killing revocation notifier because it did not terminate after 5 seconds...")
-            broker_proc.kill()
+            broker_proc.kill()  # pylint: disable=E1101
 
 
 def notify(tosend):

--- a/keylime/web_util.py
+++ b/keylime/web_util.py
@@ -115,7 +115,7 @@ def generate_mtls_context(
         context = ssl.create_default_context(ssl_purpose)
         context.check_hostname = False  # We do not use hostnames as part of our authentication
         if sys.version_info >= (3, 7):
-            context.minimum_version = ssl.TLSVersion.TLSv1_2
+            context.minimum_version = ssl.TLSVersion.TLSv1_2  # pylint: disable=E1101
         else:
             context.options &= ~ssl.OP_NO_TLSv1_2
         context.load_verify_locations(cafile=ca_path)

--- a/test/test_fs_util.py
+++ b/test/test_fs_util.py
@@ -8,6 +8,9 @@ class TestChDir(unittest.TestCase):
     @patch("keylime.fs_util.os.path.exists")
     @patch("keylime.fs_util.os.makedirs")
     @patch("keylime.fs_util.os.chdir")
+    # "no-self-use" warning has been reassigned from R0201 to R6301:
+    # https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/old-no-self-use.html
+    # pylint: disable-next=R
     def test_ch_dir_present(self, chdir_mock, makedirs_mock, exists_mock):
         """Test ch_dir when the directory exists."""
         exists_mock.return_value = True
@@ -19,6 +22,9 @@ class TestChDir(unittest.TestCase):
     @patch("keylime.fs_util.os.path.exists")
     @patch("keylime.fs_util.os.makedirs")
     @patch("keylime.fs_util.os.chdir")
+    # "no-self-use" warning has been reassigned from R0201 to R6301:
+    # https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/old-no-self-use.html
+    # pylint: disable-next=R
     def test_ch_dir_missing(self, chdir_mock, makedirs_mock, exists_mock):
         """Test ch_dir when the directory is missing."""
         exists_mock.return_value = False

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -901,7 +901,7 @@ class TestRestful(unittest.TestCase):
 
         # Kill the Python agent and launch the Rust agent!
         kill_cloudagent()
-        launch_cloudagent(agent="rust")
+        self.assertTrue(launch_cloudagent(agent="rust"))
 
     @unittest.skipIf(SKIP_RUST_TEST, "Testing against rust-keylime is disabled!")
     def test_071_agent_keys_pubkey_get(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.18.0
-envlist = py3,pylint
+envlist = py3,py36,pylint,pylint36
 skipsdist = True
 ignore_basepython_conflict=true
 
@@ -11,6 +11,15 @@ setenv =
    VIRTUAL_ENV={envdir}
 
 [testenv:pylint]
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
+    pylint
+commands = bash scripts/check_codestyle.sh
+allowlist_externals = bash
+
+[testenv:pylint36]
+basepython = python3.6
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
As the minimal supported version of Python is 3.6, run the lint check
in the CI with that version to catch any usage of >= 3.7 features.

This utilizes the multiple Python interpreter support in Fedora:
https://developer.fedoraproject.org/tech/languages/python/multiple-pythons.html

Signed-off-by: Daiki Ueno <dueno@redhat.com>