### PR TITLE
Drop SPDX-License-Identifier header

### DIFF
--- a/keylime/agentstates.py
+++ b/keylime/agentstates.py
@@ -1,9 +1,3 @@
-#!/usr/bin/python3
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 IBM Corporation
-"""
-
 import threading
 
 from keylime.common.algorithms import Hash

--- a/keylime/api_version.py
+++ b/keylime/api_version.py
@@ -1,7 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 Red Hat, Inc
-"""
 import re
 
 from packaging import version

--- a/keylime/ca_impl_openssl.py
+++ b/keylime/ca_impl_openssl.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import datetime
 
 from cryptography import x509

--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -1,22 +1,18 @@
-#!/usr/bin/python3
+"""Tools for creating a CA cert and signed server certs.
 
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-
-Tools for creating a CA cert and signed server certs.
 Divined from http://svn.osafoundation.org/m2crypto/trunk/tests/test_x509.py
 The mk_temporary_xxx calls return a NamedTemporaryFile with certs.
-Usage ;
-   # Create a temporary CA cert and it's private key
-   cacert, cakey = mk_temporary_cacert()
-   # Create a temporary server cert+key, signed by the CA
-   server_cert = mk_temporary_cert(cacert.name, cakey.name, '*.server.co.uk')
+Usage:
+  # Create a temporary CA cert and it's private key
+  cacert, cakey = mk_temporary_cacert()
+  # Create a temporary server cert+key, signed by the CA
+  server_cert = mk_temporary_cert(cacert.name, cakey.name, '*.server.co.uk')
 
-protips
-# openssl verify -CAfile cacert.crt cacert.crt cert.crt
-# openssl x509 -in cert.crt -noout -text
-# openssl x509 -in cacert.crt -noout -text
+Protips:
+  # openssl verify -CAfile cacert.crt cacert.crt cert.crt
+  # openssl x509 -in cert.crt -noout -text
+  # openssl x509 -in cacert.crt -noout -text
+
 """
 
 import argparse

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import ast
 import base64
 import time

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -1,8 +1,3 @@
-#!/usr/bin/python3
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
 import asyncio
 import functools
 import os

--- a/keylime/cmd/agent.py
+++ b/keylime/cmd/agent.py
@@ -1,10 +1,3 @@
-#!/usr/bin/python3
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 from keylime import keylime_agent, keylime_logging
 
 logger = keylime_logging.init_logging("cloudagent")

--- a/keylime/cmd/ca.py
+++ b/keylime/cmd/ca.py
@@ -1,10 +1,3 @@
-#!/usr/bin/python3
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 from keylime import ca_util, keylime_logging
 
 logger = keylime_logging.init_logging("ca-util")

--- a/keylime/cmd/ima_emulator_adapter.py
+++ b/keylime/cmd/ima_emulator_adapter.py
@@ -1,9 +1,3 @@
-#!/usr/bin/python3
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import argparse
 import codecs
 import itertools

--- a/keylime/cmd/migrations_apply.py
+++ b/keylime/cmd/migrations_apply.py
@@ -1,10 +1,3 @@
-#!/usr/bin/python3
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2020 Michael Peters (mpeters@redhat.com), Red Hat, Inc.
-"""
-
 import os
 
 import alembic.config

--- a/keylime/cmd/registrar.py
+++ b/keylime/cmd/registrar.py
@@ -1,10 +1,3 @@
-#!/usr/bin/python3
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import keylime.cmd.migrations_apply
 from keylime import config, keylime_logging, registrar_common
 

--- a/keylime/cmd/tenant.py
+++ b/keylime/cmd/tenant.py
@@ -1,10 +1,3 @@
-#!/usr/bin/python3
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import sys
 
 from keylime import keylime_logging, tenant

--- a/keylime/cmd/user_data_encrypt.py
+++ b/keylime/cmd/user_data_encrypt.py
@@ -1,10 +1,3 @@
-#!/usr/bin/python3
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import base64
 import os
 import sys

--- a/keylime/cmd/verifier.py
+++ b/keylime/cmd/verifier.py
@@ -1,10 +1,3 @@
-#!/usr/bin/python3
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import keylime.cmd.migrations_apply
 from keylime import cloud_verifier_tornado, config, keylime_logging
 

--- a/keylime/cmd/webapp.py
+++ b/keylime/cmd/webapp.py
@@ -1,10 +1,3 @@
-#!/usr/bin/python3
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 from keylime import keylime_logging, tenant_webapp
 
 logger = keylime_logging.init_logging("tenant_webapp")

--- a/keylime/cmd_exec.py
+++ b/keylime/cmd_exec.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import os
 import subprocess
 import time

--- a/keylime/common/algorithms.py
+++ b/keylime/common/algorithms.py
@@ -1,7 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2020 Kaifeng Wang
-"""
 import enum
 import hashlib
 from typing import Any, List, Optional

--- a/keylime/common/exception.py
+++ b/keylime/common/exception.py
@@ -1,9 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2020 Kaifeng Wang
-"""
-
-
 class KeylimeException(Exception):
     """Base class for all Keylime exceptions"""
 

--- a/keylime/common/metrics.py
+++ b/keylime/common/metrics.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2020 Kaifeng Wang
-"""
-
 import time
 
 

--- a/keylime/common/retry.py
+++ b/keylime/common/retry.py
@@ -1,9 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 Angelo Ruocco - IBM Research Lab Zurich
-"""
-
-
 def retry_time(exponential, base, ntries, logger):
     if exponential:
         if base > 1:

--- a/keylime/common/states.py
+++ b/keylime/common/states.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2020 Kaifeng Wang
-"""
-
 from keylime.common import exception
 
 ######################

--- a/keylime/common/validators.py
+++ b/keylime/common/validators.py
@@ -1,4 +1,5 @@
 """Validators module."""
+
 import re
 
 

--- a/keylime/config.py
+++ b/keylime/config.py
@@ -1,7 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
 import configparser
 import os
 import os.path

--- a/keylime/crypto.py
+++ b/keylime/crypto.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import base64
 import datetime
 import hashlib

--- a/keylime/cryptodome.py
+++ b/keylime/cryptodome.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import base64
 
 from Cryptodome.Cipher import AES, PKCS1_OAEP

--- a/keylime/db/keylime_db.py
+++ b/keylime/db/keylime_db.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2020 Luke Hinds (lhinds@redhat.com), Red Hat, Inc.
-"""
-
 import os
 from configparser import NoOptionError
 

--- a/keylime/db/registrar_db.py
+++ b/keylime/db/registrar_db.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2020 Luke Hinds (lhinds@redhat.com), Red Hat, Inc.
-"""
-
 from sqlalchemy import Column, Integer, PickleType, String, Text
 from sqlalchemy.ext.declarative import declarative_base
 

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2020 Luke Hinds (lhinds@redhat.com), Red Hat, Inc.
-"""
-
 from sqlalchemy import Column, Integer, LargeBinary, PickleType, String, Text, schema
 from sqlalchemy.ext.declarative import declarative_base
 

--- a/keylime/failure.py
+++ b/keylime/failure.py
@@ -1,9 +1,7 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 Thore Sommer
+"""Tagging of failure events that might cause revocation in Keylime.
 
-Tagging of failure events that might cause revocation in Keylime.
 """
+
 import ast
 import enum
 import functools

--- a/keylime/ima/ast.py
+++ b/keylime/ima/ast.py
@@ -1,11 +1,10 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 Thore Sommer
+"""AST with parser and validator for IMA ASCII entries.
 
-AST with parser and validator for IMA ASCII entries.
 Implements the templates (modes) and types as defined in:
-- https://elixir.bootlin.com/linux/latest/source/security/integrity/ima/ima_template.c
-- https://www.kernel.org/doc/html/v5.12/security/IMA-templates.html
+
+  - https://elixir.bootlin.com/linux/latest/source/security/integrity/ima/ima_template.c
+  - https://www.kernel.org/doc/html/v5.12/security/IMA-templates.html
+
 """
 
 import abc

--- a/keylime/ima/file_signatures.py
+++ b/keylime/ima/file_signatures.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python3
-"""
-SPDX-License-Identifier: Apache-2.0
-"""
-
 import base64
 import enum
 import json

--- a/keylime/ima/ima.py
+++ b/keylime/ima/ima.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import codecs
 import copy
 import datetime

--- a/keylime/ima/ima_dm.py
+++ b/keylime/ima/ima_dm.py
@@ -1,10 +1,9 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2022 Thore Sommer
+"""Parser and validator for device mapper IMA events
 
-Parser and validator for device mapper IMA events
-- https://www.kernel.org/doc/html/v5.15/admin-guide/device-mapper/dm-ima.html
+  - https://www.kernel.org/doc/html/v5.15/admin-guide/device-mapper/dm-ima.html
+
 """
+
 import pickle
 import re
 import sys

--- a/keylime/ima/ima_test.py
+++ b/keylime/ima/ima_test.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 IBM Corporation
-"""
-
 import tempfile
 import unittest
 

--- a/keylime/json.py
+++ b/keylime/json.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 Sergio Correia (scorreia@redhat.com), Red Hat, Inc.
-"""
-
 import json as json_module
 from typing import IO, Any, Dict, List, Union
 

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -1,10 +1,3 @@
-#!/usr/bin/python3
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import asyncio
 import base64
 import configparser

--- a/keylime/keylime_logging.py
+++ b/keylime/keylime_logging.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import logging
 import os
 from logging import Logger

--- a/keylime/measured_boot.py
+++ b/keylime/measured_boot.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright (c) 2021 IBM Corp.
-"""
-
 import argparse
 import json
 import sys

--- a/keylime/migrations/env.py
+++ b/keylime/migrations/env.py
@@ -1,9 +1,7 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
+"""Database migration
 
-Database migration
 """
+
 import logging
 import re
 import sys

--- a/keylime/registrar_client.py
+++ b/keylime/registrar_client.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import logging
 import os
 import sys

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import base64
 import http.server
 import ipaddress

--- a/keylime/requests_client.py
+++ b/keylime/requests_client.py
@@ -1,7 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
 import os.path
 import tempfile
 

--- a/keylime/revocation_actions/print_metadata.py
+++ b/keylime/revocation_actions/print_metadata.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 from keylime import json, keylime_logging
 
 logger = keylime_logging.init_logging("print_metadata")

--- a/keylime/revocation_actions/update_crl.py
+++ b/keylime/revocation_actions/update_crl.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import os
 import time
 

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -1,7 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
 import functools
 import os
 import signal

--- a/keylime/secure_mount.py
+++ b/keylime/secure_mount.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import os
 import shutil
 

--- a/keylime/signing.py
+++ b/keylime/signing.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import tempfile
 
 import gnupg

--- a/keylime/static/css/webapp.css
+++ b/keylime/static/css/webapp.css
@@ -1,8 +1,3 @@
-/*
-* SPDX-License-Identifier: Apache-2.0
-* Copyright 2017 Massachusetts Institute of Technology.
-*/
-
 html, body {margin:0px;padding:0px;height:100%;width:100%;font-family:verdana,sans-serif;}
 
 /* 'Add Agent' modal dialogue box theme */

--- a/keylime/static/js/webapp.js
+++ b/keylime/static/js/webapp.js
@@ -1,8 +1,3 @@
-/*
-* SPDX-License-Identifier: Apache-2.0
-* Copyright 2017 Massachusetts Institute of Technology.
-*/
-
 'use strict';
 let API_VERSION=2;
 let MAX_TERM_LEN=100;

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -1,10 +1,3 @@
-#!/usr/bin/python3
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import argparse
 import base64
 import hashlib

--- a/keylime/tenant_webapp.py
+++ b/keylime/tenant_webapp.py
@@ -1,10 +1,3 @@
-#!/usr/bin/python3
-
-"""
-SPDX-License-Identifier: BSD-2-Clause
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import base64
 import logging
 import os

--- a/keylime/tornado_requests.py
+++ b/keylime/tornado_requests.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python3
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import ssl
 
 from tornado import httpclient

--- a/keylime/tpm/tpm2_objects.py
+++ b/keylime/tpm/tpm2_objects.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 Red Hat, Inc.
-"""
-
 import hashlib
 import struct
 from typing import Tuple, Union

--- a/keylime/tpm/tpm2_objects_test.py
+++ b/keylime/tpm/tpm2_objects_test.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 Red Hat, Inc.
-"""
-
 import base64
 import unittest
 

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -1,7 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
 import codecs
 import os
 import string

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import base64
 import binascii
 import codecs

--- a/keylime/tpm_bootlog_enrich.py
+++ b/keylime/tpm_bootlog_enrich.py
@@ -1,9 +1,3 @@
-#!/usr/bin/python3
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 # important notice: this file was temporarly added to keylime in order to cover the gap
 # left by some additiomal features still not available on Intel's tpm2-tools. There is
 # an ongoing effort to add the aforementioned features to their toolkit and when this

--- a/keylime/tpm_ek_ca.py
+++ b/keylime/tpm_ek_ca.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import glob
 import os
 

--- a/keylime/user_utils.py
+++ b/keylime/user_utils.py
@@ -1,10 +1,3 @@
-#!/usr/bin/python3
-
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2022 IBM Corporation
-"""
-
 import grp
 import os
 import pwd

--- a/keylime/user_utils_test.py
+++ b/keylime/user_utils_test.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2022 IBM Corporation
-"""
-
 import unittest
 
 from keylime import user_utils


### PR DESCRIPTION
Currently we provide the project shared license in the LICENSE file,
making the SPDX-License-Identifier header reduntant.

Also fix some file permissions and extra shebangs not used.

Fix #830

Signed-off-by: Alberto Planas <aplanas@suse.com>