### PR TITLE
Complete implementation of the Allowlists API

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -28,7 +28,7 @@ def get_AgentAttestStates():
     return AgentAttestStates.get_instance()
 
 
-def process_quote_response(agent, json_response, agentAttestState) -> Failure:
+def process_quote_response(agent, ima_policy, json_response, agentAttestState) -> Failure:
     """Validates the response from the Cloud agent.
 
     This method invokes an Registrar Server call to register, and then check the quote.
@@ -156,7 +156,7 @@ def process_quote_response(agent, json_response, agentAttestState) -> Failure:
         agent["ak_tpm"],
         agent["tpm_policy"],
         ima_measurement_list,
-        agent["allowlist"],
+        ima_policy.ima_policy,
         algorithms.Hash(hash_alg),
         ima_keyrings,
         mb_measurement_list,
@@ -216,9 +216,9 @@ def prepare_get_quote(agent):
 
 
 def process_get_status(agent):
-    allowlist = json.loads(agent.allowlist)
-    if isinstance(allowlist, dict) and "allowlist" in allowlist:
-        al_len = len(allowlist["allowlist"])
+    allowlist_json = json.loads(agent.ima_policy.ima_policy)
+    if isinstance(allowlist_json, dict) and "allowlist" in allowlist_json:
+        al_len = len(allowlist_json["allowlist"])
     else:
         al_len = 0
 
@@ -290,12 +290,12 @@ def prepare_error(agent, msgtype="revocation", event=None):
     return tosend
 
 
-def validate_agent_data(agent_data):
+def validate_ima_policy_data(agent_data):
     if agent_data is None:
         return False, None
 
     # validate that the allowlist is proper JSON
-    lists = json.loads(agent_data["allowlist"])
+    lists = json.loads(agent_data)
 
     # Validate exlude list contains valid regular expressions
     is_valid, _, err_msg = validators.valid_exclude_list(lists.get("exclude"))

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, LargeBinary, PickleType, String, Text, schema
+from sqlalchemy import Column, ForeignKey, Integer, LargeBinary, PickleType, String, Text, schema
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
 
 from keylime.json import JSONPickler
 
@@ -24,7 +25,8 @@ class VerfierMain(Base):
     public_key = Column(String(500))
     tpm_policy = Column(JSONPickleType(pickler=JSONPickler))
     meta_data = Column(String(200))
-    allowlist = Column(Text().with_variant(Text(429400000), "mysql"))
+    ima_policy = relationship("VerifierAllowlist", back_populates="agent", uselist=False)
+    ima_policy_id = Column(Integer, ForeignKey("allowlists.id"))
     ima_sign_verification_keys = Column(Text().with_variant(Text(429400000), "mysql"))
     mb_refstate = Column(Text().with_variant(Text(429400000), "mysql"))
     revocation_key = Column(String(2800))
@@ -51,6 +53,7 @@ class VerifierAllowlist(Base):
     __tablename__ = "allowlists"
     __table_args__ = (schema.UniqueConstraint("name", name="uniq_allowlists0name"),)
     id = Column(Integer, primary_key=True)
+    agent = relationship("VerfierMain", back_populates="ima_policy")
     name = Column(String(255), nullable=False)
     tpm_policy = Column(Text())
     ima_policy = Column(Text().with_variant(Text(429400000), "mysql"))

--- a/keylime/migrations/versions/4329e2d14944_associate_moved_allowlists_to_agents.py
+++ b/keylime/migrations/versions/4329e2d14944_associate_moved_allowlists_to_agents.py
@@ -1,0 +1,55 @@
+"""Associate moved allowlists to agents (2/2)
+
+Revision ID: 4329e2d14944
+Revises: a72aec03d720
+Create Date: 2022-08-03 10:29:14.858393
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4329e2d14944"
+down_revision = "a72aec03d720"
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()[f"upgrade_{engine_name}"]()
+
+
+def downgrade(engine_name):
+    globals()[f"downgrade_{engine_name}"]()
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+    # get existing table metadata
+    conn = op.get_bind()
+    meta = sa.MetaData(bind=conn)
+    meta.reflect(only=("verifiermain",))
+    verifiermain = meta.tables["verifiermain"]
+
+    res = conn.execute("SELECT id, name FROM allowlists")
+    results = res.fetchall()
+
+    # Update new foreign key column with associated items in the "allowlists" table
+    for allowlist_id, name in results:
+        conn.execute(
+            verifiermain.update().where(verifiermain.c.agent_id == name).values(**{"ima_policy_id": allowlist_id})
+        )
+
+
+def downgrade_cloud_verifier():
+    with op.batch_alter_table("verifiermain") as batch_op:
+        batch_op.add_column(
+            sa.Column("allowlist", sa.Text().with_variant(sa.Text(length=429400000), "mysql"), nullable=True)
+        )

--- a/keylime/migrations/versions/a72aec03d720_migrate_allowlists_to_separate_table.py
+++ b/keylime/migrations/versions/a72aec03d720_migrate_allowlists_to_separate_table.py
@@ -1,0 +1,75 @@
+"""Migrate allowlists to dedicated table (1/2)
+
+Revision ID: a72aec03d720
+Revises: bc3b6b551b0a
+Create Date: 2022-07-21 12:17:17.779159
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a72aec03d720"
+down_revision = "bf48e0c4751d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()[f"upgrade_{engine_name}"]()
+
+
+def downgrade(engine_name):
+    globals()[f"downgrade_{engine_name}"]()
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+
+    # Migrate existing agent info to the allowlists table.
+    conn = op.get_bind()
+
+    res = conn.execute("SELECT agent_id, tpm_policy, allowlist FROM verifiermain")
+    results = res.fetchall()
+    old_policy = [{"name": r[0], "tpm_policy": r[1], "ima_policy": r[2]} for r in results]
+
+    # get existing table metadata
+    meta = sa.MetaData(bind=conn)
+    meta.reflect(only=("allowlists",))
+    allowlists = meta.tables["allowlists"]
+
+    op.bulk_insert(allowlists, old_policy)
+
+    with op.batch_alter_table("verifiermain") as batch_op:
+        batch_op.add_column(
+            sa.Column("ima_policy_id", sa.Integer(), sa.ForeignKey("allowlists.id", name="fk_verifiermain_allowlists"))
+        )
+        batch_op.drop_column("allowlist")
+
+
+def downgrade_cloud_verifier():
+    # Migrate existing agent info to the allowlist column in verifiermain.
+    conn = op.get_bind()
+    meta = sa.MetaData(bind=conn)
+    meta.reflect(only=("verifiermain", "allowlists"))
+    verifiermain = meta.tables["verifiermain"]
+    allowlists = meta.tables["allowlists"]
+
+    res = conn.execute("SELECT name, ima_policy FROM allowlists")
+    results = res.fetchall()
+
+    # Put allowlists back into the "allowlist" column, and delete from the "allowlists" database
+    for name, ima_policy in results:
+        conn.execute(verifiermain.update().where(verifiermain.c.agent_id == name).values(**{"allowlist": ima_policy}))
+        conn.execute(allowlists.delete().where(allowlists.c.name == name))
+
+    # Drop the foreign key table
+    with op.batch_alter_table("verifiermain") as batch_op:
+        batch_op.drop_column("ima_policy_id")

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -641,7 +641,7 @@ class TestRestful(unittest.TestCase):
         data = {
             "name": "test-allowlist",
             "tpm_policy": json.dumps(self.tpm_policy),
-            "ima_policy": json.dumps(self.allowlist),
+            "ima_policy_bundle": json.dumps(self.ima_policy_bundle),
         }
 
         cv_client = RequestsClient(tenant_templ.verifier_base_url, tls_enabled)
@@ -673,7 +673,14 @@ class TestRestful(unittest.TestCase):
         results = json_response["results"]
         self.assertEqual(results["name"], "test-allowlist")
         self.assertEqual(results["tpm_policy"], json.dumps(self.tpm_policy))
-        self.assertEqual(results["ima_policy"], json.dumps(self.allowlist))
+        self.assertEqual(
+            results["ima_policy"],
+            json.dumps(
+                ima.process_ima_policy(
+                    ima.unbundle_ima_policy(self.ima_policy_bundle, False), self.ima_policy_bundle["excllist"]
+                )
+            ),
+        )
 
     def test_027_cv_allowlist_delete(self):
         """Test CV's DELETE /allowlists/{name} Interface"""

--- a/test/test_verifier_db.py
+++ b/test/test_verifier_db.py
@@ -6,6 +6,7 @@ Copyright 2020 Luke Hinds (lhinds@redhat.com), Red Hat, Inc.
 import unittest
 
 from sqlalchemy import create_engine
+from sqlalchemy.orm import joinedload
 
 from keylime import json
 from keylime.db.keylime_db import SessionManager
@@ -21,7 +22,6 @@ test_data = {
     "public_key": "",
     "tpm_policy": '{"22": ["0000000000000000000000000000000000000001", "0000000000000000000000000000000000000000000000000000000000000001", "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001", "ffffffffffffffffffffffffffffffffffffffff", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"], "15": ["0000000000000000000000000000000000000000", "0000000000000000000000000000000000000000000000000000000000000000", "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"], "mask": "0x408400"}',
     "meta_data": '{"cert_serial": 2, "subject": "/C=US/CN=d432fbb3-d2f1-4a97-9ef7-75bd81c00000/ST=MA/L=Lexington/O=MITLL/OU=53"}',
-    "allowlist": '{"allowlist": {"/boot/System.map-5.1.17-300.fc30.x86_64": ["bdc084cc61c67dada53ff92c3235fbc774eace36aceb11967718399837e36485"], "/boot/vmlinuz-5.0.9-301.fc30.x86_64": ["187e65c35f449df145b57940cb73606623ab1eccc352f5b0d9b64c4d2ad3be58"], "/boot/initramfs-5.1.15-300.fc30.x86_64.img": ["7fb94b644d95de6ed2f70c247cf9a572027815b8f6a00b8c5f7b9fd2feef0ff1"], "/boot/config-5.0.9-301.fc30.x86_64": ["540f7b2732b8018be45dcfdf737fa6e51d9f5924d85b6c1987ddb4215260b49f"], "boot_aggregate": ["0000000000000000000000000000000000000000"]}, "exclude": ["/*"]}',
     "ima_sign_verification_keys": "",
     "revocation_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDs1onKjLZHDnqu\nnrsCb5aZohK2FU+jjU4NT23x1UzYzpFU9wBZ0avj+HeFYbQiAKanSbS7PvhjJMdE\naWMgRMgigr2K1xx+ZhBu4zTPFMy11msxMIL/HPROSYx/9wUZrhf4z/rBsuppFVs3\nKfKmQHuptjZX+D+m+nANO8WOILyW2+5YO5FNw1XJ3gVO6elJJ/CzQcYWIioONuTM\nQ+g8OQc+yTZruwedcSpOX56GpBImWUKXzTz3zoX7AlYxjEBjT86rxoBVXo3ZIwYx\n+mJk7NADN2qvLSXxTnLBxISHdsUDBP5DfurFQPhZC5oARN6/Y4zPESnhm8iwlG5o\n2ZjxVzphAgMBAAECggEBAKVKudImUJTY8yBp4aS6koXYymxQBUvlM8MwW1A7iK2L\nxXxiAtms7uVlJK1vWhOdFrKMS1mfgiVXpscFMkx0FKWZT4XVyaohu3hYlCOupYyH\nADrNW6+G2q7EwA0TLnkUuuBI7v4+y0DZydZ/LT2ApY31gIn21R3JjWh+/crK6DP0\nJO51hLO+z4GAMbWimRzA3lnYltUSJEvam3EHnj/pW+hlczjdI6AfJTWRWx6+gqP3\nRBvLcjBA9ZIx4JzYab5tnvwnd8ZzVItYBQJ8UhxzNsrSzEGguUEO4G/jYQTtYi6T\nufksmewcIClp48AfDThKSCMQXgFwpVI4EPxwmfd6Mt0CgYEA+i+2jjeFREMNam4p\nEBf5tmY2xvg3HXGgCjBfllepZQZHQatfv/kEqhFW497W+okyjTXflMR1TkjMKAqO\nahA+D1lItycPxsvTTiZ85KgrybbQT7Y+s2ET2f68wZh2XyiJIYE/MNi3ZclIBFaY\npyXicj0RIB6IY9PIHNgdEHI4casCgYEA8ldrcbWof8YpwJ6KFVuMvkYKniVF0aXH\nsQUWL/dyjBYIq/jg3Z4J+b0360DhZVpp1SaO4jFISxVMRzkDf3/gbKxH9F4a9Id8\nDmGH15v1ooKBYfkk7GwEB3AOY4gN3RMnWb1hxxhjsM9pmeTffqgqYzHYzv1ArjHe\ntYkjWOqPECMCgYBT//kXPuTrymeSuHHpCWO6Lg9uNqCqrh/BzAQMAlrJpJYAIn3/\ngqhiQXgfAg7EB5SFfPUYie2o3yBMwV6XleSAWsXjWKYfZQgJUTrVuvEYxNykJthe\nedWkd7cAeSQlRwLj0PVafSj2b+JSMpEGbd3d5Ur+scGxYsXpiVYY04DICQKBgBPZ\nhTtzHbIZkSHt2nGVZhnPst7xPp7FbW3adM7I/eDrjRpI8GI2p6qFDSd/0PZ0SWbk\nGZ/9WWaNAAp1aQvwdXlxQxOJAbw1vLuQ0Yefhqcg+WgE+DlFP688RnFwm3IYN4jq\nMjAUl1XMJ2IrlQLS02X8lz2dEMcz3oIQEY0e6UjxAoGAFeiOjFF2i4wRRUKx8kpb\nnBKRmFaMXdkeMV2IQALJ4skNNflf0YdDFVniFUyq9vfbq2drJSnMiy8Dvju0j5PC\n+MALz22fsNoIV2h6gz0i1lXiyVgpoAhYCbbPv0wO6iHKPBzH3Onv6BKrVMy1pnzh\n6QsfbhjzBfFg1Zxp/h1tBqA=\n-----END PRIVATE KEY-----\n",
     "accept_tpm_hash_algs": ["sha512", "sha384", "sha256", "sha1"],
@@ -54,15 +54,12 @@ class TestVerfierDB(unittest.TestCase):
         self.engine = create_engine("sqlite://")
         VerfierMain.metadata.create_all(self.engine, checkfirst=True)
         self.session = SessionManager().make_session(self.engine)
-        self.populate_agent()
-        self.populate_allowlist()
+        self.populate_tables()
 
-    def populate_agent(self):
-        self.session.add(VerfierMain(**test_data))
-        self.session.commit()
-
-    def populate_allowlist(self):
-        self.session.add(VerifierAllowlist(**test_allowlist_data))
+    def populate_tables(self):
+        allowlist = VerifierAllowlist(**test_allowlist_data)
+        self.session.add(allowlist)
+        self.session.add(VerfierMain(**test_data, ima_policy=allowlist))
         self.session.commit()
 
     def test_add_allowlist(self):
@@ -72,12 +69,21 @@ class TestVerfierDB(unittest.TestCase):
         self.assertEqual(allowlist.ima_policy, test_allowlist_data["ima_policy"])
 
     def test_add_agent(self):
-        agent = self.session.query(VerfierMain).filter_by(agent_id=agent_id).first()
+        agent = (
+            self.session.query(VerfierMain)
+            .options(joinedload(VerfierMain.ima_policy))
+            .filter_by(agent_id=agent_id)
+            .first()
+        )
         self.assertEqual(agent.v, "cf0B779EA1dkHVWfTxQuSLHNFeutYeSmVWe7JOFWzXg=")
         self.assertEqual(agent.port, 9002)
         self.assertEqual(
             agent.tpm_policy,
             '{"22": ["0000000000000000000000000000000000000001", "0000000000000000000000000000000000000000000000000000000000000001", "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001", "ffffffffffffffffffffffffffffffffffffffff", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"], "15": ["0000000000000000000000000000000000000000", "0000000000000000000000000000000000000000000000000000000000000000", "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"], "mask": "0x408400"}',
+        )
+        self.assertEqual(
+            agent.ima_policy.ima_policy,
+            test_allowlist_data["ima_policy"],
         )
         self.assertEqual(
             agent.revocation_key,


### PR DESCRIPTION
This is a WIP, draft implementation of a completed Allowlists API. When complete, this will move allowlist storage to their own database, enable allowlist CRD operations through the Keylime tenant, and allow for agents to be provisioned using existing allowlists on the verifier.

This work is still WIP; some things may be rough around the edges. But it is functionally complete.