### PR TITLE
keylime: initialize supplementary groups when dropping privileges

### DIFF
--- a/keylime/user_utils.py
+++ b/keylime/user_utils.py
@@ -73,6 +73,19 @@ def change_uidgid(user_and_group):
         except (OSError, PermissionError) as e:
             raise RuntimeError(f"Could not set gid to {gid}: {e}") from e
 
+    if uid is not None and gid is not None:
+        try:
+            passwd = pwd.getpwuid(uid)
+            username = passwd.pw_name
+        except KeyError as e:
+            raise ValueError(f"Could not resolve user {uid}: {e}") from e
+
+        try:
+            groups = os.getgrouplist(username, gid)
+            os.setgroups(groups)
+        except (OSError, PermissionError) as e:
+            raise RuntimeError(f"Could not set group list to {groups}: {e}") from e
+
     if uid is not None:
         try:
             os.setuid(uid)


### PR DESCRIPTION
On some distributions the keylime user's primary group may not have
permission to access /dev/tpmrm0 devices. For example, on Fedora,
/dev/tpmrm0 is owned root:tss, but keylime runs keylime:keylime,
with 'tss' as a supplementary group.

We need to load supplementary groups when dropping privileges,
otherwise we'll be unable to access the TPM device.

Resolves: #1038
Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>