### PR TITLE
Set revocation_notifiers = agent as default in keylime.conf

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -273,6 +273,9 @@ quote_interval = 2
 #
 # Available methods are:
 #
+# "agent": Deliver notification directly to the agent via the REST
+# protocol.
+#
 # "zeromq": Enable the ZeroMQ based revocation notification method;
 # revocation_notifier_ip and revocation_notifier_port options must be
 # set. Currently this only works if you are using keylime-CA.
@@ -280,10 +283,7 @@ quote_interval = 2
 # "webhook": Send notification via webhook. The endpoint URL must be
 # configured with webhook_url option. This can be used to notify other
 # systems that do not have a Keylime agent running.
-#
-# "agent": Deliver notification directly to the agent via the REST
-# protocol.
-revocation_notifiers = zeromq
+revocation_notifiers = agent
 
 # The binding address and port of the revocation notifier service.
 # If the 'revocation_notifier' option is set to "true", then the verifier


### PR DESCRIPTION
Since PR#795 keylime supports agent revocation mechanism.
Together with the rust-agent usage users can avoid using
zeromq completely. This change is a step towards using more
secure default setup.

Signed-off-by: Karel Srot <ksrot@redhat.com>