### PR TITLE
Add docs status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Keylime
 
 [![Slack CNCF chat](https://img.shields.io/badge/Chat-CNCF%20Slack-informational)](https://cloud-native.slack.com/archives/C01ARE2QUTZ)
+[![Docs Status](https://readthedocs.org/projects/keylime-docs/badge/?version=latest)](https://keylime-docs.readthedocs.io/en/latest/?badge=latest)
 
 ![keylime](doc/keylime.png?raw=true "Title")
 


### PR DESCRIPTION
Docs are building correctly now, so add a badge

<img width="883" alt="image" src="https://user-images.githubusercontent.com/7058938/179004940-56a0a0a6-3057-400e-9a4f-13717a2f8c9b.png">


Signed-off-by: Luke Hinds <lhinds@redhat.com>