### PR TITLE
Update fmf plans to run tests which checking ek_certs

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -27,6 +27,8 @@
      - /functional/basic-attestation-with-ima-signatures 
      - /functional/basic-attestation-without-mtls
      - /functional/basic-attestation-with-unpriviledged-agent
+     - /functional/ek-cert-use-ek_check_script
+     - /functional/ek-cert-use-ek_handle-custom-ca_certs
      - /functional/install-rpm-with-ima-signature
      - /functional/keylime_tenant-commands-on-localhost
      - /functional/tpm_policy-sanity-on-localhost


### PR DESCRIPTION
Update fmf plans for enabling run tests 
which checking ek_cert.

Signed-off-by: Patrik Koncity <pkoncity@redhat.com>