### PR TITLE
Update installer.sh for RHEL8, PowerTools

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -105,9 +105,9 @@ case "$ID" in
                 NEED_BUILD_TOOLS=1
                 NEED_PYTHON_DIR=1
                 if test "$ID" = centos; then
-                   POWERTOOLS="--enablerepo=PowerTools"
+                    POWERTOOLS="--enablerepo=PowerTools"
                 else
-                   POWERTOOLS="config-manager --set-enabled rhui-codeready-builder-for-rhel-8-x86_64-rhui-source-rpms"
+                    POWERTOOLS="config-manager --set-enabled rhui-codeready-builder-for-rhel-8-x86_64-rhui-source-rpms"
                 fi 
 
             ;;

--- a/installer.sh
+++ b/installer.sh
@@ -76,44 +76,8 @@ case "$ID" in
         esac
     ;;
 
-    centos)
+    rhel | centos)
         case "${VERSION_ID}" in
-            7*)
-                echo "${ID} ${VERSION_ID} selected."
-                PACKAGE_MGR=$(command -v yum)
-                NEED_EPEL=1
-                PYTHON_PREIN="python36 python36-devel python36-setuptools python36-pip git wget patch openssl"
-                PYTHON_DEPS="gcc gcc-c++ openssl-devel swig python36-PyYAML python36-tornado python36-cryptography python36-requests python36-zmq yaml-cpp-devel python3-psutil python3-alembic"
-                if [ "$(uname -m)" = "x86_64" ]; then
-                    PYTHON_DEPS+=" efivar-libs"
-                fi
-                BUILD_TOOLS="openssl-devel file libtool make automake m4 libgcrypt-devel autoconf autoconf-archive libcurl-devel libstdc++-devel uriparser-devel dbus-devel gnulib-devel doxygen libuuid-devel json-c-devel"
-                NEED_BUILD_TOOLS=1
-                CENTOS7_TSS_FLAGS="--enable-esapi=no --disable-doxygen-doc"
-            ;;
-            8*)
-                echo "${ID} ${VERSION_ID} selected."
-                PACKAGE_MGR=$(command -v dnf)
-                NEED_EPEL=1
-                PYTHON_PREIN="python3 python3-devel python3-setuptools python3-pip"
-                PYTHON_DEPS="gcc gcc-c++ openssl-devel python3-yaml python3-requests swig python3-cryptography wget git python3-tornado python3-zmq python3-gpg python3-psutil"
-                if [ "$(uname -m)" = "x86_64" ]; then
-                    PYTHON_DEPS+=" efivar-libs"
-                fi
-                BUILD_TOOLS="git wget patch libyaml openssl-devel libtool make automake m4 libgcrypt-devel autoconf libcurl-devel libstdc++-devel dbus-devel libuuid-devel json-c-devel"
-                #TPM2_TOOLS_PKGS="tpm2-tss tpm2-tools" TODO: still on 3.1.1 tpm2_tools
-                NEED_BUILD_TOOLS=1
-                NEED_PYTHON_DIR=1
-		POWERTOOLS="--enablerepo=PowerTools install autoconf-archive"
-            ;;
-	     *)
-                echo "Version ${VERSION_ID} of ${ID} not supported"
-                exit 1
-        esac
-    ;;
-
-    rhel) 
-	case "${VERSION_ID}" in
             7*)
                 echo "${ID} ${VERSION_ID} selected."
                 PACKAGE_MGR=$(command -v yum)
@@ -140,9 +104,14 @@ case "$ID" in
                 #TPM2_TOOLS_PKGS="tpm2-tss tpm2-tools" TODO: still on 3.1.1 tpm2_tools
                 NEED_BUILD_TOOLS=1
                 NEED_PYTHON_DIR=1
-		POWERTOOLS="config-manager --set-enabled rhui-codeready-builder-for-rhel-8-x86_64-rhui-source-rpms"
+		if test "$ID" = centos; then
+			POWERTOOLS="--enablerepo=PowerTools"
+		else
+			POWERTOOLS="config-manager --set-enabled rhui-codeready-builder-for-rhel-8-x86_64-rhui-source-rpms"
+		fi 
+
             ;;
-            *)
+	     *)
                 echo "Version ${VERSION_ID} of ${ID} not supported"
                 exit 1
         esac

--- a/installer.sh
+++ b/installer.sh
@@ -104,14 +104,14 @@ case "$ID" in
                 #TPM2_TOOLS_PKGS="tpm2-tss tpm2-tools" TODO: still on 3.1.1 tpm2_tools
                 NEED_BUILD_TOOLS=1
                 NEED_PYTHON_DIR=1
-		if test "$ID" = centos; then
-			POWERTOOLS="--enablerepo=PowerTools"
-		else
-			POWERTOOLS="config-manager --set-enabled rhui-codeready-builder-for-rhel-8-x86_64-rhui-source-rpms"
-		fi 
+                if test "$ID" = centos; then
+                   POWERTOOLS="--enablerepo=PowerTools"
+                else
+                   POWERTOOLS="config-manager --set-enabled rhui-codeready-builder-for-rhel-8-x86_64-rhui-source-rpms"
+                fi 
 
             ;;
-	     *)
+            *)
                 echo "Version ${VERSION_ID} of ${ID} not supported"
                 exit 1
         esac
@@ -184,11 +184,11 @@ echo "==========================================================================
 echo $'\t\t\tInstalling python & crypto libs'
 echo "=================================================================================="
 if [[ "$NEED_EPEL" -eq "1" ]] ; then
-	$PACKAGE_MGR -y install epel-release
-	if [[ $? > 0 ]] ; then
-    	echo "ERROR: EPEL package failed to install properly!"
-    	exit 1
-	fi
+    $PACKAGE_MGR -y install epel-release
+    if [[ $? > 0 ]] ; then
+        echo "ERROR: EPEL package failed to install properly!"
+        exit 1
+    fi
 fi
 
 $PACKAGE_MGR install -y $PYTHON_PREIN
@@ -291,11 +291,11 @@ if [[ "$NEED_BUILD_TOOLS" -eq "1" ]] ; then
     echo "INFO: Using temp tpm directory: $TMPDIR"
 
     if [[ -n "${POWERTOOLS}" ]] ; then
-    	$PACKAGE_MGR -y $POWERTOOLS
-    	if [[ $? > 0 ]] ; then
-        	echo "ERROR: Package(s) failed to install properly!"
-        	exit 1
-    	fi
+        $PACKAGE_MGR -y $POWERTOOLS
+        if [[ $? > 0 ]] ; then
+            echo "ERROR: Package(s) failed to install properly!"
+            exit 1
+        fi
     fi
 
     $PACKAGE_MGR -y install $BUILD_TOOLS


### PR DESCRIPTION
Fixes #1056.
Separated RHEL and Centos due to differences with the PowerTools repository. Enabled the repository first, then installed the build tools. 