### PR TITLE
Adds a per-agent counter for "successfull attestations" on Keylime.

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -166,9 +166,7 @@ def process_quote_response(agent, json_response, agentAttestState) -> Failure:
     failure.merge(quote_validation_failure)
 
     if not failure:
-        # set a flag so that we know that the agent was verified once.
-        # we only issue notifications for agents that were at some point good
-        agent["first_verified"] = True
+        agent["attestation_count"] += 1
 
         # has public key changed? if so, clear out b64_encrypted_V, it is no longer valid
         if received_public_key != agent.get("public_key", ""):
@@ -258,6 +256,7 @@ def process_get_status(agent):
         "verifier_port": agent.verifier_port,
         "severity_level": agent.severity_level,
         "last_event_id": agent.last_event_id,
+        "attestation_count": agent.attestation_count,
     }
     return response
 

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -44,6 +44,7 @@ class VerfierMain(Base):
     supported_version = Column(String(20))
     ak_tpm = Column(String(500))
     mtls_cert = Column(String(2048), nullable=True)
+    attestation_count = Column(Integer)
 
 
 class VerifierAllowlist(Base):

--- a/keylime/migrations/versions/bf48e0c4751d_add_attestation_count_column.py
+++ b/keylime/migrations/versions/bf48e0c4751d_add_attestation_count_column.py
@@ -1,0 +1,39 @@
+"""add_attestation_count_column
+
+Revision ID: bf48e0c4751d
+Revises: bc3b6b551b0a
+Create Date: 2022-07-12 12:00:55.599169
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "bf48e0c4751d"
+down_revision = "bc3b6b551b0a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()[f"upgrade_{engine_name}"]()
+
+
+def downgrade(engine_name):
+    globals()[f"downgrade_{engine_name}"]()
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+    op.add_column("verifiermain", sa.Column("attestation_count", sa.Integer))
+
+
+def downgrade_cloud_verifier():
+    op.drop_column("verifiermain", "attestation_count")


### PR DESCRIPTION
This counter, "attestations" is now available via API calls (e.g.,
`keylime_tenant -c status`) and it is stored on the database to preserve
state in case the `verifier` is restarted. Given the availability of
this information, the old "first_verified" attribute is now removed.
This PR is the first one on a series of PRs to implement "Durable
Attestation", also known as "Offline Attestation" (enhancement #73).

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>