### PR TITLE
Extracts (and uses) TPM clock information from the quote

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -99,6 +99,7 @@ def _from_db_obj(agent_db_obj):
         "mtls_cert",
         "ak_tpm",
         "attestation_count",
+        "tpm_clockinfo",
     ]
     agent_dict = {}
     for field in fields:

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -47,6 +47,7 @@ class VerfierMain(Base):
     ak_tpm = Column(String(500))
     mtls_cert = Column(String(2048), nullable=True)
     attestation_count = Column(Integer)
+    tpm_clockinfo = Column(JSONPickleType(pickler=JSONPickler))
 
 
 class VerifierAllowlist(Base):

--- a/keylime/migrations/versions/4089e1c79be9_add_tpm_clockinfo.py
+++ b/keylime/migrations/versions/4089e1c79be9_add_tpm_clockinfo.py
@@ -1,0 +1,41 @@
+"""add_tpm_clockinfo
+
+Revision ID: 4089e1c79be9
+Revises: 4329e2d14944
+Create Date: 2022-08-08 16:29:41.784890
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+import keylime
+
+# revision identifiers, used by Alembic.
+revision = "4089e1c79be9"
+down_revision = "4329e2d14944"
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()[f"upgrade_{engine_name}"]()
+
+
+def downgrade(engine_name):
+    globals()[f"downgrade_{engine_name}"]()
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+    op.add_column("verifiermain", sa.Column("tpm_clockinfo", keylime.db.verifier_db.JSONPickleType(), nullable=True))
+
+
+def downgrade_cloud_verifier():
+    op.drop_column("verifiermain", "tpm_clockinfo")

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -40,7 +40,17 @@ from pathlib import Path
 import dbus
 from cryptography.hazmat.primitives import serialization
 
-from keylime import api_version, config, crypto, fs_util, json, secure_mount, tenant, tornado_requests
+from keylime import (
+    api_version,
+    cloud_verifier_common,
+    config,
+    crypto,
+    fs_util,
+    json,
+    secure_mount,
+    tenant,
+    tornado_requests,
+)
 from keylime.cmd import user_data_encrypt
 from keylime.common import algorithms
 from keylime.ima import ima
@@ -573,9 +583,11 @@ class TestRestful(unittest.TestCase):
         self.assertIn("quote", json_response["results"], "Malformed response body!")
         self.assertIn("pubkey", json_response["results"], "Malformed response body!")
 
+        agentAttestState = cloud_verifier_common.get_AgentAttestStates().get_by_agent_id(tenant_templ.agent_uuid)
+
         # Check the quote identity
         failure = tpm_instance.check_quote(
-            tenant_templ.agent_uuid,
+            agentAttestState,
             nonce,
             json_response["results"]["pubkey"],
             json_response["results"]["quote"],
@@ -853,8 +865,10 @@ class TestRestful(unittest.TestCase):
         quote = json_response["results"]["quote"]
         hash_alg = algorithms.Hash(json_response["results"]["hash_alg"])
 
+        agentAttestState = cloud_verifier_common.get_AgentAttestStates().get_by_agent_id(tenant_templ.agent_uuid)
+
         failure = tpm_instance.check_quote(
-            tenant_templ.agent_uuid, nonce, public_key, quote, aik_tpm, self.tpm_policy, hash_alg=hash_alg
+            agentAttestState, nonce, public_key, quote, aik_tpm, self.tpm_policy, hash_alg=hash_alg
         )
         self.assertTrue(not failure)
 


### PR DESCRIPTION
With this chnage, the `verifier` will now use the `tpm2_print` command
to extract clock information from the quote. It will then uses this
information to make decisions about the attestation of the agent (i.e.,
the quote timestamp has to monotonically grow in a TPM which wasn't
restarted/reset). In order to make this comparison the clock information
from the previous quote is stored on the database and then both
timestamps are compared.

While this is not strictly needed for the current implementation of the
"online attestation", it will add yet another attestation check to it,
and is crucial to  "Durable Attestation", also known as "Offline
Attestation" (enhancement #73).

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>