### PR TITLE
Fixes #1063 in a minimalistic way, by making log output configurable

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -249,7 +249,6 @@ database_pool_sz_ovfl=5,10
 
 auto_migrate_db = True
 
-
 # The number of worker processes to use for the cloud verifier.
 # Set to "0" to create one worker per processor.
 multiprocessing_pool_num_workers = 0
@@ -339,6 +338,12 @@ tomtou_errors = False
 # associated key be sent alongside newly-created allowlists, and will perform a
 # signature check before storing them in the database.
 require_allow_list_signatures = False
+
+# Destination for log output, in addition to console. Values can be 'file', 
+# with the file being named after the "service" - cloud_verifier - created under 
+# /var/log/keylime), 'stream' or it can be left empty (which results in 
+# logging to console only, recommended when running inside a container)
+log_destination = file
 
 #=============================================================================
 [tenant]
@@ -584,6 +589,12 @@ auto_migrate_db = True
 
 # The file to use for SQLite persistence of provider hypervisor data.
 prov_db_filename = provider_reg_data.sqlite
+
+# Destination for log output, in addition to console. Values can be 'file',
+# with the file being named after the "service" - registrar - created under
+# /var/log/keylime), 'stream' or it can be left empty (which results in
+# logging to console only, recommended when running inside a container)
+log_destination = file
 
 #=============================================================================
 [ca]

--- a/keylime/keylime_logging.py
+++ b/keylime/keylime_logging.py
@@ -6,8 +6,17 @@ from typing import Any, Callable, Dict
 
 from keylime import config
 
-LOG_TO_FILE = ["registrar", "provider_registrar", "cloudverifier"]
+LOG_TO_FILE = []
 LOG_TO_STREAM = []
+for svc in ["registrar", "cloud_verifier"]:
+    logdest = config.get(svc, "log_destination", fallback="")
+
+    if logdest == "file":
+        LOG_TO_FILE.append(svc)
+
+    if logdest == "stream":
+        LOG_TO_STREAM.append(svc)
+
 LOGDIR = os.getenv("KEYLIME_LOGDIR", "/var/log/keylime")
 # not clear that this works right.  console logging may not work
 LOGSTREAM = os.path.join(LOGDIR, "keylime-stream.log")


### PR DESCRIPTION
This PR just removes the hard-coded log file destination, replacing it
with two attributes on `keylime.conf`. In the future, more work will be
needed in order to make the logging system more robust and configurable,
but this minimalistic set of changes fixes a clear and present
operational problem (in production deployments)

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>