### PR TITLE
Refactor allowlist handling on verifier to prevent premature DB writes

### DIFF
--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -380,10 +380,10 @@ class TestRestful(unittest.TestCase):
 
         # Set up allowlist bundles. Use invalid exclusion list regex for bad bundle.
         cls.ima_policy_bundle = ima.read_allowlist()
-        cls.ima_policy_bundle["excllist"] = base64.b64encode(json.dumps([]).encode()).decode()
+        cls.ima_policy_bundle["excllist"] = []
 
         cls.bad_ima_policy_bundle = ima.read_allowlist()
-        cls.bad_ima_policy_bundle["excllist"] = base64.b64encode(json.dumps(["*"]).encode()).decode()
+        cls.bad_ima_policy_bundle["excllist"] = ["*"]
 
     def setUp(self):
         """Nothing to set up before each test"""


### PR DESCRIPTION
This PR refactors how allowlists are handled on the verifier, with the goal of catching a few edge cases where database writes could have happened before the verifier realized that an incoming request was incorrect.

Concrete example: user attempts to add an agent and allowlist, but provides an agent UUID that is already in use. Prior to this PR, adding the agent would fail with an error, while adding the allowlist would silently succeed. This would cause additional problems later on. This is fixed by making sure that the verifier won't attempt any database writes of any kind until all sanity checks have succeeded.

This PR also fixes a broken test that used incorrect dummy data (specifically, `test_040_agent_quotes_integrity_get` in `test_restful.py`).

Most of this PR is just moving existing code around; hopefully the end result also makes more logical sense to read than before. I've included a few comments where I thought they might be helpful.

Resolves https://github.com/keylime/keylime/issues/1073. Thanks to @maugustosilva for the report, which caused me to look further into this and write the fix.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>