### PR TITLE
Fix for cloudverifier_tornado: retry 408 errors instead of failing attestation immediately

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -868,7 +868,7 @@ async def invoke_get_quote(agent, ima_policy, need_pubkey):
 
     if response.status_code != 200:
         # this is a connection error, retry get quote
-        if response.status_code in [500, 599]:
+        if response.status_code in [408, 500, 599]:
             asyncio.ensure_future(process_agent(agent, states.GET_QUOTE_RETRY))
         else:
             # catastrophic error, do not continue
@@ -936,7 +936,7 @@ async def invoke_provide_v(agent):
     response = await res
 
     if response.status_code != 200:
-        if response.status_code in [500, 599]:
+        if response.status_code in [408, 500, 599]:
             asyncio.ensure_future(process_agent(agent, states.PROVIDE_V_RETRY))
         else:
             # catastrophic error, do not continue


### PR DESCRIPTION
This small issue was found as a side effect during scale testing the keylime rust agent.

Executive summary
--
When verifiers are running in a busy environment, tornado sometimes generates http 408 return codes ("connection timed out"). This can be caused by network traffic or load network buffer overruns -- any number of causes. The correct behavior of cloudverifier-tornado *should be* to retry 408 failures with the usual exponential backoff algorithm.

Test setup
--
The setup involves 5 verifiers and 680 agents (all rust agents) running attestation at the usual 2 second rate. Everything is running in small virtual machines, which means that the verifiers are overloaded. In our setup we clocked about 10 failures in 24 hours. With the unmodified code this means the same amount of attestation failures, quite annoying for a large scale cluster, even as the setup is unrealistic in terms of pressure on the verifiers.

The reason this bug was found _now_ is because with the small RAM and CPU signature of the rust agent we were able to double the simulation density of the cluster (but we did not also double the number of verifiers). The test shows the new-found solidity of the rust agent, but also resulted in this small finding about the verifier.

Outcome
--
With the fix we have reduced the number of spontaneous attestation failures to zero in the first 24 hours of testing.




Signed-off-by: George Almasi <gheorghe@us.ibm.com>