### PR TITLE
Prevent deletion of in-use allowlists + better error handling

### DIFF
--- a/keylime/ima/file_signatures.py
+++ b/keylime/ima/file_signatures.py
@@ -50,6 +50,7 @@ class HashAlgo(enum.IntEnum):
 
 
 # Streebog is supported by evmctl
+# pylint: disable=E1101
 @utils.register_interface(hashes.HashAlgorithm)
 class MyStreebog256:
     """Basic class for Streebog256"""
@@ -59,6 +60,7 @@ class MyStreebog256:
     block_size = 64
 
 
+# pylint: disable=E1101
 @utils.register_interface(hashes.HashAlgorithm)
 class MyStreebog512:
     """Basic class for Streebog512"""

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -662,7 +662,7 @@ class Tenant:
 
         if response.status_code == 409:
             # this is a conflict, need to update or delete it
-            logger.error("Agent %s already existed at CV. Please use delete or update.", self.agent_uuid)
+            Tenant._print_json_response(response)
             sys.exit()
         elif response.status_code != 200:
             keylime_logging.log_http_response(logger, logging.ERROR, response.json())

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -828,6 +828,17 @@ class TestRestful(unittest.TestCase):
         json_response = response.json()
         self.assertIn("results", json_response, "Malformed response body!")
 
+    def test_035_test_delete_in_use_allowlist(self):
+        """Test CV's DELETE /allowlists/{name} Interface with an in-use allowlist (should return non-successful status code)"""
+        cv_client = RequestsClient(tenant_templ.verifier_base_url, tls_enabled)
+        response = cv_client.delete(
+            f"/v{self.api_version}/allowlists/{tenant_templ.agent_uuid}", cert=tenant_templ.cert, verify=False
+        )
+
+        self.assertEqual(
+            response.status_code, 409, "Unexpected status code for CV allowlist Delete of in-use allowlist!"
+        )
+
     # Agent Poll Testset
 
     def test_040_agent_quotes_integrity_get(self):


### PR DESCRIPTION
Previously, it was possible to delete an allowlist from the verifier while that allowlist was still in use by an agent. Doing so would break the agent on the verifier, and make it impossible to delete (and generally put the verifier in an unrecoverable state). This PR adds a safeguard against that scenario.

It also improves error messaging for `409` errors returned by the verifier; prior to the Allowlists API, that error was assumed to be an agent conflict, but now it can also be due to an allowlist conflict. Error messages should better reflect that now.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>