### PR TITLE
This commit solves #1091 by adding a per-agent verifier-issued epoch timestamp

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -181,6 +181,8 @@ def process_quote_response(agent, ima_policy, json_response, agentAttestState) -
     )  # TODO: change this to always False after initial update
     failure.merge(quote_validation_failure)
 
+    agent["last_received_quote"] = time.time()
+
     if not failure:
         agent["attestation_count"] += 1
 
@@ -277,6 +279,7 @@ def process_get_status(agent):
         "severity_level": agent.severity_level,
         "last_event_id": agent.last_event_id,
         "attestation_count": agent.attestation_count,
+        "last_received_quote": agent.last_received_quote,
     }
     return response
 

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -99,6 +99,7 @@ def _from_db_obj(agent_db_obj):
         "mtls_cert",
         "ak_tpm",
         "attestation_count",
+        "last_received_quote",
         "tpm_clockinfo",
     ]
     agent_dict = {}
@@ -461,6 +462,7 @@ class AgentsHandler(BaseHandler):
                     agent_data["verifier_ip"] = config.get("cloud_verifier", "cloudverifier_ip")
                     agent_data["verifier_port"] = config.get("cloud_verifier", "cloudverifier_port")
                     agent_data["attestation_count"] = 0
+                    agent_data["last_received_quote"] = 0
 
                     # TODO: Always error for v1.0 version after initial upgrade
                     if agent_data["mtls_cert"] is None and agent_data["supported_version"] != "1.0":

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, ForeignKey, Integer, LargeBinary, PickleType, String, Text, schema
+from sqlalchemy import Column, Float, ForeignKey, Integer, LargeBinary, PickleType, String, Text, schema
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
@@ -47,6 +47,7 @@ class VerfierMain(Base):
     ak_tpm = Column(String(500))
     mtls_cert = Column(String(2048), nullable=True)
     attestation_count = Column(Integer)
+    last_received_quote = Column(Float)
     tpm_clockinfo = Column(JSONPickleType(pickler=JSONPickler))
 
 

--- a/keylime/migrations/versions/a09cc94177f0_add_last_received_quote.py
+++ b/keylime/migrations/versions/a09cc94177f0_add_last_received_quote.py
@@ -1,0 +1,39 @@
+"""add_last_received_quote
+
+Revision ID: a09cc94177f0
+Revises: 4089e1c79be9
+Create Date: 2022-08-30 12:16:37.506940
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a09cc94177f0"
+down_revision = "4089e1c79be9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()[f"upgrade_{engine_name}"]()
+
+
+def downgrade(engine_name):
+    globals()[f"downgrade_{engine_name}"]()
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+    op.add_column("verifiermain", sa.Column("last_received_quote", sa.Float, nullable=True))
+
+
+def downgrade_cloud_verifier():
+    op.drop_column("verifiermain", "last_received_quote")


### PR DESCRIPTION
A new DB column, containing an epoch timestamp (from the verifier)
records when a quote was received. This new column is then exposed as an
additional parameter on the API (whenever agent status is requested).

In case a verifier thread dealing with an  agent dies (while the
verifier process remains responsive) or in case of a multi-verifier
configuration (where a whole verifier could die, while one keeps
requesting status from a different verifier), there is a way for an user
to make a decision about the "age" of the last successful attestation.

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>