### PR TITLE
Adds two small utilities which are used by "Offline Attestation" (enhancement #73)

### DIFF
--- a/keylime/crypto.py
+++ b/keylime/crypto.py
@@ -59,11 +59,15 @@ def get_public_key(private_key):
     return public_key
 
 
-def rsa_sign(key, message):
+def rsa_sign(key, message, paddingt="internal"):
     """RSA sign message"""
-    signature = key.sign(
-        message, padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH), hashes.SHA256()
-    )
+    if paddingt == "internal":
+        _padding = padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH)
+
+    if paddingt == "default":
+        _padding = padding.PKCS1v15()
+
+    signature = key.sign(message, _padding, hashes.SHA256())
     return base64.b64encode(signature)
 
 

--- a/keylime/web_util.py
+++ b/keylime/web_util.py
@@ -14,7 +14,7 @@ from keylime import api_version as keylime_api_version
 from keylime import ca_util, config, json
 
 
-def init_mtls(section="cloud_verifier", generatedir="cv_ca", logger=None):
+def init_mtls(section="cloud_verifier", generatedir="cv_ca", logger=None, generate_context=True):
     """
     Generates mTLS SSLContext for either the cloud verifier or the registrar.
     """
@@ -97,8 +97,10 @@ def init_mtls(section="cloud_verifier", generatedir="cv_ca", logger=None):
     check_client_cert = config.has_option(section, "check_client_cert") and config.getboolean(
         section, "check_client_cert"
     )
-    context = generate_mtls_context(my_cert, my_priv_key, ca_path, check_client_cert, my_key_pw, logger=logger)
-
+    if generate_context:
+        context = generate_mtls_context(my_cert, my_priv_key, ca_path, check_client_cert, my_key_pw, logger=logger)
+    else:
+        context = None
     return context, (my_cert, my_priv_key, my_key_pw)
 
 


### PR DESCRIPTION
After discussing with @mepeters and @ansasaki, I have decided to hold
off on the "main" PRs for "Offline Attestation" (a.k.a. "Durable
Attestation" or DA) until after #1068 is merged. Meanwhile this small PR
introduces changes used by DA: a small utility to locate (registrar or
verifier) mTLS certs from the config file and another to sign artifacts
using such certs in a format which is acceptable by Rekor (Transparency
Log)

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>