### PR TITLE
Fixes #1072 by explicitly and carefully dealing with yet another corn…

### DIFF
--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -72,7 +72,8 @@ class ProtectedHandler(BaseHTTPRequestHandler, SessionManager):
             try:
                 agent = session.query(RegistrarMain).filter_by(agent_id=agent_id).first()
             except SQLAlchemyError as e:
-                logger.error("SQLAlchemy Error: %s", e)
+                logger.error("SQLAlchemy Error for agent ID %s: %s", agent_id, e)
+                return
 
             if agent is None:
                 web_util.echo_json_response(self, 404, f"agent {agent_id} not found")


### PR DESCRIPTION
…er case.

If the `registrar` is unable to retrieve the agent data from the
datatabase (for whatever reason), properly log it (including agent ID),
and avoid the `UnboundLocalError`.

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>