### PR TITLE
A fix for "per-agent verifier-issued epoch timestamp"

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -181,7 +181,7 @@ def process_quote_response(agent, ima_policy, json_response, agentAttestState) -
     )  # TODO: change this to always False after initial update
     failure.merge(quote_validation_failure)
 
-    agent["last_received_quote"] = time.time()
+    agent["last_received_quote"] = int(time.time())
 
     if not failure:
         agent["attestation_count"] += 1

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Float, ForeignKey, Integer, LargeBinary, PickleType, String, Text, schema
+from sqlalchemy import Column, ForeignKey, Integer, LargeBinary, PickleType, String, Text, schema
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
@@ -47,7 +47,7 @@ class VerfierMain(Base):
     ak_tpm = Column(String(500))
     mtls_cert = Column(String(2048), nullable=True)
     attestation_count = Column(Integer)
-    last_received_quote = Column(Float)
+    last_received_quote = Column(Integer)
     tpm_clockinfo = Column(JSONPickleType(pickler=JSONPickler))
 
 

--- a/keylime/migrations/versions/a09cc94177f0_add_last_received_quote.py
+++ b/keylime/migrations/versions/a09cc94177f0_add_last_received_quote.py
@@ -32,7 +32,7 @@ def downgrade_registrar():
 
 
 def upgrade_cloud_verifier():
-    op.add_column("verifiermain", sa.Column("last_received_quote", sa.Float, nullable=True))
+    op.add_column("verifiermain", sa.Column("last_received_quote", sa.Integer(), nullable=True))
 
 
 def downgrade_cloud_verifier():


### PR DESCRIPTION
In some database backends, such as MySQL, the use of a float as column lead to representation and rounding errors. In order to preserve the information in the most backend-agnostic way possible, we will simply use string (varchar)