### PR TITLE
Fix testing with the rust agent

### DIFF
--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -1016,6 +1016,10 @@ class TestRestful(unittest.TestCase):
     def test_076_agent_quotes_integrity_get(self):
         self.test_040_agent_quotes_integrity_get()
 
+    @unittest.skipIf(SKIP_RUST_TEST, "Testing against rust-keylime is disabled!")
+    async def test_077_agent_keys_verify_get(self):
+        await self.test_041_agent_keys_verify_get()
+
     def tearDown(self):
         """Nothing to bring down after each test"""
         return


### PR DESCRIPTION
Fix testing with the rust agent (triggered by setting the `RUST_TEST` environment variable)

This depends on:

- https://github.com/keylime/rust-keylime/pull/448
  - Uses the `tpm_ownerpassword` when generating the EK
- https://github.com/keylime/rust-keylime/pull/432
  - Add the `tpm_ownerpassword` to the `keylime-agent.conf`

One test is still skipped due to https://github.com/keylime/rust-keylime/issues/447

Add a test case for the `/keys/verify` endpoint for the rust agent