### PR TITLE
Replace use of cryptography.utils.register_interface

### DIFF
--- a/keylime/ima/file_signatures.py
+++ b/keylime/ima/file_signatures.py
@@ -3,7 +3,7 @@ import enum
 import json
 import struct
 
-from cryptography import utils, x509
+from cryptography import x509
 from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives import hashes, serialization
@@ -50,9 +50,7 @@ class HashAlgo(enum.IntEnum):
 
 
 # Streebog is supported by evmctl
-# pylint: disable=E1101
-@utils.register_interface(hashes.HashAlgorithm)
-class MyStreebog256:
+class MyStreebog256(hashes.HashAlgorithm):
     """Basic class for Streebog256"""
 
     name = "streebog256"
@@ -60,9 +58,7 @@ class MyStreebog256:
     block_size = 64
 
 
-# pylint: disable=E1101
-@utils.register_interface(hashes.HashAlgorithm)
-class MyStreebog512:
+class MyStreebog512(hashes.HashAlgorithm):
     """Basic class for Streebog512"""
 
     name = "streebog512"


### PR DESCRIPTION
```
$ pip show cryptography | head -2
Name: cryptography
Version: 38.0.1

$ ./bin/keylime_tenant --help
...
AttributeError: module 'cryptography.utils' has no attribute
'register_interface'. Did you mean: 'verify_interface'?
```

Latest `cryptography` lib dropped register_interface: https://github.com/pyca/cryptography/pull/7234

Recommendation is to just subclass directly, as was done in similar case here:
https://github.com/secdev/scapy/pull/3732/commits/488641868f8f5e54e6fe2dc7ba8fc4b30231d629

pylint exclusions aren't needed after this I think.
Proving `keylime_tenant --help` worked was the extent of my testing.