### PR TITLE
GH first-interaction action is busted, workaround

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/first-interaction@v1
+      continue-on-error: true
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: 'Thank you for reporting your first issue. If the issue relates to a change you intend to work on, please ask that someone assign it to you.'

--- a/.github/workflows/submit-PR-coverage.yaml
+++ b/.github/workflows/submit-PR-coverage.yaml
@@ -5,6 +5,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: true
     name: Submit code coverage from Packit tests
     defaults:
       run:


### PR DESCRIPTION
This works around a busted actions/first-interaction@v1 until it's fixed https://github.com/actions/first-interaction/issues/101

Even after it's fixed it's probably good to keep around just so it won't block merges in the future.

Signed-off-by: Michael Peters <mpeters@redhat.com>