### PR TITLE
README, docs: remove reference to ipsec demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ CRL.  To enable this feature, run:
 
 The revocation key will be automatically created by the tenant the first time
 you use the CA with keylime.  Currently the CRL is only written back to the CA
-directory, unless IPsec configuration is being used (see [Additional Reading](#additional-reading)).
+directory.
 
 ## Systemd service support
 
@@ -425,9 +425,6 @@ Please, see [TESTING.md](TESTING.md) for details.
 * See the HotCloud 2018 paper: [docs/old/hotcloud18.pdf](https://github.com/keylime/keylime/blob/master/docs/old/hotcloud18.pdf)
 * Details about Keylime REST API: [docs/old/keylime RESTful API.docx](https://github.com/keylime/keylime/raw/master/docs/old/keylime%20RESTful%20API.docx)
 * [Bundling a portable Cloud Agent](https://github.com/keylime/keylime/blob/master/docs/old/cloud-agent-tarball-notes.md) - Create portable tarball of Cloud Agent, for usage on systems without python and other dependencies.
-* IPsec Configurations
-  * [IPsec with Libreswan](auto-ipsec/libreswan) - Configuring Keylime with a Libreswan backend for IPsec functionality.
-  * [IPsec with Racoon](auto-ipsec/racoon) - Configuring Keylime with a Racoon backend for IPsec functionality.
 * [Demo files](demo/) - Some pre-packaged demos to show off what Keylime can do.
 * [IMA stub service](ima_stub_service/) - Allows you to test IMA and keylime on a machine without a TPM.  Service keeps emulated TPM synchronized with IMA.
 

--- a/docs/user_guide/secure_payload.rst
+++ b/docs/user_guide/secure_payload.rst
@@ -117,10 +117,6 @@ malicious things.  So, revocation actions are for other well-behaving Agents in
 the system to take action against the revoked Agent.  For example, by revoking
 its certificate as described above or firewalling it from the network, etc.
 
-There are several revocation actions implemented in Keylime that you can look at
-to get an idea of how to write your own.  See the files starting with `local_action`
-in https://github.com/keylime/keylime/tree/master/auto-ipsec/libreswan/src
-
 There are some conventions to specifying revocation actions. As described above,
 their names must start with `local_action` to be executed. They also must be
 listed (without `.py` extensions) in a comma separated list in a file called


### PR DESCRIPTION
This demo was removed because it was unmaintained.
