### PR TITLE
elchecking/tests: fix type hints for Dispatcher

### DIFF
--- a/keylime/elchecking/tests.py
+++ b/keylime/elchecking/tests.py
@@ -176,7 +176,7 @@ class Dispatcher(Test):
         self.key_names = key_names
         self.tests = {}
 
-    def set(self, key_vals: typing.Tuple[str, ...], test: Test) -> None:
+    def set(self, key_vals: typing.Tuple[typing.Union[int, str], ...], test: Test) -> None:
         """Set the test for the given value tuple"""
         if len(key_vals) != len(self.key_names):
             raise Exception(f"{key_vals!a} does not match length of {self.key_names}")


### PR DESCRIPTION
The values can also be an int in the case of the PCRs.
