### PR TITLE
Revert "tenant: open file to send utf-8 encoded"

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -324,7 +324,7 @@ class Tenant:
                 else:
                     raise UserError("Invalid file payload provided")
             else:
-                with open(args["file"], encoding="utf-8") as f:
+                with open(args["file"], 'rb') as f:
                     contents = f.read()
             ret = user_data_encrypt.encrypt(contents)
             self.K = ret["k"]

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -324,7 +324,7 @@ class Tenant:
                 else:
                     raise UserError("Invalid file payload provided")
             else:
-                with open(args["file"], 'rb') as f:
+                with open(args["file"], "rb") as f:
                     contents = f.read()
             ret = user_data_encrypt.encrypt(contents)
             self.K = ret["k"]


### PR DESCRIPTION
This reverts commit a86588956cfedb64733c841152df17dbca4a3298.

By restricting files to be sent to be utf-8 encoded, this commit made impossible to send zipped payloads using the tenant '-f' sub-option of the 'add' command.

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>