### PR TITLE
Allow encrypting arbitraty binary input

### DIFF
--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -458,7 +458,7 @@ def write_private(inp):
 
     priv_encoded = yaml.dump(priv, Dumper=SafeDumper)
     key = crypto.kdf(global_password, salt)
-    ciphertext = crypto.encrypt(priv_encoded, key)
+    ciphertext = crypto.encrypt(priv_encoded.encode("utf-8"), key)
     towrite = {"salt": salt, "priv": ciphertext}
 
     mask = os.umask(0o037)

--- a/keylime/cmd/user_data_encrypt.py
+++ b/keylime/cmd/user_data_encrypt.py
@@ -16,10 +16,8 @@ def encrypt(contents):
     u = crypto.strbitxor(k, v)
     ciphertext = crypto.encrypt(contents, k)
 
-    try:
-        recovered = crypto.decrypt(ciphertext, k).decode("utf-8")
-    except UnicodeDecodeError:
-        recovered = crypto.decrypt(ciphertext, k)
+    # Try decrypting to check encrypted content
+    recovered = crypto.decrypt(ciphertext, k)
 
     if recovered != contents:
         raise Exception("Test decryption failed")
@@ -36,7 +34,7 @@ def main(argv=sys.argv):  # pylint: disable=dangerous-default-value
         print(f"ERROR: File %s not found. {infile}")
         usage()
 
-    with open(infile, encoding="utf-8") as f:
+    with open(infile, "rb") as f:
         contents = f.read()
 
     ret = encrypt(contents)

--- a/keylime/crypto.py
+++ b/keylime/crypto.py
@@ -189,11 +189,7 @@ def encrypt(plaintext, key):
         plaintext = b""
     iv = generate_random_key(aes_block_size)
     encryptor = Cipher(algorithms.AES(key), modes.GCM(iv), backend=default_backend()).encryptor()
-    # The following try/except captures both str and bytes
-    try:
-        cipher_text = encryptor.update(plaintext.encode("ascii")) + encryptor.finalize()
-    except Exception:
-        cipher_text = encryptor.update(plaintext) + encryptor.finalize()
+    cipher_text = encryptor.update(plaintext) + encryptor.finalize()
     return base64.b64encode(iv + cipher_text + encryptor.tag)
 
 

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -324,7 +324,7 @@ class Tenant:
                 else:
                     raise UserError("Invalid file payload provided")
             else:
-                with open(args["file"], encoding="utf-8") as f:
+                with open(args["file"], "rb") as f:
                     contents = f.read()
             ret = user_data_encrypt.encrypt(contents)
             self.K = ret["k"]

--- a/test/test_restful.py
+++ b/test/test_restful.py
@@ -357,8 +357,7 @@ class TestRestful(unittest.TestCase):
     def setUpClass(cls):
         """Prepare the keys and payload to give to the CV"""
         contents = "random garbage to test as payload"
-        # contents = contents.encode('utf-8')
-        ret = user_data_encrypt.encrypt(contents)
+        ret = user_data_encrypt.encrypt(contents.encode("utf-8"))
         cls.K = ret["k"]
         cls.U = ret["u"]
         cls.V = ret["v"]


### PR DESCRIPTION
Do not require the input data to be utf-8 encoded and read as raw bytes instead. 
This allows binary files to be sent using the tenant `-f` sub-option of the `add` command, including zipped payloads.

This reverts #1141