### PR TITLE
Fix improper handling of IMA policy bundle when none is provided

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -487,7 +487,7 @@ class AgentsHandler(BaseHandler):
                     # - Name, policy: store policy using name
 
                     ima_policy_name = json_body.get("ima_policy_name")
-                    ima_policy_bundle = json.loads(json_body.get("ima_policy_bundle"))
+                    ima_policy_bundle = json.loads(json_body.get("ima_policy_bundle", "{}"))
 
                     # Get policy from payload if present
                     if ima_policy_bundle:


### PR DESCRIPTION
Thanks to @THS-on for reporting the bug - when a request to add an agent is made to the Keylime verifier with no `ima_policy_bundle` parameter, an error occurs. This fixes that error.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>