### PR TITLE
Move EK cert verification to cert_utils

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -501,6 +501,8 @@ require_ek_cert = True
 # PROVKEYS - contains a json document containing EK, EKcert, and AIK from the
 # provider.  EK and AIK are in PEM format.  The EKcert is in base64 encoded
 # DER format.
+# TPM_CERT_STORE - contains the path to the TPM certificates store, e.g.:
+# "/var/lib/keylime/tpm_cert_store".
 #
 # Set to blank to disable this check.  See warning above if require_ek_cert
 # is "False".

--- a/keylime/cert_utils.py
+++ b/keylime/cert_utils.py
@@ -1,13 +1,104 @@
-from cryptography.hazmat.primitives.serialization import load_der_public_key
-from pyasn1.codec.der import decoder, encoder
-from pyasn1_modules import rfc2459
+import io
+import sys
 
+from cryptography import exceptions as crypto_exceptions
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import ec, padding
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from pyasn1.codec.der import decoder, encoder
+from pyasn1_modules import pem, rfc2459
+
+from keylime import config, keylime_logging, tpm_ek_ca
 
 # Issue #944 -- python-cryptography won't parse malformed certs,
 # such as some Nuvoton ones we have encountered in the field.
 # Unfortunately, we still have to deal with such certs anyway.
-# Let's read the EK cert with pyasn1 instead of python-cryptography.
-def read_x509_der_cert_pubkey(der_cert_data):
-    """Returns the public key of a DER-encoded X.509 certificate"""
-    der509 = decoder.decode(der_cert_data, asn1Spec=rfc2459.Certificate())[0]
-    return load_der_public_key(encoder.encode(der509["tbsCertificate"]["subjectPublicKeyInfo"]))
+
+# Here we provide some helpers that use pyasn1 to parse the certificates
+# when parsing them with python-cryptography fails, and in this case, we
+# try to read the parsed certificate again into python-cryptograhy.
+
+logger = keylime_logging.init_logging("cert_utils")
+
+
+def x509_der_cert(der_cert_data: bytes):
+    """Load an x509 certificate provided in DER format
+    :param der_cert_data: the DER bytes of the certificate
+    :type der_cert_data: bytes
+    :returns: cryptography.x509.Certificate
+    """
+    try:
+        return x509.load_der_x509_certificate(data=der_cert_data, backend=default_backend())
+    except Exception as e:
+        logger.warning("Failed to parse DER data with python-cryptography: %s", e)
+        pyasn1_cert = decoder.decode(der_cert_data, asn1Spec=rfc2459.Certificate())[0]
+        return x509.load_der_x509_certificate(data=encoder.encode(pyasn1_cert), backend=default_backend())
+
+
+def x509_pem_cert(pem_cert_data: str):
+    """Load an x509 certificate provided in PEM format
+    :param pem_cert_data: the base-64 encoded PEM certificate
+    :type pem_cert_data: str
+    :returns: cryptography.x509.Certificate
+    """
+    try:
+        return x509.load_pem_x509_certificate(data=pem_cert_data.encode("utf-8"), backend=default_backend())
+    except Exception as e:
+        logger.warning("Failed to parse PEM data with python-cryptography: %s", e)
+        # Let's read the DER bytes from the base-64 PEM.
+        der_data = pem.readPemFromFile(io.StringIO(pem_cert_data))
+        # Now we can load it as we do in x509_der_cert().
+        pyasn1_cert = decoder.decode(der_data, asn1Spec=rfc2459.Certificate())[0]
+        return x509.load_der_x509_certificate(data=encoder.encode(pyasn1_cert), backend=default_backend())
+
+
+def verify_ek(ekcert, tpm_cert_store=config.get("tenant", "tpm_cert_store")):
+    """Verify that the provided EK certificate is signed by a trusted root
+    :param ekcert: The Endorsement Key certificate in DER format
+    :returns: True if the certificate can be verified, False otherwise
+    """
+    try:
+        trusted_certs = tpm_ek_ca.cert_loader(tpm_cert_store)
+    except Exception as e:
+        logger.warning("Error loading trusted certificates from the TPM cert store: %s", e)
+        return False
+
+    try:
+        ek509 = x509_der_cert(ekcert)
+        for cert_file, pem_cert in trusted_certs.items():
+            signcert = x509_pem_cert(pem_cert)
+            if ek509.issuer != signcert.subject:
+                continue
+
+            signcert_pubkey = signcert.public_key()
+            try:
+                if isinstance(signcert_pubkey, RSAPublicKey):
+                    signcert_pubkey.verify(
+                        ek509.signature,
+                        ek509.tbs_certificate_bytes,
+                        padding.PKCS1v15(),
+                        ek509.signature_hash_algorithm,
+                    )
+                elif isinstance(signcert_pubkey, EllipticCurvePublicKey):
+                    signcert_pubkey.verify(
+                        ek509.signature,
+                        ek509.tbs_certificate_bytes,
+                        ec.ECDSA(ek509.signature_hash_algorithm),
+                    )
+                else:
+                    logger.warning("Unsupported public key type: %s", type(signcert_pubkey))
+                    continue
+            except crypto_exceptions.InvalidSignature:
+                continue
+
+            logger.debug("EK cert matched cert: %s", cert_file)
+            return True
+    except Exception as e:
+        # Log the exception so we don't lose the raw message
+        logger.exception(e)
+        raise Exception("Error processing ek/ekcert. Does this TPM have a valid EK?").with_traceback(sys.exc_info()[2])
+
+    logger.error("No Root CA matched EK Certificate")
+    return False

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -261,11 +261,8 @@ class UnprotectedHandler(BaseHTTPRequestHandler, SessionManager):
                 # Note, we don't validate the EKCert here, other than the implicit
                 #  "is it a valid x509 cert" check. So it's still untrusted.
                 # This will be validated by the tenant.
-                ek_tpm = base64.b64encode(
-                    tpm2_objects.ek_low_tpm2b_public_from_pubkey(
-                        cert_utils.read_x509_der_cert_pubkey(base64.b64decode(ekcert))
-                    )
-                ).decode()
+                cert = cert_utils.x509_der_cert(base64.b64decode(ekcert))
+                ek_tpm = base64.b64encode(tpm2_objects.ek_low_tpm2b_public_from_pubkey(cert.public_key())).decode()
 
             aik_attrs = tpm2_objects.get_tpm2b_public_object_attributes(
                 base64.b64decode(aik_tpm),

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -795,7 +795,7 @@ class tpm(tpm_abstract.AbstractTPM):
             )
 
             trusted_certs = tpm_ek_ca.cert_loader()
-            for cert in trusted_certs:
+            for _, cert in trusted_certs.items():
                 signcert = x509.load_pem_x509_certificate(
                     data=cert.encode(),
                     backend=default_backend(),

--- a/keylime/tpm_ek_ca.py
+++ b/keylime/tpm_ek_ca.py
@@ -7,8 +7,7 @@ logger = keylime_logging.init_logging("tpm_ek_ca")
 trusted_certs = {}
 
 
-def check_tpm_cert_store():
-    tpm_cert_store = config.get("tenant", "tpm_cert_store")
+def check_tpm_cert_store(tpm_cert_store=config.get("tenant", "tpm_cert_store")):
     if not os.path.isdir(tpm_cert_store):
         logger.error("The directory %s does not exist.", tpm_cert_store)
         raise Exception(f"The directory {tpm_cert_store} does not exist.")
@@ -21,11 +20,10 @@ def check_tpm_cert_store():
         raise Exception(f"The directory {tpm_cert_store} does not contain " f"any .pem files")
 
 
-def cert_loader():
-    tpm_cert_store = config.get("tenant", "tpm_cert_store")
+def cert_loader(tpm_cert_store=config.get("tenant", "tpm_cert_store")):
     file_list = glob.glob(os.path.join(tpm_cert_store, "*.pem"))
-    my_trusted_certs = []
+    my_trusted_certs = {}
     for file_path in file_list:
         with open(file_path, encoding="utf-8") as f_input:
-            my_trusted_certs.append(f_input.read())
+            my_trusted_certs[file_path] = f_input.read()
     return my_trusted_certs

--- a/scripts/ek-openssl-verify
+++ b/scripts/ek-openssl-verify
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+# This script can be used as the `ek_check_script' (tenant configuration),
+# to attempt to verify a provided EK_CERT via env var using openssl.
+
+# EK             - contains a PEM-encoded version of the public EK
+# EK_CERT        - contains a base64 DER-encoded EK certificate if one is
+#                  available.
+# PROVKEYS       - contains a json document containing EK, EKcert, and AIK
+#                  from the provider. EK and AIK are in PEM format. The
+#                  EKcert is in base64-encoded DER format
+# TPM_CERT_STORE - contains the path of the TPM certificate store.
+EK=${EK:-}
+EK_CERT=${EK_CERT:-}
+PROVKEYS=${PROVKEYS:-}
+
+EK_VERIFICATION_LOG=${EK_VERIFICATION_LOG:-/var/log/keylime/ek-verification.log}
+LOG="${EK_VERIFICATION_LOG}"
+
+# Setting log fallback in case we cannot write to the specified file.
+touch "${LOG}" 2>/dev/null || LOG=/dev/stderr
+
+log() {
+  _stderr=${2:-}
+  echo "[$(date)] ${1}" >&2 >> "${LOG}"
+  [ -n "${_stderr}" ] && [ "${LOG}" != '/dev/stderr' ] && echo "${1}" >&2
+}
+
+die() {
+  log "ERROR: ${1}" _
+  exit 1
+}
+
+command -v openssl >/dev/null \
+  || die "openssl CLI was not found in the PATH; please make sure it is installed"
+
+[ -n "${EK_CERT}" ] || die "EK_CERT was not provided as an env var"
+
+# Cert store directory. If one is not provided via TPM_CERT_STORE env var,
+# we start by attempting to read tenant.conf.
+CERT_STORE=${TPM_CERT_STORE:-}
+
+if [ -z "${CERT_STORE}" ]; then
+  KEYLIME_CONFIG_DIR=${KEYLIME_CONFIG_DIR:-/etc/keylime}
+  [ -d "${KEYLIME_CONFIG_DIR}" ] \
+    || die "KEYLIME_CONFIG_DIR (${KEYLIME_CONFIG_DIR}) does not seem to exist"
+
+  if [ -r "${KEYLIME_CONFIG_DIR}"/tenant.conf ]; then
+    CERT_STORE="$(grep -w ^tpm_cert_store "${KEYLIME_CONFIG_DIR}"/tenant.conf \
+                  | tail -1 | cut -d'=' -f2 | tr -d "[:blank:]")"
+  fi
+
+  # Next we try to read any snippets in tenant.conf.d/
+  if [ -d "${KEYLIME_CONFIG_DIR}"/tenant.conf.d ]; then
+    for _s in "${KEYLIME_CONFIG_DIR}"/tenant.conf.d/*.conf; do
+      [ -e "${_s}" ] || continue
+      _store="$(grep -w ^tpm_cert_store "${_s}" \
+                | tail -1 | cut -d'=' -f2 | tr -d "[:blank:]")"
+      [ -n "${_store}" ] && CERT_STORE="${_store}"
+    done
+  fi
+fi
+
+[ -n "${CERT_STORE}" ] \
+  || die "It was not possible to determine the TPM cert store dir from tenant.conf or tenant.conf.d/ snippets"
+[ -d "${CERT_STORE}" ] \
+  || die "TPM cert store is not a valid directory (${CERT_STORE})"
+
+EK_VERIFICATION_TMPDIR=
+ek_verification_cleanup() {
+  [ -d "${EK_VERIFICATION_TMPDIR}" ] || return 0
+  rm -rf "${EK_VERIFICATION_TMPDIR}"
+}
+trap ek_verification_cleanup EXIT
+
+mkdir -p "${TMPDIR:-/tmp}"
+EK_VERIFICATION_TMPDIR="$(mktemp -d)" || \
+  die "Creating a temp dir for EK verification failed"
+
+EK_CERT_FILE_DER="${EK_VERIFICATION_TMPDIR}"/ek.der
+EK_CERT_FILE_PEM="${EK_VERIFICATION_TMPDIR}"/ek.pem
+
+printf '%s' "${EK_CERT}" > "${EK_CERT_FILE_DER}".b64
+base64 -d "${EK_CERT_FILE_DER}".b64 > "${EK_CERT_FILE_DER}"
+openssl x509 -inform der -in "${EK_CERT_FILE_DER}" > "${EK_CERT_FILE_PEM}"
+
+for c in "${CERT_STORE}"/*.pem; do
+  [ -e "${c}" ] || continue
+  log "Checking if ${c} is the issuer of EK cert..."
+  if openssl verify -partial_chain -CAfile "${c}" "${EK_CERT_FILE_PEM}" \
+                                           >>"${LOG}" 2>>"${LOG}"; then
+    log "${EK_CERT} successfully verified by $(basename "${c}")" _
+    exit 0
+  fi
+done
+
+die "EK signature did not match certificates from TPM cert store"
+# vim:set ts=2 sw=2 et:

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -107,19 +107,19 @@ fi
 # Set correct dependencies
 # Fedora
 if [ $PACKAGE_MGR = "dnf" ]; then
-    PYTHON_PREIN="python3"
+    PYTHON_PREIN="python3 openssl"
     PYTHON_DEPS="python3-pip python3-dbus"
 # RHEL / CentOS etc
 elif [ $PACKAGE_MGR = "yum" ]; then
-    PYTHON_PREIN="epel-release python36"
+    PYTHON_PREIN="epel-release python36 openssl"
     PYTHON_DEPS="python36-pip python36-dbus"
 # Ubuntu / Debian
 elif [ $PACKAGE_MGR = "apt-get" ]; then
-    PYTHON_PREIN="python3"
+    PYTHON_PREIN="python3 openssl"
     PYTHON_DEPS="python3-pip python3-dbus"
 # SUSE
 elif [ $PACKAGE_MGR = "zypper" ]; then
-    PYTHON_PREIN="python3"
+    PYTHON_PREIN="python3 openssl"
     PYTHON_DEPS="python3-pip python3-dbus"
 else
     echo "No recognized package manager found on this system!" 1>&2

--- a/test/test_cert_utils.py
+++ b/test/test_cert_utils.py
@@ -4,9 +4,12 @@ Copyright 2022 Red Hat, Inc.
 """
 
 import base64
+import os
 import unittest
 
-from keylime import cert_utils
+from keylime import cert_utils, tpm_ek_ca
+
+CERT_STORE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "tpm_cert_store"))
 
 
 class Cert_Utils_Test(unittest.TestCase):
@@ -67,3 +70,9 @@ rTJ1x4NA2ZtQMYyT29Yy1UlkjocAaXL5u0m3Hvz/////////////////////////////////////
             except Exception:
                 self.fail("read_x509_der_cert_pubkey() is not expected to raise an exception here")
             self.assertIsNotNone(pubkey)
+
+    def test_tpm_cert_store(self):
+        tpm_ek_ca.check_tpm_cert_store(CERT_STORE_DIR)
+        my_trusted_certs = tpm_ek_ca.cert_loader(CERT_STORE_DIR)
+
+        self.assertNotEqual(len(my_trusted_certs), 0)


### PR DESCRIPTION
We had partially addressed the issue we encountered when parsing some
certificates with python-cryptography by writing cert_utils module that
provided a single helper to parse the pubkey from a certificate.

However, we still were doing the EK validation in tpm_main using
python-cryptography, which means we would fall into the same parsing
problem again, since during the validation it would read all the certs
in the tpm cert store to check if it is signing the presented EK.

We address this issue by moving the EK cert verification to cert_utils:
we use the same approach as before, i.e. we parse the cert with pyasn1
when python-cryptography fails, and then use python-cryptography to do
the actual signature verification, as before.

By moving the method to cert_utils, it also becomes simpler to test it,
so in this commit we more tests to verify the methods work as expected.

Additionally, the updated EK verification is also capable of handling
ECDSA signatures