### PR TITLE
Disable dnf-makecache.service to save RAM

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -11,6 +11,7 @@
     script:
      - rm -f /etc/yum.repos.d/tag-repository.repo
      - ln -s $(pwd) /var/tmp/keylime_sources
+     - systemctl disable --now dnf-makecache.service || true
 
   discover:
     how: fmf
@@ -91,6 +92,7 @@
     script:
      - rm -f /etc/yum.repos.d/tag-repository.repo
      - ln -s $(pwd) /var/tmp/keylime_sources
+     - systemctl disable --now dnf-makecache.service || true
 
   discover:
     how: fmf


### PR DESCRIPTION
This service running on background can consume a lot of memory, resulting in OOM killer interrupting tests.

Signed-off-by: Karel Srot <ksrot@redhat.com>