### PR TITLE
Set permissions of keylime_agent_secure.mount to 664

### DIFF
--- a/services/installer.sh
+++ b/services/installer.sh
@@ -52,7 +52,7 @@ chown keylime:keylime -R /var/run/keylime
 chmod 664 /etc/systemd/system/keylime_agent.service
 chmod 664 /etc/systemd/system/keylime_registrar.service
 chmod 664 /etc/systemd/system/keylime_verifier.service
-chmod 666 /etc/systemd/system/keylime_agent_secure.mount
+chmod 664 /etc/systemd/system/keylime_agent_secure.mount
 
 chmod 700 /var/run/keylime
 


### PR DESCRIPTION
Currently, file permissions set by services/installer.sh are 666 which makes systemd to complain:

systemd[1]: Configuration file
/etc/systemd/system/keylime_agent_secure.mount
is marked world-writable. Please remove world writability permission bits. Proceeding anyway.

Signed-off-by: Karel Srot <ksrot@redhat.com>