### PR TITLE
Fix issue #1106 by handling reading a PCR from an unsupported PCR bank

### DIFF
--- a/keylime/cmd/ima_emulator_adapter.py
+++ b/keylime/cmd/ima_emulator_adapter.py
@@ -65,7 +65,12 @@ def main(argv=sys.argv):  # pylint: disable=dangerous-default-value
         position[pcr_hash_alg] = 0
 
     for pcr_hash_alg in dict(position):
-        pcr_val = tpm_instance.readPCR(config.IMA_PCR, pcr_hash_alg)
+        try:
+            pcr_val = tpm_instance.readPCR(config.IMA_PCR, pcr_hash_alg)
+        except Exception as ex:
+            print(f"Error: {ex}")
+            sys.exit(1)
+
         if codecs.decode(pcr_val.encode("utf-8"), "hex") != ast.get_START_HASH(pcr_hash_alg):
             print(
                 f"Warning: IMA PCR is not empty for hash algorithm {pcr_hash_alg}, "

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -1358,7 +1358,7 @@ class tpm(tpm_abstract.AbstractTPM):
         if jsonout is None:
             raise Exception("Could not read YAML output of tpm2_pcrread.")
 
-        if hash_alg not in jsonout:
+        if not jsonout.get(hash_alg):
             raise Exception(f"Invalid hashing algorithm '{hash_alg}' for reading PCR number {pcrval}.")
 
         # alg_size = Hash_Algorithms.get_hash_size(hash_alg)/4


### PR DESCRIPTION
This PR fixes issue #1106 by handling the failure when trying to read a PCR from an unsupported PCR bank