### PR TITLE
chore: shallow type fixes

### DIFF
--- a/keylime/api_version.py
+++ b/keylime/api_version.py
@@ -50,15 +50,15 @@ def normalize_version(v):
 
 
 def major(v):
-    version_ = version.parse(str(v))
-    assert isinstance(version_, version.Version)
-    return version_.major
+    v_obj = version.parse(str(v))
+    assert isinstance(v_obj, version.Version)
+    return v_obj.major
 
 
 def minor(v):
-    version_ = version.parse(str(v))
-    assert isinstance(version_, version.Version)
-    return version_.minor
+    v_obj = version.parse(str(v))
+    assert isinstance(v_obj, version.Version)
+    return v_obj.minor
 
 
 def log_api_versions(logger):

--- a/keylime/api_version.py
+++ b/keylime/api_version.py
@@ -42,7 +42,7 @@ def normalize_version(v):
     v = v.strip("/")
     base_version = version.parse(v).base_version
     # if the base version is a single number, get the latest minor version
-    if not "." in base_version:
+    if "." not in base_version:
         latest_minor = latest_minor_version(base_version)
         if latest_minor != "0":
             return latest_minor
@@ -50,11 +50,15 @@ def normalize_version(v):
 
 
 def major(v):
-    return version.parse(str(v)).major
+    version_ = version.parse(str(v))
+    assert isinstance(version_, version.Version)
+    return version_.major
 
 
 def minor(v):
-    return version.parse(str(v)).minor
+    version_ = version.parse(str(v))
+    assert isinstance(version_, version.Version)
+    return version_.minor
 
 
 def log_api_versions(logger):

--- a/keylime/ca_impl_openssl.py
+++ b/keylime/ca_impl_openssl.py
@@ -183,10 +183,10 @@ def gencrl(serials, cert: str, ca_pk: str):
     builder = builder.next_update(date_now)
 
     for serial in serials:
-        cert = x509.RevokedCertificateBuilder()
-        cert = cert.serial_number(int(serial))
-        cert = cert.revocation_date(date_now)
-        builder = builder.add_revoked_certificate(cert.build())
+        cert_builder = x509.RevokedCertificateBuilder()
+        cert_builder = cert_builder.serial_number(int(serial))
+        cert_builder = cert_builder.revocation_date(date_now)
+        builder = builder.add_revoked_certificate(cert_builder.build())
 
     crl = builder.sign(private_key=priv_key, algorithm=hashes.SHA256(), backend=default_backend())
     return crl.public_bytes(encoding=Encoding.DER)

--- a/keylime/cli/options.py
+++ b/keylime/cli/options.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 from keylime import keylime_logging
 
 logger = keylime_logging.init_logging("cli_opts")
@@ -7,7 +9,7 @@ class UserError(Exception):
     pass
 
 
-def get_opts_error(args):
+def get_opts_error(args) -> Tuple[bool, str]:
     if args.ima_exclude and not args.allowlist:
         return True, "--exclude cannot be used without an --allowlist"
     if args.allowlist and args.allowlist_url:
@@ -29,4 +31,4 @@ def get_opts_error(args):
         return True, "--allowlist-sig-url must also have --allowlist-sig-key"
     if args.allowlist_sig_key and not (args.allowlist_sig or args.allowlist_sig_url):
         return True, "--allowlist-sig-key must have either --allowlist-sig or --allowlist-sig-url"
-    return False, None
+    return False, ""

--- a/keylime/config.py
+++ b/keylime/config.py
@@ -27,7 +27,7 @@ def convert(data):
     if isinstance(data, bytes):
         return data.decode()
     if isinstance(data, dict):
-        return dict(map(convert, data.items()))
+        return dict(iter(map(convert, data.items())))
     if isinstance(data, tuple):
         return tuple(map(convert, data))
     if isinstance(data, list):

--- a/keylime/db/keylime_db.py
+++ b/keylime/db/keylime_db.py
@@ -96,8 +96,8 @@ class SessionManager:
         To use: session = self.make_session(engine)
         """
         self.engine = engine
+        Session = scoped_session(sessionmaker())
         try:
-            Session = scoped_session(sessionmaker())
             Session.configure(bind=self.engine)
         except SQLAlchemyError as e:
             logger.error("Error creating SQL session manager %s", e)

--- a/keylime/migrations/env.py
+++ b/keylime/migrations/env.py
@@ -25,9 +25,14 @@ logger = logging.getLogger("alembic.env")
 # gather section names referring to different
 # databases.  These are named "engine1", "engine2"
 # in the sample .ini file.
-db_names = context.get_x_argument(as_dictionary=True).get("db")
-if not db_names:
-    db_names = config.get_main_option("databases")
+db_names = ""
+db_names_ = context.get_x_argument(as_dictionary=True).get("db")
+if db_names_:
+    db_names = db_names_
+else:
+    db_names_ = config.get_main_option("databases")
+    if db_names_:
+        db_names = db_names_
 
 # add your model's MetaData objects here
 # for 'autogenerate' support.  These must be set

--- a/keylime/requests_client.py
+++ b/keylime/requests_client.py
@@ -1,5 +1,5 @@
 import requests
-from requests.adapters import HTTPAdapter
+from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter
 from requests.packages.urllib3.poolmanager import PoolManager  # pylint: disable=import-error
 
 
@@ -72,7 +72,7 @@ class HostNameIgnoreAdapter(HTTPAdapter):
 
         super().__init__(*args, **kwargs)
 
-    def init_poolmanager(self, connections, maxsize, block=requests.adapters.DEFAULT_POOLBLOCK, **pool_kwargs):
+    def init_poolmanager(self, connections, maxsize, block=DEFAULT_POOLBLOCK, **pool_kwargs):
         assert_hostname = False if self._ignore_hostname and self._tls_context else None
         self.poolmanager = PoolManager(
             num_pools=connections,

--- a/keylime/signing.py
+++ b/keylime/signing.py
@@ -52,6 +52,7 @@ def verify_signature(key, sig, file):
                 ctx = gpg.Context(home_dir=gpg_homedir)
                 try:
                     logger.debug("Importing GPG key")
+                    assert callable(ctx.key_import)
                     result = ctx.key_import(key)
                 except Exception as e:
                     raise Exception("Unable to import GPG key") from e

--- a/keylime/tpm/tpm2_objects_test.py
+++ b/keylime/tpm/tpm2_objects_test.py
@@ -2,6 +2,7 @@ import base64
 import unittest
 
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.x509 import load_der_x509_certificate
 
 from keylime.tpm.tpm2_objects import (
@@ -99,7 +100,9 @@ class TestTpm2Objects(unittest.TestCase):
             "OFx6eb/QB1+oAZewW2wRrwO4MQ=="
         )
         test_rsa_cert = load_der_x509_certificate(test_rsa_cert, backend=default_backend())
-        new_rsa_obj = ek_low_tpm2b_public_from_pubkey(test_rsa_cert.public_key())
+        test_rsa_pubkey = test_rsa_cert.public_key()
+        assert isinstance(test_rsa_pubkey, rsa.RSAPublicKey)
+        new_rsa_obj = ek_low_tpm2b_public_from_pubkey(test_rsa_pubkey)
         self.assertEqual(new_rsa_obj.hex(), correct_rsa_obj.hex())
 
     def test_tpm2b_public_from_pubkey_ec(self):
@@ -127,7 +130,9 @@ class TestTpm2Objects(unittest.TestCase):
             "wGqmoOwgqQSByVBrADgEVHlhS9J2tJQNMQ=="
         )
         test_ec_cert = load_der_x509_certificate(test_ec_cert, backend=default_backend())
-        new_ec_obj = ek_low_tpm2b_public_from_pubkey(test_ec_cert.public_key())
+        test_ec_pubkey = test_ec_cert.public_key()
+        assert isinstance(test_ec_pubkey, ec.EllipticCurvePublicKey)
+        new_ec_obj = ek_low_tpm2b_public_from_pubkey(test_ec_pubkey)
         self.assertEqual(new_ec_obj.hex(), correct_ec_obj.hex())
 
     def test_pubkey_from_tpm2b_public_rsa(self):
@@ -168,7 +173,9 @@ class TestTpm2Objects(unittest.TestCase):
             "OFx6eb/QB1+oAZewW2wRrwO4MQ=="
         )
         new_rsa_pubkey = pubkey_from_tpm2b_public(correct_rsa_obj)
+        assert isinstance(new_rsa_pubkey, rsa.RSAPublicKey)
         correct_rsa_pubkey = test_rsa_cert.public_key()
+        assert isinstance(correct_rsa_pubkey, rsa.RSAPublicKey)
         new_rsa_pubkey_n = new_rsa_pubkey.public_numbers()
         correct_rsa_pubkey_n = correct_rsa_pubkey.public_numbers()
         self.assertEqual(new_rsa_pubkey.key_size, correct_rsa_pubkey.key_size)
@@ -190,6 +197,7 @@ class TestTpm2Objects(unittest.TestCase):
                 "dde753"
             )
         )
+        assert isinstance(new_rsa_pubkey, rsa.RSAPublicKey)
         new_rsa_pubkey_n = new_rsa_pubkey.public_numbers()
 
         self.assertEqual(new_rsa_pubkey.key_size, 2048)
@@ -234,7 +242,10 @@ class TestTpm2Objects(unittest.TestCase):
         )
         test_ec_cert = load_der_x509_certificate(test_ec_cert, backend=default_backend())
         new_ec_pubkey = pubkey_from_tpm2b_public(correct_ec_obj)
+        assert isinstance(new_ec_pubkey, ec.EllipticCurvePublicKey)
+
         correct_ec_pubkey = test_ec_cert.public_key()
+        assert isinstance(correct_ec_pubkey, ec.EllipticCurvePublicKey)
         new_ec_pubkey_n = new_ec_pubkey.public_numbers()
         correct_ec_pubkey_n = correct_ec_pubkey.public_numbers()
         self.assertEqual(new_ec_pubkey_n.curve.name, correct_ec_pubkey_n.curve.name)
@@ -249,6 +260,7 @@ class TestTpm2Objects(unittest.TestCase):
                 "b53e348bc916b43a015e6ceefd947d685e59ff65357499f2c4788cba"
             )
         )
+        assert isinstance(new_ec_pubkey, ec.EllipticCurvePublicKey)
         new_ec_pubkey_n = new_ec_pubkey.public_numbers()
 
         self.assertEqual(new_ec_pubkey_n.curve.name, "secp256r1")

--- a/keylime/tpm_bootlog_enrich.py
+++ b/keylime/tpm_bootlog_enrich.py
@@ -65,6 +65,7 @@ def getGUID(b):
     ret = efivarlib_functions.efi_guid_to_str(b, byref(s))
     if ret < 0:
         raise Exception(f"getGUID: efi_guid_to_str({b}) returned {ret}")
+    assert isinstance(s.value, bytes)
     return s.value.decode("utf-8")  # pylint: disable=E1101
 
 

--- a/keylime/user_utils.py
+++ b/keylime/user_utils.py
@@ -80,8 +80,8 @@ def change_uidgid(user_and_group):
         except KeyError as e:
             raise ValueError(f"Could not resolve user {uid}: {e}") from e
 
+        groups = os.getgrouplist(username, gid)
         try:
-            groups = os.getgrouplist(username, gid)
             os.setgroups(groups)
         except (OSError, PermissionError) as e:
             raise RuntimeError(f"Could not set group list to {groups}: {e}") from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,14 @@ include = '\.pyi?$'
 [tool.isort]
 profile = "black"
 line_length = 120
+
+[tool.pyright]
+include = ["keylime"]
+ignore = [
+    "keylime/backport_dataclasses.py",
+    "keylime/keylime_agent.py",
+    "keylime/elchecking/",
+    "keylime/migrations/versions/",
+    "keylime/test/"
+]
+reportMissingImports = false


### PR DESCRIPTION
Following @stefanberger's suggestion, I am splitting #1139 into smaller PRs. This one provides "shallow" fixes, in the sense they should not change the behavior of the code at all:

- uninitialized variables
- variables initialized with wrong types
- missing/incomplete imports
- unspecified exceptions
- missing asserts (e.g., not None, instanceof, callable)
- missing type annotations