### PR TITLE
installer: Enable installation on RHEL-9

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -91,19 +91,32 @@ case "$ID" in
                 NEED_BUILD_TOOLS=1
                 CENTOS7_TSS_FLAGS="--enable-esapi=no --disable-doxygen-doc"
             ;;
-            8*)
+            8*|9*)
                 echo "${ID} ${VERSION_ID} selected."
                 PACKAGE_MGR=$(command -v dnf)
                 NEED_EPEL=1
                 PYTHON_PREIN="python3 python3-devel python3-setuptools python3-pip"
-                PYTHON_DEPS="gcc gcc-c++ openssl-devel python3-yaml python3-requests swig python3-cryptography wget git python3-tornado python3-zmq python3-gpg python3-psutil"
+                PYTHON_DEPS="gcc gcc-c++ openssl-devel python3-yaml python3-requests python3-cryptography wget git python3-tornado python3-zmq python3-gpg python3-psutil"
                 if [ "$(uname -m)" = "x86_64" ]; then
                     PYTHON_DEPS+=" efivar-libs"
                 fi
+                case "${VERSION_ID}" in
+                8*)
+                    PYTHON_DEPS+=" swig"
+                ;;
+                esac
                 BUILD_TOOLS="git wget patch libyaml openssl-devel libtool make automake m4 libgcrypt-devel autoconf libcurl-devel libstdc++-devel dbus-devel libuuid-devel json-c-devel autoconf-archive"
-                #TPM2_TOOLS_PKGS="tpm2-tss tpm2-tools" TODO: still on 3.1.1 tpm2_tools
-                NEED_BUILD_TOOLS=1
-                NEED_PYTHON_DIR=1
+                case "${VERSION_ID}" in
+                8*)
+                    NEED_BUILD_TOOLS=1
+                    NEED_PYTHON_DIR=1
+                ;;
+                9*)
+                    NEED_BUILD_TOOLS=0
+                    NEED_PYTHON_DIR=0
+                    TPM2_TOOLS_PKGS="tpm2-tools"
+                ;;
+                esac
                 if test "$ID" = centos; then
                     POWERTOOLS="--enablerepo=PowerTools"
                 else


### PR DESCRIPTION
RHEL-9 has the tpm2-tools package available and therefore does not need to build it.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>