### PR TITLE
Check tpm2-tools before running create_mb_refstate

### DIFF
--- a/scripts/create_mb_refstate
+++ b/scripts/create_mb_refstate
@@ -12,6 +12,8 @@ import json
 import re
 import sys
 
+from packaging.version import Version
+
 from keylime.tpm import tpm_main
 
 
@@ -124,6 +126,12 @@ def get_mok(events):
 
 
 def main():
+    tpm = tpm_main.tpm()
+
+    if Version(tpm.tools_version) < Version("4.2"):
+        print(f"tpm2_eventlog is not available: tpm2-tools version {tpm.tools_version} < 4.2")
+        sys.exit(1)
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "eventlog_file",
@@ -136,7 +144,6 @@ def main():
     )
     args = parser.parse_args()
     log_bin = args.eventlog_file.read()
-    tpm = tpm_main.tpm()
 
     failure, log_data = tpm.parse_binary_bootlog(log_bin)
     if failure or not log_data:

--- a/scripts/create_mb_refstate
+++ b/scripts/create_mb_refstate
@@ -137,8 +137,17 @@ def main():
     args = parser.parse_args()
     log_bin = args.eventlog_file.read()
     tpm = tpm_main.tpm()
-    _, log_data = tpm.parse_binary_bootlog(log_bin)
-    events = log_data["events"]
+
+    failure, log_data = tpm.parse_binary_bootlog(log_bin)
+    if failure or not log_data:
+        print(f"Parsing of binary boot measurements failed with: {list(map(lambda x: x.context, failure.events))}")
+        sys.exit(1)
+
+    events = log_data.get("events")
+    if not events:
+        print("No events found on binary boot measurements log")
+        sys.exit(1)
+
     mb_refstate = {
         "scrtm_and_bios": [
             {

--- a/test/test_tpm.py
+++ b/test/test_tpm.py
@@ -1,8 +1,12 @@
 import os
 import unittest
 
+from packaging.version import Version
+
 from keylime.common.algorithms import Hash
 from keylime.tpm.tpm_main import tpm
+
+TPM2TOOLS_VERSION = Version(tpm().tools_version)
 
 # ############################################################
 # list of input challenges for get_tpm_manufacturer function
@@ -94,6 +98,7 @@ class TestTPM(unittest.TestCase):
             response = self.tpm.get_tpm_manufacturer(output=test["challenge"])
             self.assertEqual(test["response"], response)
 
+    @unittest.skipIf(TPM2TOOLS_VERSION < Version("4.2"), "tpm_eventlog is not available")
     def test_parse_mb_bootlog(self):
         """Test parsing binary measured boot event log"""
         # Use the file that triggered https://github.com/keylime/keylime/issues/1153


### PR DESCRIPTION
Check if the tpm2-tools version is recent enough to have the tpm_eventlog tool available before trying to run the create_mb_refstate script.

Also skip the test for measured boot log parsing test in test_tpm.py if the tpm2-tools version is too old.