### PR TITLE
Add --retry 5 parameter to curl

### DIFF
--- a/.github/workflows/submit-HEAD-coverage.yaml
+++ b/.github/workflows/submit-HEAD-coverage.yaml
@@ -18,7 +18,7 @@ jobs:
       env:
         TESTING_FARM_API_TOKEN: ${{ secrets.TESTING_FARM_API_TOKEN }}
     - name: Find PR Packit tests to finish and download coverage.xml file
-      run: grep -q 'tests passed' tt_output && sleep 10 && scripts/download_packit_coverage.sh --testing-farm-log tt_output
+      run: grep -q 'tests passed' tt_output && sleep 20 && scripts/download_packit_coverage.sh --testing-farm-log tt_output
       env:
         MAX_DURATION: 120
         SLEEP_DELAY: 20

--- a/scripts/download_packit_coverage.sh
+++ b/scripts/download_packit_coverage.sh
@@ -69,7 +69,7 @@ function do_GitHub_API_call() {
 
     while [ -z "${VALUE}" -o \( -n "${EXP_VALUE}" -a "${VALUE}" != "${EXP_VALUE}" \) ] && [ ${DURATION} -lt ${MAX_DURATION} ]; do
         if [ "$URL" != "-" ]; then  # when URL='-', we reuse data downloaded previously
-            curl -s -H "Accept: application/vnd.github.v3+json" "$URL" &> ${TMPFILE}
+            curl --retry 5 -s -H "Accept: application/vnd.github.v3+json" "$URL" &> ${TMPFILE}
         fi
         VALUE=$( cat ${TMPFILE} | jq "${JQ_REF}" | sed 's/"//g' )
         if [ -z "${VALUE}" ] || [ -n "${EXP_VALUE}" -a "${VALUE}" != "${EXP_VALUE}" ]; then
@@ -137,11 +137,11 @@ fi
 # now we have TF_ARTIFACTS_URL so we can proceed with the download
 echo "TF_ARTIFACTS_URL=${TF_ARTIFACTS_URL}"
 
-TF_TESTLOG=$( curl -s ${TF_ARTIFACTS_URL}/results.xml | egrep -o "${TF_ARTIFACTS_URL}.*${TF_TEST_OUTPUT}" )
+TF_TESTLOG=$( curl --retry 5 ${TF_ARTIFACTS_URL}/results.xml | egrep -o "${TF_ARTIFACTS_URL}.*${TF_TEST_OUTPUT}" )
 echo "TF_TESTLOG=${TF_TESTLOG}"
 
 # parse the URL of coverage XML file on WEBDRIVE_URL and download it
-curl -s "${TF_TESTLOG}" &> ${TMPFILE}
+curl --retry 5 -s "${TF_TESTLOG}" &> ${TMPFILE}
 for REPORT in coverage.packit.xml coverage.testsuite.xml coverage.unittests.xml; do
     COVERAGE_URL=$( grep "$REPORT report is available at" ${TMPFILE} | egrep -o "${WEBDRIVE_URL}.*\.xml" )
     echo "COVERAGE_URL=${COVERAGE_URL}"
@@ -152,6 +152,6 @@ for REPORT in coverage.packit.xml coverage.testsuite.xml coverage.unittests.xml;
     fi
 
     # download the file
-    curl -L -O ${COVERAGE_URL}
+    curl --retry 5 -L -O ${COVERAGE_URL}
 done
 rm ${TMPFILE}


### PR DESCRIPTION
There are occasional failures when submitting code coverage. It is likely that a connections fails and adding --retry could help.

Signed-off-by: Karel Srot <ksrot@redhat.com>