### PR TITLE
cloud_verifier: This is the first PR to address the scalability problems uncovered in #1167, starting with `agent` status.

### DIFF
--- a/docs/rest_apis.rst
+++ b/docs/rest_apis.rst
@@ -72,8 +72,7 @@ Cloud verifier (CV)
             "tpm_policy": "{\"22\": [\"0000000000000000000000000000000000000001\", \"0000000000000000000000000000000000000000000000000000000000000001\", \"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001\", \"ffffffffffffffffffffffffffffffffffffffff\", \"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\", \"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\"], \"15\": [\"0000000000000000000000000000000000000000\", \"0000000000000000000000000000000000000000000000000000000000000000\", \"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"], \"mask\": \"0x408000\"}",
             "vtpm_policy": "{\"23\": [\"ffffffffffffffffffffffffffffffffffffffff\", \"0000000000000000000000000000000000000000\"], \"15\": [\"0000000000000000000000000000000000000000\"], \"mask\": \"0x808000\"}",
             "meta_data": "{}",
-            "allowlist_len": 0,
-            "mb_refstate_len": 0,
+            "has_mb_refstate": 0,
             "accept_tpm_hash_algs": [
               "sha512",
               "sha384",

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -237,27 +237,20 @@ def prepare_get_quote(agent):
 
 def process_get_status(agent):
     agent_id = agent.agent_id
-    allowlist_json = json.loads(agent.ima_policy.ima_policy)
-    if isinstance(allowlist_json, dict) and "allowlist" in allowlist_json:
-        al_len = len(allowlist_json["allowlist"])
-    else:
-        al_len = 0
 
+    has_mb_refstate = 0
     try:
         mb_refstate = json.loads(agent.mb_refstate)
+        if mb_refstate and mb_refstate.keys():
+            has_mb_refstate = 1
     except Exception as e:
         logger.warning(
-            'Non-fatal problem ocurred while attempting to evaluate agent %s attribute "mb_refstate" (%s). Will just consider the value of this attribute to be "None"',
+            'Non-fatal problem ocurred while attempting to evaluate agent %s attribute "mb_refstate" (%s). Will just consider the value of this attribute as empty',
             agent_id,
             e.args,
         )
-        mb_refstate = None
         logger.debug('The contents of the agent %s attribute "mb_refstate" are %s', agent_id, agent.mb_refstate)
 
-    if isinstance(mb_refstate, dict) and "mb_refstate" in mb_refstate:
-        mb_refstate_len = len(mb_refstate["mb_refstate"])
-    else:
-        mb_refstate_len = 0
     response = {
         "operational_state": agent.operational_state,
         "v": agent.v,
@@ -265,8 +258,7 @@ def process_get_status(agent):
         "port": agent.port,
         "tpm_policy": agent.tpm_policy,
         "meta_data": agent.meta_data,
-        "allowlist_len": al_len,
-        "mb_refstate_len": mb_refstate_len,
+        "has_mb_refstate": has_mb_refstate,
         "accept_tpm_hash_algs": agent.accept_tpm_hash_algs,
         "accept_tpm_encryption_algs": agent.accept_tpm_encryption_algs,
         "accept_tpm_signing_algs": agent.accept_tpm_signing_algs,

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -13,7 +13,7 @@ import tornado.netutil
 import tornado.process
 import tornado.web
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, noload
 from sqlalchemy.orm.exc import NoResultFound
 
 from keylime import api_version as keylime_api_version
@@ -278,7 +278,10 @@ class AgentsHandler(BaseHandler):
             try:
                 agent = (
                     session.query(VerfierMain)
-                    .options(joinedload(VerfierMain.ima_policy))
+                    # "noload" will be temporarily used here as way to address a
+                    # scalability problem. This will be replaced with a finer-grained
+                    # joinedload (only a few columns) in the future
+                    .options(noload(VerfierMain.ima_policy))
                     .filter_by(agent_id=agent_id)
                     .one_or_none()
                 )
@@ -298,12 +301,18 @@ class AgentsHandler(BaseHandler):
                 if ("verifier" in rest_params) and (rest_params["verifier"] != ""):
                     agent_list = (
                         session.query(VerfierMain)
-                        .options(joinedload(VerfierMain.ima_policy))
+                        # "noload" will be temporarily used here as way to address a
+                        # scalability problem. This will be replaced with a finer-grained
+                        # joinedload (only a few columns) in the future
+                        .options(noload(VerfierMain.ima_policy))
                         .filter_by(verifier_id=rest_params["verifier"])
                         .all()
                     )
                 else:
-                    agent_list = session.query(VerfierMain).options(joinedload(VerfierMain.ima_policy)).all()
+                    # "noload" will be temporarily used here as way to address a
+                    # scalability problem. This will be replaced with a finer-grained
+                    # joinedload (only a few columns) in the future
+                    agent_list = session.query(VerfierMain).options(noload(VerfierMain.ima_policy)).all()
 
                 json_response = {}
                 for agent in agent_list:


### PR DESCRIPTION
While requesting `agent` status, either individually or in bulk (`bulkinfo`), there is simply no need for loading anything from the `allowlists` table on the database, especialmente if the leght of the allowlist for a given agent is non-trivial (e.g., tens of megabytes).

In addition to that, two attributes for the `agent` - `allowlist_len` and `mb_refstate_len` - in addition of being of dubious utility, were being calculated in an incorrect manner. These were dutifully removed.

A meaningful attribute for mesured boot reference states - `has_mb_refstate` is already implemented on this PR.

In a subsquent PR we will find a way to introduce meaningful attribute for IMA allowlists (i.e., `has_ima_allowlist`, or something to that effect), **without** requiring a full load from the database table.

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>