### PR TITLE
tpm_main: fix ek creation for tpm2-tools versions > 4.2

### DIFF
--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -289,7 +289,8 @@ class tpm(tpm_abstract.AbstractTPM):
                     "-P",
                     owner_pw,
                 ]
-            elif self.tools_version == "4.2":
+            else:
+                # version 4.2 or later
                 command = [
                     "tpm2_createek",
                     "-c",


### PR DESCRIPTION
I missed that statement when I added the check for tpm2-tools version 5.4.
