### PR TITLE
ima: this PR adds checksums for allowlists as a separate column on the DB

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -580,11 +580,11 @@ class AgentsHandler(BaseHandler):
                             logger.warning(err_msg)
                             return
 
-                        ima_policy_db_format = {}
                         if not ima_policy_name:
                             ima_policy_name = agent_id
-                        ima_policy_db_format["name"] = ima_policy_name
-                        ima_policy_db_format["ima_policy"] = ima_policy
+
+                        ima_policy_db_format = ima.ima_policy_db_contents(ima_policy_name, ima_policy)
+
                         try:
                             ima_policy_stored = (
                                 session.query(VerifierAllowlist).filter_by(name=ima_policy_name).one_or_none()
@@ -848,9 +848,9 @@ class AllowlistHandler(BaseHandler):
             logger.warning("POST returning 400 response. Expected non zero content length.")
             return
 
-        ima_policy_db_format = {}
+        ima_policy = "{}"
+
         json_body = json.loads(self.request.body)
-        ima_policy_db_format["name"] = allowlist_name
 
         ima_policy_bundle = json.loads(json_body.get("ima_policy_bundle"))
         if ima_policy_bundle:
@@ -864,11 +864,10 @@ class AllowlistHandler(BaseHandler):
                 web_util.echo_json_response(self, e.code, e.message)
                 logger.warning(e.message)
                 return
-            ima_policy_db_format["ima_policy"] = ima_policy
 
         tpm_policy = json_body.get("tpm_policy")
-        if tpm_policy:
-            ima_policy_db_format["tpm_policy"] = tpm_policy
+
+        ima_policy_db_format = ima.ima_policy_db_contents(allowlist_name, ima_policy, tpm_policy)
 
         session = get_session()
         # don't allow overwritting

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -57,5 +57,6 @@ class VerifierAllowlist(Base):
     id = Column(Integer, primary_key=True)
     agent = relationship("VerfierMain", back_populates="ima_policy")
     name = Column(String(255), nullable=False)
+    checksum = Column(String(128))
     tpm_policy = Column(Text())
     ima_policy = Column(Text().with_variant(Text(429400000), "mysql"))

--- a/keylime/migrations/versions/2fbc0fb8fa4d_add_checksum_to_allowlist.py
+++ b/keylime/migrations/versions/2fbc0fb8fa4d_add_checksum_to_allowlist.py
@@ -1,0 +1,39 @@
+"""add_checksum_and_generator_to_allowlist
+
+Revision ID: 2fbc0fb8fa4d
+Revises: a09cc94177f0
+Create Date: 2022-11-14 13:21:47.555834
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2fbc0fb8fa4d"
+down_revision = "a09cc94177f0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()[f"upgrade_{engine_name}"]()
+
+
+def downgrade(engine_name):
+    globals()[f"downgrade_{engine_name}"]()
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+    op.add_column("allowlists", sa.Column("checksum", sa.String(128), index=True))
+
+
+def downgrade_cloud_verifier():
+    op.drop_column("allowlists", "checksum")

--- a/test/test_ima_verification.py
+++ b/test/test_ima_verification.py
@@ -281,7 +281,8 @@ class TestIMAVerification(unittest.TestCase):
         self.assertEqual(
             al_data["meta"]["generator"], "keylime-legacy-format-upgrade", "AllowList metadata generator is correct"
         )
-        self.assertNotIn("checksum", al_data["meta"], "AllowList metadata no checksum")
+
+        self.assertIsNotNone(al_data["meta"].get("checksum", None), "AllowList checksum is present")
         self.assertIsNotNone(al_data["hashes"], "AllowList hashes are present")
         self.assertEqual(len(al_data["hashes"]), 21, "AllowList hashes are correct length")
         self.assertEqual(
@@ -328,7 +329,7 @@ class TestIMAVerification(unittest.TestCase):
 
         # unbundle and test output
         al_data = ima.unbundle_ima_policy(al_bundle, verify=True)
-        self.assertNotIn("checksum", al_data["meta"], "AllowList metadata no checksum")
+        self.assertIsNotNone(al_data["meta"].get("checksum", None), "AllowList checksum is present")
         self.assertIsNotNone(al_data["hashes"], "AllowList hashes are present")
         self.assertEqual(len(al_data["hashes"]), 21, "AllowList hashes are correct length")
         self.assertEqual(


### PR DESCRIPTION
When an user provides an allowlist, a checksum is already automatically calculated (used for comparison when a checksum is also provided, ignored if not). 

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>