### PR TITLE
Do not use default values that need reading the config in methods

### DIFF
--- a/keylime/cert_utils.py
+++ b/keylime/cert_utils.py
@@ -12,7 +12,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from pyasn1.codec.der import decoder, encoder
 from pyasn1_modules import pem, rfc2459
 
-from keylime import config, keylime_logging, tpm_ek_ca
+from keylime import keylime_logging, tpm_ek_ca
 
 # Issue #944 -- python-cryptography won't parse malformed certs,
 # such as some Nuvoton ones we have encountered in the field.
@@ -56,9 +56,10 @@ def x509_pem_cert(pem_cert_data: str):
         return x509.load_der_x509_certificate(data=encoder.encode(pyasn1_cert), backend=default_backend())
 
 
-def verify_ek(ekcert, tpm_cert_store=config.get("tenant", "tpm_cert_store")):
+def verify_ek(ekcert: bytes, tpm_cert_store: str) -> bool:
     """Verify that the provided EK certificate is signed by a trusted root
     :param ekcert: The Endorsement Key certificate in DER format
+    :param tpm_cert_store: The path for the TPM certificate store
     :returns: True if the certificate can be verified, False otherwise
     """
     try:

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -430,7 +430,7 @@ class Tenant:
             elif ekcert is None:
                 logger.warning("No EK cert provided, require_ek_cert option in config set to True")
                 return False
-            elif not self.tpm_instance.verify_ek(base64.b64decode(ekcert)):
+            elif not self.tpm_instance.verify_ek(base64.b64decode(ekcert), config.get("tenant", "tpm_cert_store")):
                 logger.warning("Invalid EK certificate")
                 return False
 

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -97,7 +97,7 @@ class AbstractTPM(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def verify_ek(self, ekcert):
+    def verify_ek(self, ekcert, tpm_cert_store):
         pass
 
     @abstractmethod

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -784,12 +784,12 @@ class tpm(tpm_abstract.AbstractTPM):
                 os.remove(sesspath)
         return key
 
-    def verify_ek(self, ekcert):
+    def verify_ek(self, ekcert, tpm_cert_store):
         """Verify that the provided EK certificate is signed by a trusted root
         :param ekcert: The Endorsement Key certificate in DER format
         :returns: True if the certificate can be verified, false otherwise
         """
-        return cert_utils.verify_ek(ekcert)
+        return cert_utils.verify_ek(ekcert, tpm_cert_store)
 
     def get_tpm_manufacturer(self, output=None):
         vendorStr = None

--- a/keylime/tpm_ek_ca.py
+++ b/keylime/tpm_ek_ca.py
@@ -1,13 +1,13 @@
 import glob
 import os
 
-from keylime import config, keylime_logging
+from keylime import keylime_logging
 
 logger = keylime_logging.init_logging("tpm_ek_ca")
 trusted_certs = {}
 
 
-def check_tpm_cert_store(tpm_cert_store=config.get("tenant", "tpm_cert_store")):
+def check_tpm_cert_store(tpm_cert_store):
     if not os.path.isdir(tpm_cert_store):
         logger.error("The directory %s does not exist.", tpm_cert_store)
         raise Exception(f"The directory {tpm_cert_store} does not exist.")
@@ -20,7 +20,7 @@ def check_tpm_cert_store(tpm_cert_store=config.get("tenant", "tpm_cert_store")):
         raise Exception(f"The directory {tpm_cert_store} does not contain " f"any .pem files")
 
 
-def cert_loader(tpm_cert_store=config.get("tenant", "tpm_cert_store")):
+def cert_loader(tpm_cert_store):
     file_list = glob.glob(os.path.join(tpm_cert_store, "*.pem"))
     my_trusted_certs = {}
     for file_path in file_list:


### PR DESCRIPTION
Following up from the recent refactoring that moved the EK validation to cert_utils, in a few places were added default method values that were reading the configuration files directly.

It was not such a great idea becasue it then made those config files as required to even import the modules.

Example `"from keylime import cert_utils"` now also requires that the tenant configuration be available for getting the path for the TPM cert store.

Let's stop doing that.

Signed-off-by: Sergio Correia <scorreia@redhat.com>