### PR TITLE
verifier: Implement updateruntimepolicy to update an existing runtime policy

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -865,22 +865,13 @@ class AllowlistHandler(BaseHandler):
         self.finish()
         logger.info("DELETE returning 204 response for allowlist: %s", allowlist_name)
 
-    def post(self):
-        """Create an allowlist
-
-        POST /allowlists/{name}
-        body: {"tpm_policy": {..} ...
-        """
-
-        runtime_policy_name = self.__validate_input("POST")
-        if runtime_policy_name is None:
-            return
-
+    def __get_runtime_policy_db_format(self, runtime_policy_name: str) -> Optional[Dict[str, Any]]:
+        """Get the IMA policy from the request and return it in Db format"""
         content_length = len(self.request.body)
         if content_length == 0:
             web_util.echo_json_response(self, 400, "Expected non zero content length")
             logger.warning("POST returning 400 response. Expected non zero content length.")
-            return
+            return None
 
         runtime_policy = "{}"
 
@@ -908,11 +899,28 @@ class AllowlistHandler(BaseHandler):
         except ima.ImaValidationError as e:
             web_util.echo_json_response(self, e.code, e.message)
             logger.warning(e.message)
-            return
+            return None
 
         tpm_policy = json_body.get("tpm_policy")
 
         runtime_policy_db_format = ima.runtime_policy_db_contents(runtime_policy_name, runtime_policy, tpm_policy)
+
+        return runtime_policy_db_format
+
+    def post(self):
+        """Create an allowlist
+
+        POST /allowlists/{name}
+        body: {"tpm_policy": {..} ...
+        """
+
+        runtime_policy_name = self.__validate_input("POST")
+        if runtime_policy_name is None:
+            return
+
+        runtime_policy_db_format = self.__get_runtime_policy_db_format(runtime_policy_name)
+        if not runtime_policy_db_format:
+            return
 
         session = get_session()
         # don't allow overwritting


### PR DESCRIPTION
This PR extends the keylime tenant tool with the updateruntimepolicy command to enable a user to update an existing named runtime policy. IMA Attestation is NOT reset but simply continues with the new policy.