### PR TITLE
Remove redundant return parameters from functions

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -313,14 +313,8 @@ def validate_ima_policy_data(agent_data):
     lists = json.loads(agent_data)
 
     # Validate exlude list contains valid regular expressions
-    is_valid, _, err_msg_from_validator = validators.valid_exclude_list(lists.get("exclude"))
-    if not is_valid:
-        if err_msg_from_validator is not None:
-            err_msg_base = err_msg_from_validator + " "
-        else:
-            err_msg_base = ""
-        err_msg = err_msg_base + "Exclude list regex is misformatted. Please correct the issue and try again."
-    else:
-        err_msg = err_msg_from_validator
+    _, err_msg_from_validator = validators.valid_exclude_list(lists.get("exclude"))
+    if err_msg_from_validator:
+        err_msg_from_validator += " Exclude list regex is misformatted. Please correct the issue and try again."
 
-    return is_valid, err_msg
+    return err_msg_from_validator is None, err_msg_from_validator

--- a/keylime/common/validators.py
+++ b/keylime/common/validators.py
@@ -6,15 +6,15 @@ import re
 def valid_regex(regex):
     """Check if string is a valid regular expression."""
     if regex is None:
-        return True, None, None
+        return None, None
 
     try:
         compiled_regex = re.compile(regex)
     except re.error as regex_err:
         err = "Invalid regex: " + regex_err.msg + "."
-        return False, None, err
+        return None, err
 
-    return True, compiled_regex, None
+    return compiled_regex, None
 
 
 def valid_exclude_list(exclude_list):
@@ -23,7 +23,8 @@ def valid_exclude_list(exclude_list):
         return True, None, None
 
     combined_regex = "(" + ")|(".join(exclude_list) + ")"
-    return valid_regex(combined_regex)
+    compiled_regex, err = valid_regex(combined_regex)
+    return err is None, compiled_regex, err
 
 
 def valid_hex(value):

--- a/keylime/common/validators.py
+++ b/keylime/common/validators.py
@@ -20,11 +20,10 @@ def valid_regex(regex):
 def valid_exclude_list(exclude_list):
     """Check if the list is composed of valid regex."""
     if not exclude_list:
-        return True, None, None
+        return None, None
 
     combined_regex = "(" + ")|(".join(exclude_list) + ")"
-    compiled_regex, err = valid_regex(combined_regex)
-    return err is None, compiled_regex, err
+    return valid_regex(combined_regex)
 
 
 def valid_hex(value):

--- a/keylime/ima/ima.py
+++ b/keylime/ima/ima.py
@@ -283,8 +283,8 @@ def _process_measurement_list(
                 if val not in allow_list["hashes"]["boot_aggregate"]:
                     allow_list["hashes"]["boot_aggregate"].append(val)
 
-    is_valid, compiled_regex, err_msg = validators.valid_exclude_list(exclude_list)
-    if not is_valid:
+    compiled_regex, err_msg = validators.valid_exclude_list(exclude_list)
+    if err_msg:
         # This should not happen as the exclude list has already been validated
         # by the verifier before acceping it. This is a safety net just in case.
         err_msg += " Exclude list will be ignored."

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -27,26 +27,24 @@ class TestValidExcludeList(unittest.TestCase):
 
     def test_none(self):
         """Check that the empty list is valid."""
-        self.assertEqual(validators.valid_exclude_list(None), (True, None, None))
+        self.assertEqual(validators.valid_exclude_list(None), (None, None))
 
     def test_single(self):
         """Check a single exclude list element."""
         value = validators.valid_exclude_list([r"a.*"])
-        self.assertTrue(value[0])
-        self.assertEqual(value[1].pattern, r"(a.*)")
-        self.assertEqual(value[2], None)
+        self.assertEqual(value[0].pattern, r"(a.*)")
+        self.assertEqual(value[1], None)
 
     def test_multi(self):
         """Check a multiple elements exclude list."""
         value = validators.valid_exclude_list([r"a.*", r"b.*"])
-        self.assertTrue(value[0])
-        self.assertEqual(value[1].pattern, r"(a.*)|(b.*)")
-        self.assertEqual(value[2], None)
+        self.assertEqual(value[0].pattern, r"(a.*)|(b.*)")
+        self.assertEqual(value[1], None)
 
     def test_invalid(self):
         """Check an invalid exclude list."""
         value = validators.valid_exclude_list([r"a["])
-        self.assertEqual(value, (False, None, "Invalid regex: unterminated character set."))
+        self.assertEqual(value, (None, "Invalid regex: unterminated character set."))
 
 
 class TestValidHex(unittest.TestCase):

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -8,19 +8,18 @@ class TestValidRegex(unittest.TestCase):
 
     def test_none(self):
         """Check that None is a valid regex."""
-        self.assertEqual(validators.valid_regex(None), (True, None, None))
+        self.assertEqual(validators.valid_regex(None), (None, None))
 
     def test_valid(self):
         """Check a well formed regex."""
         value = validators.valid_regex(r"a.*")
-        self.assertTrue(value[0])
-        self.assertEqual(value[1].pattern, r"a.*")
-        self.assertEqual(value[2], None)
+        self.assertEqual(value[0].pattern, r"a.*")
+        self.assertEqual(value[1], None)
 
     def test_invalid(self):
         """Check a not valid regex."""
         value = validators.valid_regex(r"a[")
-        self.assertEqual(value, (False, None, "Invalid regex: unterminated character set."))
+        self.assertEqual(value, (None, "Invalid regex: unterminated character set."))
 
 
 class TestValidExcludeList(unittest.TestCase):


### PR DESCRIPTION
Remove a redundant 'valid' return parameter from functions that also return an error message when the result is not valid and return None otherwise.