### PR TITLE
common: Remove redundant return parameter from validate_ima_policy_data

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -312,9 +312,9 @@ def validate_ima_policy_data(agent_data):
     # validate that the allowlist is proper JSON
     lists = json.loads(agent_data)
 
-    # Validate exlude list contains valid regular expressions
+    # Validate that exclude list contains valid regular expressions
     _, err_msg_from_validator = validators.valid_exclude_list(lists.get("exclude"))
     if err_msg_from_validator:
         err_msg_from_validator += " Exclude list regex is misformatted. Please correct the issue and try again."
 
-    return err_msg_from_validator is None, err_msg_from_validator
+    return err_msg_from_validator

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -574,8 +574,8 @@ class AgentsHandler(BaseHandler):
                         ima_policy = json.dumps(ima.process_ima_policy(ima.EMPTY_ALLOWLIST, []))
 
                     if ima_policy:
-                        is_valid, err_msg = cloud_verifier_common.validate_ima_policy_data(ima_policy)
-                        if not is_valid:
+                        err_msg = cloud_verifier_common.validate_ima_policy_data(ima_policy)
+                        if err_msg:
                             web_util.echo_json_response(self, 400, err_msg)
                             logger.warning(err_msg)
                             return


### PR DESCRIPTION
Remove the redundant 'valid' return parameter from validate_ima_policy_data() and let the error message, that may either be None or an error string, be the deciding factor whether the IMA policy is valid. It's valid if the error message is 'None', invalid otherwise.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>