### PR TITLE
Some fixes to validate_ima_policy_data

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -305,12 +305,12 @@ def prepare_error(agent, msgtype="revocation", event=None):
     return tosend
 
 
-def validate_ima_policy_data(agent_data):
-    if agent_data is None:
+def validate_ima_policy_data(ima_policy):
+    if ima_policy is None:
         return "No ima_policy provided"
 
     # validate that the allowlist is proper JSON
-    lists = json.loads(agent_data)
+    lists = json.loads(ima_policy)
 
     # Validate that exclude list contains valid regular expressions
     _, err_msg_from_validator = validators.valid_exclude_list(lists.get("exclude"))

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -307,7 +307,7 @@ def prepare_error(agent, msgtype="revocation", event=None):
 
 def validate_ima_policy_data(agent_data):
     if agent_data is None:
-        return False, None
+        return "No ima_policy provided"
 
     # validate that the allowlist is proper JSON
     lists = json.loads(agent_data)


### PR DESCRIPTION
This PR fixes a recently introduced bug (by me) where the return parameters of the function were adjusted to only return an error message instead of the redundant is_valid parameter.
