### PR TITLE
Run 'pyright' and 'black --diff' as part of make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check check-rebuild
 check:
-	tox -vv -epylint -epyright -eblack -eisort
+	tox -epylint -epyright -eblack -eisort
 
 check-rebuild:
 	tox -r -vv -epylint -epyright -eblack -eisort

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check check-rebuild
 check:
-	tox -vv -epylint -epyright
+	tox -vv -epylint -epyright -eblack
 
 check-rebuild:
-	tox -r -vv -epylint -epyright
+	tox -r -vv -epylint -epyright -eblack

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check check-rebuild
 check:
-	tox -vv -epylint
+	tox -vv -epylint -epyright
 
 check-rebuild:
-	tox -r -vv -epylint
+	tox -r -vv -epylint -epyright

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check check-rebuild
 check:
-	tox -vv -epylint -epyright -eblack
+	tox -vv -epylint -epyright -eblack -eisort
 
 check-rebuild:
-	tox -r -vv -epylint -epyright -eblack
+	tox -r -vv -epylint -epyright -eblack -eisort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,5 +40,6 @@ ignore = [
     "keylime/registrar_common.py",
     "keylime/json.py",
     "keylime/cloud_verifier_tornado.py",
+    "keylime/ca_impl_openssl.py",
 ]
 reportMissingImports = false

--- a/tox.ini
+++ b/tox.ini
@@ -41,4 +41,4 @@ commands = black --diff ./keylime
 [testenv:isort]
 deps =
     isort
-commands = isort --diff --check --profile black --line-length 120 ./keylime
+commands = isort --diff --check ./keylime

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,9 @@ deps =
     pylint
 commands = bash scripts/check_codestyle.sh
 allowlist_externals = bash
+
+[testenv:pyright]
+deps =
+    -r{toxinidir}/requirements.txt
+    pyright
+commands = pyright

--- a/tox.ini
+++ b/tox.ini
@@ -37,3 +37,8 @@ commands = pyright
 deps =
     black
 commands = black --diff ./keylime
+
+[testenv:isort]
+deps =
+    isort
+commands = isort --diff --check --profile black --line-length 120 ./keylime

--- a/tox.ini
+++ b/tox.ini
@@ -32,3 +32,8 @@ deps =
     -r{toxinidir}/requirements.txt
     pyright
 commands = pyright
+
+[testenv:black]
+deps =
+    black
+commands = black --diff ./keylime


### PR DESCRIPTION
This PR extends tox to run 'pyright' and 'black --diff' when running 'make check'