### PR TITLE
pyright: Fix a 2nd batch of issues reported by pyright

### DIFF
--- a/keylime/cli/policies.py
+++ b/keylime/cli/policies.py
@@ -46,7 +46,10 @@ def process_allowlist(args):
         # Add all IMA file signing verification keys to a keyring
         tenant_keyring = file_signatures.ImaKeyring()
         for filename in args["ima_sign_verification_keys"]:
-            pubkey, keyidv2 = file_signatures.get_pubkey_from_file(filename)
+            try:
+                pubkey, keyidv2 = file_signatures.get_pubkey_from_file(filename)
+            except ValueError as e:
+                raise UserError(f"File '{filename}' does not have a supported key: {e}") from e
             if not pubkey:
                 raise UserError(f"File '{filename}' is not a file with a key")
             tenant_keyring.add_pubkey(pubkey, keyidv2)

--- a/keylime/cmd/convert_ima_policy.py
+++ b/keylime/cmd/convert_ima_policy.py
@@ -140,10 +140,13 @@ def update_ima_policy(policy, excludelist_path=None, verification_keys=None):
     if verification_keys:
         keyring = file_signatures.ImaKeyring().from_string(policy["ima_sign_verification_keys"])
         for key in verification_keys:
-            pubkey, keyidv2 = file_signatures.get_pubkey_from_file(key)
-            if not pubkey:
-                print(f"File '{key}' is not a file with a key")
-            keyring.add_pubkey(pubkey, keyidv2)
+            try:
+                pubkey, keyidv2 = file_signatures.get_pubkey_from_file(key)
+                if not pubkey:
+                    print(f"File '{key}' is not a file with a key")
+                keyring.add_pubkey(pubkey, keyidv2)
+            except ValueError as e:
+                print(f"File '{key}' does not have a supported key: {e}")
         verification_key_list = json.dumps(keyring.to_string())
 
     policy["excludes"] += excl_list

--- a/keylime/ima/file_signatures.py
+++ b/keylime/ima/file_signatures.py
@@ -447,6 +447,8 @@ def get_pubkey(filedata):
     ]:
         pubkey, keyidv2 = func(filedata, default_be)
         if pubkey:
+            if not isinstance(pubkey, (RSAPublicKey, EllipticCurvePublicKey)):
+                raise ValueError(f"Unsupported key type {type(pubkey).__name__}")
             return pubkey, keyidv2
 
     return None, None
@@ -454,13 +456,10 @@ def get_pubkey(filedata):
 
 def get_pubkey_from_file(filename):
     """Get the public key object from a file"""
-    try:
-        with open(filename, "rb") as fobj:
-            filedata = fobj.read()
-            pubkey, keyidv2 = get_pubkey(filedata)
-            if pubkey:
-                return pubkey, keyidv2
-    except Exception:
-        pass
+    with open(filename, "rb") as fobj:
+        filedata = fobj.read()
+        pubkey, keyidv2 = get_pubkey(filedata)
+        if pubkey:
+            return pubkey, keyidv2
 
     return None, None

--- a/keylime/ima/ima.py
+++ b/keylime/ima/ima.py
@@ -227,7 +227,11 @@ def _validate_ima_buf(
 ):
     failure = Failure(Component.IMA)
     # Is data.data a key?
-    pubkey, keyidv2 = file_signatures.get_pubkey(data.data)
+    try:
+        pubkey, keyidv2 = file_signatures.get_pubkey(data.data)
+    except ValueError as ve:
+        failure.add_event("invalid_key", f"key from {path.name} does not have a supported key: {ve}", True)
+        return failure
     if pubkey:
         ignored_keyrings = allowlist["ima"]["ignored_keyrings"]
         if "*" not in ignored_keyrings and path.name not in ignored_keyrings:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ ignore = [
     "keylime/da/examples/redis.py",
     "keylime/da/examples/file.py",
     "keylime/da/record.py",
-    "keylime/cmd/ima_emulator_adapter.py",
     "keylime/revocation_actions/update_crl.py",
     "keylime/cloud_verifier_tornado.py",
     "keylime/ca_impl_openssl.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ ignore = [
     "keylime/da/examples/file.py",
     "keylime/da/record.py",
     "keylime/cmd/ima_emulator_adapter.py",
-    "keylime/cmd/convert_ima_policy.py",
     "keylime/revocation_actions/update_crl.py",
     "keylime/cloud_verifier_tornado.py",
     "keylime/ca_impl_openssl.py",


### PR DESCRIPTION
This PR fixes a 2nd batch of issues reported by pyright:

- Raise a ValueError on unsupported key types so that applications using a non-RSA or non-ECDSA don't use the key; this helps to subsequently add restrictive type annotations to ima/file_signatures.py
- Add type annotations to ima/file_signatures.py
- Add type annotations to cmd/convert_ima_policy.py
- Enable pyright checking on files that are clean
