### PR TITLE
pyright: Fix an issue in ima/ima.py

### DIFF
--- a/keylime/ima/ima.py
+++ b/keylime/ima/ima.py
@@ -624,11 +624,11 @@ def ima_policy_db_contents(ima_policy_name: str, ima_policy: str, tpm_policy: st
         ima_policy_db_format["ima_policy"] = None
     else:
         ima_policy_db_format["ima_policy"] = ima_policy
-    ima_policy = json.loads(ima_policy)
-    if "allowlist" in ima_policy:
-        if "meta" in ima_policy["allowlist"]:
-            if "checksum" in ima_policy["allowlist"]["meta"]:
-                ima_policy_db_format["checksum"] = ima_policy["allowlist"]["meta"]["checksum"]
+    ima_policy_json = json.loads(ima_policy)
+    if "allowlist" in ima_policy_json:
+        if "meta" in ima_policy_json["allowlist"]:
+            if "checksum" in ima_policy_json["allowlist"]["meta"]:
+                ima_policy_db_format["checksum"] = ima_policy_json["allowlist"]["meta"]["checksum"]
             else:
                 alist_bytes = json.dumps(copy.deepcopy(EMPTY_ALLOWLIST)).encode()
                 sha256 = hashlib.sha256()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ ignore = [
     "keylime/cmd/ima_emulator_adapter.py",
     "keylime/cmd/convert_ima_policy.py",
     "keylime/ima/file_signatures.py",
-    "keylime/ima/ima.py",
     "keylime/revocation_actions/update_crl.py",
     "keylime/revocation_notifier.py",
     "keylime/registrar_common.py",


### PR DESCRIPTION
Fix the following issues detected by pyright and enable pyright checking on this file.

/home/stefanb/keylime/keylime/ima/ima.py
  /home/stefanb/keylime/keylime/ima/ima.py:629:22 - error: Argument of type "Literal['allowlist']" cannot be assigned to parameter "__i" of type "SupportsIndex | slice" in function "__getitem__"
    Type "Literal['allowlist']" cannot be assigned to type "SupportsIndex | slice"
      "Literal['allowlist']" is incompatible with protocol "SupportsIndex"
        "__index__" is not present
      "Literal['allowlist']" is incompatible with "slice" (reportGeneralTypeIssues)
[...]

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>