### PR TITLE
The verifier can selectively load only a subset of columns from the `allowlist` table.

### DIFF
--- a/docs/rest_apis.rst
+++ b/docs/rest_apis.rst
@@ -73,6 +73,7 @@ Cloud verifier (CV)
             "vtpm_policy": "{\"23\": [\"ffffffffffffffffffffffffffffffffffffffff\", \"0000000000000000000000000000000000000000\"], \"15\": [\"0000000000000000000000000000000000000000\"], \"mask\": \"0x808000\"}",
             "meta_data": "{}",
             "has_mb_refstate": 0,
+            "has_ima_policy": 0,
             "accept_tpm_hash_algs": [
               "sha512",
               "sha384",
@@ -108,7 +109,8 @@ Cloud verifier (CV)
     :>json string vtpm_policy: Static PCR policy and mask for vTPM
     :>json string meta_data: Metadata about the agent. Normally contains certificate information if a CA is used.
     :>json int allowlist_len: Length of the allowlist.
-    :>json int mb_refstate_len: Length of the measured boot reference state policy.
+    :>json int mb_refstate_len: 1 if a measured boot refstate was provided via tenant, 0 otherwise.
+    :>json int mb_ima_policy: 1 if an IMA policy (allowlist and excludelist) was provided via tenant, 0 otherwise.
     :>json list[string] accept_tpm_hash_algs: Accepted TPM hashing algorithms. sha1 must be enabled for IMA validation to work.
     :>json list[string] accept_tpm_encryption_algs: Accepted TPM encryption algorithms.
     :>json list[string] accept_tpm_signing_algs: Accepted TPM signing algorithms.

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -251,6 +251,10 @@ def process_get_status(agent):
         )
         logger.debug('The contents of the agent %s attribute "mb_refstate" are %s', agent_id, agent.mb_refstate)
 
+    has_ima_policy = 0
+    if agent.ima_policy.generator > 1:
+        has_ima_policy = 1
+
     response = {
         "operational_state": agent.operational_state,
         "v": agent.v,
@@ -259,6 +263,7 @@ def process_get_status(agent):
         "tpm_policy": agent.tpm_policy,
         "meta_data": agent.meta_data,
         "has_mb_refstate": has_mb_refstate,
+        "has_ima_policy": has_ima_policy,
         "accept_tpm_hash_algs": agent.accept_tpm_hash_algs,
         "accept_tpm_encryption_algs": agent.accept_tpm_encryption_algs,
         "accept_tpm_signing_algs": agent.accept_tpm_signing_algs,

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -58,5 +58,6 @@ class VerifierAllowlist(Base):
     agent = relationship("VerfierMain", back_populates="ima_policy")
     name = Column(String(255), nullable=False)
     checksum = Column(String(128))
+    generator = Column(Integer)
     tpm_policy = Column(Text())
     ima_policy = Column(Text().with_variant(Text(429400000), "mysql"))

--- a/keylime/migrations/versions/039322ea079b_add_generator_column.py
+++ b/keylime/migrations/versions/039322ea079b_add_generator_column.py
@@ -1,0 +1,39 @@
+"""add_generator_column
+
+Revision ID: 039322ea079b
+Revises: 2fbc0fb8fa4d
+Create Date: 2022-11-17 10:19:25.183759
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "039322ea079b"
+down_revision = "2fbc0fb8fa4d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()[f"upgrade_{engine_name}"]()
+
+
+def downgrade(engine_name):
+    globals()[f"downgrade_{engine_name}"]()
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+    op.add_column("allowlists", sa.Column("generator", sa.Integer))
+
+
+def downgrade_cloud_verifier():
+    op.drop_column("allowlists", "generator")

--- a/test/test_ima_verification.py
+++ b/test/test_ima_verification.py
@@ -278,9 +278,7 @@ class TestIMAVerification(unittest.TestCase):
         al_data = ima.unbundle_ima_policy(al_bundle, verify=False)
         self.assertIsNotNone(al_data["meta"], "AllowList metadata is present")
         self.assertEqual(al_data["meta"]["version"], 5, "AllowList metadata version is correct")
-        self.assertEqual(
-            al_data["meta"]["generator"], "keylime-legacy-format-upgrade", "AllowList metadata generator is correct"
-        )
+        self.assertEqual(al_data["meta"]["generator"], 3, "AllowList metadata generator is correct")
 
         self.assertIsNotNone(al_data["meta"].get("checksum", None), "AllowList checksum is present")
         self.assertIsNotNone(al_data["hashes"], "AllowList hashes are present")


### PR DESCRIPTION
With this PR, the `verifier` can load only a few colmuns from the `allowlist` table, giving it the ability to selectively decide if the full row needs to be loaded (very useful for implementing a proxy or cache).

In addition to that, a new column, `generator` is introduced to reflect the fact that an IMA policy was supplied by an user, versus automatically generated as "empty" from within the verifier.

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>