### PR TITLE
chore: fix typing in revocation_actions/update_crl.py

### DIFF
--- a/keylime/revocation_actions/update_crl.py
+++ b/keylime/revocation_actions/update_crl.py
@@ -49,7 +49,7 @@ def execute(json_revocation):
         # write out the updated CRL
         logger.debug("Updating CRL in %s/unzipped/cacrl.der", secdir)
         with open(os.path.join(secdir, "unzipped", "cacrl.der"), "wb") as f:
-            f.write(response.body.encode())
+            f.write(response.body)
         ca_util.convert_crl_to_pem(
             os.path.join(secdir, "unzipped", "cacrl.der"), os.path.join(secdir, "unzipped", "cacrl.pem")
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ ignore = [
     "keylime/da/examples/redis.py",
     "keylime/da/examples/file.py",
     "keylime/da/record.py",
-    "keylime/revocation_actions/update_crl.py",
     "keylime/cloud_verifier_tornado.py",
     "keylime/ca_impl_openssl.py",
 ]


### PR DESCRIPTION
fixing type issue

[{
	"resource": "/home/mdrocco/git/keylime/keylime/revocation_actions/update_crl.py",
	"message": "Cannot access member \"encode\" for type \"bytes\"\n  Member \"encode\" is unknown",
	"startLineNumber": 52,
	"startColumn": 35,
	"endLineNumber": 52,
	"endColumn": 41
}]

Signed-off-by: Maurizio Drocco <maurizio.drocco@ibm.com>