### PR TITLE
chore: cleaning up pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,5 @@ ignore = [
     "keylime/da/examples/file.py",
     "keylime/da/record.py",
     "keylime/cloud_verifier_tornado.py",
-    "keylime/ca_impl_openssl.py",
 ]
 reportMissingImports = false


### PR DESCRIPTION
cleaning up pyproject.toml

Removing leftover entry from pyright exclude list: keylime/ca_impl_openssl.py

Signed-off-by: Maurizio Drocco <maurizio.drocco@ibm.com>