### PR TITLE
Avoid switching types of variable or overwriting the value of a function parameter

### DIFF
--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -250,10 +250,13 @@ class AbstractTPM(metaclass=ABCMeta):
         hash_alg,
     ) -> Failure:
         failure = Failure(Component.PCR_VALIDATION)
-        if isinstance(tpm_policy, str):
-            tpm_policy = json.loads(tpm_policy)
 
-        pcr_allowlist = tpm_policy.copy()
+        if isinstance(tpm_policy, str):
+            tpm_policy_dict = json.loads(tpm_policy)
+        else:
+            tpm_policy_dict = tpm_policy
+
+        pcr_allowlist = tpm_policy_dict.copy()
 
         if "mask" in pcr_allowlist:
             del pcr_allowlist["mask"]

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -271,23 +271,23 @@ class AbstractTPM(metaclass=ABCMeta):
 
         pcrs_in_quote = set()  # PCRs in quote that were already used for some kind of validation
 
-        pcrs = AbstractTPM.__parse_pcrs(pcrs, virtual)
-        pcr_nums = set(pcrs.keys())
+        pcrs_dict = AbstractTPM.__parse_pcrs(pcrs, virtual)
+        pcr_nums = set(pcrs_dict.keys())
 
         # Validate data PCR
         if config.TPM_DATA_PCR in pcr_nums and data is not None:
             expectedval = self.sim_extend(data, hash_alg=hash_alg)
-            if expectedval != pcrs[config.TPM_DATA_PCR]:
+            if expectedval != pcrs_dict[config.TPM_DATA_PCR]:
                 logger.error(
                     "%sPCR #%s: invalid bind data %s from quote does not match expected value %s",
                     ("", "v")[virtual],
                     config.TPM_DATA_PCR,
-                    pcrs[config.TPM_DATA_PCR],
+                    pcrs_dict[config.TPM_DATA_PCR],
                     expectedval,
                 )
                 failure.add_event(
                     f"invalid_pcr_{config.TPM_DATA_PCR}",
-                    {"got": pcrs[config.TPM_DATA_PCR], "expected": expectedval},
+                    {"got": pcrs_dict[config.TPM_DATA_PCR], "expected": expectedval},
                     True,
                 )
             pcrs_in_quote.add(config.TPM_DATA_PCR)
@@ -312,7 +312,7 @@ class AbstractTPM(metaclass=ABCMeta):
             else:
                 ima_failure = AbstractTPM.__check_ima(
                     agentAttestState,
-                    pcrs[config.IMA_PCR],
+                    pcrs_dict[config.IMA_PCR],
                     ima_measurement_list,
                     allowlist,
                     ima_keyrings,
@@ -341,38 +341,38 @@ class AbstractTPM(metaclass=ABCMeta):
                     val_from_log_int = mb_pcrs_hashes.get(str(pcr_num), 0)
                     val_from_log_hex = hex(val_from_log_int)[2:]
                     val_from_log_hex_stripped = val_from_log_hex.lstrip("0")
-                    pcrval_stripped = pcrs[pcr_num].lstrip("0")
+                    pcrval_stripped = pcrs_dict[pcr_num].lstrip("0")
                     if val_from_log_hex_stripped != pcrval_stripped:
                         logger.error(
                             "For PCR %d and hash %s the boot event log has value %r but the agent returned %r",
                             pcr_num,
                             str(hash_alg),
                             val_from_log_hex,
-                            pcrs[pcr_num],
+                            pcrs_dict[pcr_num],
                         )
                         mb_pcr_failure.add_event(
                             f"invalid_pcr_{pcr_num}",
                             {
                                 "context": "SHA256 boot event log PCR value does not match",
-                                "got": pcrs[pcr_num],
+                                "got": pcrs_dict[pcr_num],
                                 "expected": val_from_log_hex,
                             },
                             True,
                         )
 
-                    if pcr_num in pcr_allowlist and pcrs[pcr_num] not in pcr_allowlist[pcr_num]:
+                    if pcr_num in pcr_allowlist and pcrs_dict[pcr_num] not in pcr_allowlist[pcr_num]:
                         logger.error(
                             "%sPCR #%s: %s from quote does not match expected value %s",
                             ("", "v")[virtual],
                             pcr_num,
-                            pcrs[pcr_num],
+                            pcrs_dict[pcr_num],
                             pcr_allowlist[pcr_num],
                         )
                         failure.add_event(
                             f"invalid_pcr_{pcr_num}",
                             {
                                 "context": "PCR value is not in allowlist",
-                                "got": pcrs[pcr_num],
+                                "got": pcrs_dict[pcr_num],
                                 "expected": pcr_allowlist[pcr_num],
                             },
                             True,
@@ -390,19 +390,19 @@ class AbstractTPM(metaclass=ABCMeta):
                     ("", "v")[virtual],
                 )
                 continue
-            if pcrs[pcr_num] not in pcr_allowlist[pcr_num]:
+            if pcrs_dict[pcr_num] not in pcr_allowlist[pcr_num]:
                 logger.error(
                     "%sPCR #%s: %s from quote does not match expected value %s",
                     ("", "v")[virtual],
                     pcr_num,
-                    pcrs[pcr_num],
+                    pcrs_dict[pcr_num],
                     pcr_allowlist[pcr_num],
                 )
                 failure.add_event(
                     f"invalid_pcr_{pcr_num}",
                     {
                         "context": "PCR value is not in allowlist",
-                        "got": pcrs[pcr_num],
+                        "got": pcrs_dict[pcr_num],
                         "expected": pcr_allowlist[pcr_num],
                     },
                     True,

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -334,8 +334,8 @@ class tpm(tpm_abstract.AbstractTPM):
             self._set_tpm_metadata("ek_tpm", base64.b64encode(ek_tpm))
             self._set_tpm_metadata("ek_alg", asym_alg)
 
-    def __use_ek(self, ek_handle, config_pw):
-        ek_handle = int(ek_handle, 16)
+    def __use_ek(self, ek_handle_str, config_pw):
+        ek_handle = int(ek_handle_str, 16)
         logger.info("Using an already created ek with handle: %s", hex(ek_handle))
 
         self._set_tpm_metadata("owner_pw", config_pw)


### PR DESCRIPTION
This PR addresses some related to switching the type of variables inside of function or overwriting the value of a function parameter inside a function. In all cases the changes help pyright later on to reason about the type of a variable.