### PR TITLE
tpm: Replace assert with Exception

### DIFF
--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -62,7 +62,10 @@ class tpm(tpm_abstract.AbstractTPM):
 
         # Extract the `version="x.x.x"` from tools
         version_str_ = re.search(r'version="([^"]+)"', output)
-        assert version_str_ is not None
+        if version_str_ is None:
+            msg = f"Could not determine tpm2-tools version from TPM2_Startup output '{output}'"
+            logger.error(msg)
+            raise Exception(msg)
         version_str = version_str_.group(1)
         # Extract the full semver release number.
         self.tools_version = version_str.split("-")


### PR DESCRIPTION
Replace the assert that checks that the version string following a regex search for the tpm2-tools version is not 'None' with an Exception that reports this back to the user. A similar Exception is already thrown before that if TPM2_Startup could not be run at all.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>