### PR TITLE
Fix incorrect generators in converted IMA policies

### DIFF
--- a/keylime/cmd/convert_ima_policy.py
+++ b/keylime/cmd/convert_ima_policy.py
@@ -59,7 +59,7 @@ def convert_legacy_allowlist(allowlist_path: str) -> PolicyDict:
 def _convert_json_allowlist(alist_json: PolicyDict) -> PolicyDict:
     ima_policy = copy.deepcopy(ima.EMPTY_IMA_POLICY)
     ima_policy["meta"]["timestamp"] = str(datetime.datetime.now())
-    ima_policy["meta"]["generator"] = "convert_ima_policy.py"
+    ima_policy["meta"]["generator"] = ima.IMA_POLICY_GENERATOR.LegacyAllowList
     for key in ima_policy.keys():
         if key == "digests":
             digests = alist_json.get("hashes")
@@ -83,7 +83,7 @@ def _convert_json_allowlist(alist_json: PolicyDict) -> PolicyDict:
 def _convert_flat_format_allowlist(alist_raw: str) -> PolicyDict:
     ima_policy = copy.deepcopy(ima.EMPTY_IMA_POLICY)
     ima_policy["meta"]["timestamp"] = str(datetime.datetime.now())
-    ima_policy["meta"]["generator"] = "convert-ima-policy"
+    ima_policy["meta"]["generator"] = ima.IMA_POLICY_GENERATOR.LegacyAllowList
 
     lines = alist_raw.splitlines()
     for line_num, line in enumerate(lines):
@@ -121,7 +121,7 @@ def update_ima_policy(
         )
         updated_policy: Dict = copy.deepcopy(ima.EMPTY_IMA_POLICY)
         updated_policy["meta"]["timestamp"] = str(datetime.datetime.now())
-        updated_policy["meta"]["generator"] = "convert_ima_policy.py"
+        updated_policy["meta"]["generator"] = ima.IMA_POLICY_GENERATOR.CompatibleAllowList
         for key in updated_policy.keys():
             if key == "meta":
                 continue

--- a/test/test_ima_verification.py
+++ b/test/test_ima_verification.py
@@ -278,7 +278,11 @@ class TestIMAVerification(unittest.TestCase):
         al_data = ima.unbundle_ima_policy(al_bundle, verify=False)
         self.assertIsNotNone(al_data["meta"], "AllowList metadata is present")
         self.assertEqual(al_data["meta"]["version"], 5, "AllowList metadata version is correct")
-        self.assertEqual(al_data["meta"]["generator"], 3, "AllowList metadata generator is correct")
+        self.assertEqual(
+            al_data["meta"]["generator"],
+            ima.IMA_POLICY_GENERATOR.LegacyAllowList,
+            "AllowList metadata generator is correct",
+        )
 
         self.assertIsNotNone(al_data["meta"].get("checksum", None), "AllowList checksum is present")
         self.assertIsNotNone(al_data["hashes"], "AllowList hashes are present")

--- a/test/test_policy_conversion.py
+++ b/test/test_policy_conversion.py
@@ -55,7 +55,9 @@ class TestPolicyConversion(unittest.TestCase):
             created_ima_policy["meta"]["version"], ima.IMA_POLICY_CURRENT_VERSION, "Metadata version is correct"
         )
         self.assertEqual(
-            created_ima_policy["meta"]["generator"], "convert_ima_policy.py", "Metadata generator is correct"
+            created_ima_policy["meta"]["generator"],
+            ima.IMA_POLICY_GENERATOR.LegacyAllowList,
+            "Metadata generator is correct",
         )
         self.assertEqual(
             created_ima_policy["digests"][


### PR DESCRIPTION
This could cause issues with the new integer generator format.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>