### PR TITLE
cmd: removal of keylime_migrations_apply

### DIFF
--- a/keylime/cmd/registrar.py
+++ b/keylime/cmd/registrar.py
@@ -1,5 +1,5 @@
-import keylime.cmd.migrations_apply
 from keylime import config, keylime_logging, registrar_common
+from keylime.common.migrations import apply
 
 logger = keylime_logging.init_logging("registrar")
 
@@ -7,7 +7,7 @@ logger = keylime_logging.init_logging("registrar")
 def main():
     # if we are configured to auto-migrate the DB, check if there are any migrations to perform
     if config.has_option("registrar", "auto_migrate_db") and config.getboolean("registrar", "auto_migrate_db"):
-        keylime.cmd.migrations_apply.apply("registrar")
+        apply("registrar")
 
     registrar_common.start(
         config.get("registrar", "ip"),

--- a/keylime/cmd/verifier.py
+++ b/keylime/cmd/verifier.py
@@ -1,5 +1,5 @@
-import keylime.cmd.migrations_apply
 from keylime import cloud_verifier_tornado, config, keylime_logging
+from keylime.common.migrations import apply
 
 logger = keylime_logging.init_logging("verifier")
 
@@ -7,7 +7,7 @@ logger = keylime_logging.init_logging("verifier")
 def main():
     # if we are configured to auto-migrate the DB, check if there are any migrations to perform
     if config.has_option("verifier", "auto_migrate_db") and config.getboolean("verifier", "auto_migrate_db"):
-        keylime.cmd.migrations_apply.apply("cloud_verifier")
+        apply("cloud_verifier")
 
     cloud_verifier_tornado.main()
 

--- a/keylime/common/migrations.py
+++ b/keylime/common/migrations.py
@@ -3,12 +3,6 @@ from typing import Optional
 
 import alembic.config
 
-from keylime import keylime_logging
-
-
-def main() -> None:
-    apply(None)
-
 
 def apply(db_name: Optional[str]) -> None:
     # set a conservative general umask
@@ -26,11 +20,3 @@ def apply(db_name: Optional[str]) -> None:
     alembic_args.extend(["upgrade", "head"])
 
     alembic.config.main(argv=alembic_args)
-
-
-if __name__ == "__main__":
-    logger = keylime_logging.init_logging("migrations")
-    try:
-        main()
-    except Exception as e:
-        logger.exception(e)

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,5 +53,4 @@ console_scripts =
         keylime_registrar = keylime.cmd.registrar:main
         keylime_ca = keylime.cmd.ca:main
         keylime_ima_emulator = keylime.cmd.ima_emulator_adapter:main
-        keylime_migrations_apply = keylime.cmd.migrations_apply:main
         keylime_convert_ima_policy = keylime.cmd.convert_ima_policy:main


### PR DESCRIPTION
Migrations are normally applied either manually or automatically during startup of
the verifier or registrar, so the option to run the migrations via a standalone
command is no longer required.
