### PR TITLE
codestyle: Type-annotate web_util.py

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -6,7 +6,7 @@ import sys
 import traceback
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import Process
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 import tornado.httpserver
 import tornado.ioloop
@@ -267,7 +267,7 @@ class AgentsHandler(BaseHandler):
             web_util.echo_json_response(self, 405, "Not Implemented: Use /agents/ interface")
             return
 
-        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
+        if not web_util.validate_api_version(self, cast(str, rest_params["api_version"]), logger):
             return
 
         if "agents" not in rest_params:
@@ -361,7 +361,7 @@ class AgentsHandler(BaseHandler):
             web_util.echo_json_response(self, 405, "Not Implemented: Use /agents/ interface")
             return
 
-        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
+        if not web_util.validate_api_version(self, cast(str, rest_params["api_version"]), logger):
             return
 
         if "agents" not in rest_params:
@@ -436,7 +436,7 @@ class AgentsHandler(BaseHandler):
                 web_util.echo_json_response(self, 405, "Not Implemented: Use /agents/ interface")
                 return
 
-            if not web_util.validate_api_version(self, rest_params["api_version"], logger):
+            if not web_util.validate_api_version(self, cast(str, rest_params["api_version"]), logger):
                 return
 
             if "agents" not in rest_params:
@@ -657,7 +657,7 @@ class AgentsHandler(BaseHandler):
                 web_util.echo_json_response(self, 405, "Not Implemented: Use /agents/ interface")
                 return
 
-            if not web_util.validate_api_version(self, rest_params["api_version"], logger):
+            if not web_util.validate_api_version(self, cast(str, rest_params["api_version"]), logger):
                 return
 
             if "agents" not in rest_params:
@@ -745,7 +745,7 @@ class AllowlistHandler(BaseHandler):
             web_util.echo_json_response(self, 400, "Invalid URL")
             return
 
-        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
+        if not web_util.validate_api_version(self, cast(str, rest_params["api_version"]), logger):
             return
 
         allowlist_name = rest_params["allowlists"]
@@ -781,7 +781,7 @@ class AllowlistHandler(BaseHandler):
             web_util.echo_json_response(self, 400, "Invalid URL")
             return
 
-        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
+        if not web_util.validate_api_version(self, cast(str, rest_params["api_version"]), logger):
             return
 
         allowlist_name = rest_params["allowlists"]
@@ -842,7 +842,7 @@ class AllowlistHandler(BaseHandler):
             web_util.echo_json_response(self, 400, "Invalid URL")
             return
 
-        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
+        if not web_util.validate_api_version(self, cast(str, rest_params["api_version"]), logger):
             return
 
         allowlist_name = rest_params["allowlists"]

--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -7,6 +7,7 @@ import sys
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn
+from typing import cast
 
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from sqlalchemy.exc import SQLAlchemyError
@@ -61,7 +62,7 @@ class ProtectedHandler(BaseHTTPRequestHandler, SessionManager):
             web_util.echo_json_response(self, 405, "Not Implemented: Use /agents/ interface")
             return
 
-        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
+        if not web_util.validate_api_version(self, cast(str, rest_params["api_version"]), logger):
             return
 
         if "agents" not in rest_params:
@@ -140,7 +141,7 @@ class ProtectedHandler(BaseHTTPRequestHandler, SessionManager):
             web_util.echo_json_response(self, 405, "Not Implemented: Use /agents/ interface")
             return
 
-        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
+        if not web_util.validate_api_version(self, cast(str, rest_params["api_version"]), logger):
             return
 
         if "agents" not in rest_params:
@@ -222,7 +223,7 @@ class UnprotectedHandler(BaseHTTPRequestHandler, SessionManager):
             web_util.echo_json_response(self, 405, "Not Implemented: Use /agents/ interface")
             return
 
-        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
+        if not web_util.validate_api_version(self, cast(str, rest_params["api_version"]), logger):
             return
 
         if "agents" not in rest_params:
@@ -410,7 +411,7 @@ class UnprotectedHandler(BaseHTTPRequestHandler, SessionManager):
             web_util.echo_json_response(self, 405, "Not Implemented: Use /agents/ interface")
             return
 
-        if not web_util.validate_api_version(self, rest_params["api_version"], logger):
+        if not web_util.validate_api_version(self, cast(str, rest_params["api_version"]), logger):
             return
 
         if "agents" not in rest_params:

--- a/mypy.ini
+++ b/mypy.ini
@@ -59,6 +59,9 @@ ignore_errors = False
 [mypy-keylime.user_utils_test]
 ignore_errors = False
 
+[mypy-keylime.web_util]
+ignore_errors = False
+
 [mypy-keylime.*]
 ignore_errors = True
 

--- a/test/test_web_util.py
+++ b/test/test_web_util.py
@@ -23,7 +23,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(web_util.get_restful_params(version_url), version_params)
 
         basic_url = "/version"
-        basic_params = {"version": None, "api_version": 0}
+        basic_params = {"version": None, "api_version": "0"}
         self.assertEqual(web_util.get_restful_params(basic_url), basic_params)
 
     def test_json_response_tornado(self):


### PR DESCRIPTION
Type-annotate web_util.py. The following type annotation forces the casting of rest_params["api_version"] to a str. We can do this since we know that "api_version" has been set in get_restful_params.

def get_restful_params(urlstring: str) -> Dict[str, Union[str, None]]:

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>