### PR TITLE
logging: remove option to log into separate file

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -382,11 +382,6 @@ signed_attributes =
 # signature check before storing them in the database.
 require_allow_list_signatures = False
 
-# Destination for log output, in addition to console. Values can be 'file', 
-# with the file being named after the "service" - cloud_verifier - created under 
-# /var/log/keylime), 'stream' or it can be left empty (which results in 
-# logging to console only, recommended when running inside a container)
-log_destination = file
 
 #=============================================================================
 [tenant]
@@ -675,11 +670,6 @@ transparency_log_sign_algo = sha256
 # will mean no signing should be done.
 signed_attributes = ek_tpm,aik_tpm,ekcert
 
-# Destination for log output, in addition to console. Values can be 'file',
-# with the file being named after the "service" - registrar - created under
-# /var/log/keylime), 'stream' or it can be left empty (which results in
-# logging to console only, recommended when running inside a container)
-log_destination = file
 
 #=============================================================================
 [ca]

--- a/keylime/keylime_logging.py
+++ b/keylime/keylime_logging.py
@@ -1,16 +1,9 @@
 import logging
-import os
 from logging import Logger
 from logging import config as logging_config
 from typing import Any, Callable, Dict
 
 from keylime import config
-
-LOG_TO_FILE = set()
-LOG_TO_STREAM = set()
-LOGDIR = os.getenv("KEYLIME_LOGDIR", "/var/log/keylime")
-# not clear that this works right.  console logging may not work
-LOGSTREAM = os.path.join(LOGDIR, "keylime-stream.log")
 
 logging_config.fileConfig(config.get_config("logging"))
 
@@ -50,31 +43,7 @@ def log_http_response(logger: Logger, loglevel: int, response_body: Dict[str, An
 
 
 def init_logging(loggername: str) -> Logger:
-
-    if loggername in ("verifier", "registrar"):
-        logdest = config.get(loggername, "log_destination", fallback="")
-        if logdest == "file":
-            LOG_TO_FILE.add(loggername)
-        if logdest == "stream":
-            LOG_TO_STREAM.add(loggername)
-
     logger = logging.getLogger(f"keylime.{loggername}")
     logging.getLogger("requests").setLevel(logging.WARNING)
-    mainlogger = logging.getLogger("keylime")
-    basic_formatter = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
-    if loggername in LOG_TO_FILE:
-        logfilename = os.path.join(LOGDIR, f"{loggername}.log")
-        if not os.path.exists(LOGDIR):
-            os.makedirs(LOGDIR, 0o750)
-        fh = logging.FileHandler(logfilename)
-        fh.setLevel(logger.getEffectiveLevel())
-        fh.setFormatter(basic_formatter)
-        mainlogger.addHandler(fh)
-
-    if loggername in LOG_TO_STREAM:
-        fh = logging.FileHandler(filename=LOGSTREAM, mode="w")
-        fh.setLevel(logger.getEffectiveLevel())
-        fh.setFormatter(basic_formatter)
-        mainlogger.addHandler(fh)
 
     return logger

--- a/scripts/templates/2.0/registrar.j2
+++ b/scripts/templates/2.0/registrar.j2
@@ -72,15 +72,6 @@ auto_migrate_db = {{ registrar.auto_migrate_db }}
 # The file to use for SQLite persistence of provider hypervisor data.
 prov_db_filename: {{ registrar.prov_db_filename }}
 
-# Destination for log output, in addition to console. If left empty, the log
-# output will only be printed to console (recommended for containers to avoid
-# filling data storage). The accepted values are:
-# 'file': The log output will also be written to a file named after the
-#         component in '/var/log/keylime/registrar.log'
-# 'stream': The log output will be written to a common file in
-#           'var/log/keylime/keylime-stream.log'
-log_destination = {{ registrar.log_destination }}
-
 # Durable Attestation is currently marked as an experimental feature
 # In order to enable Durable Attestation, an "adapter" for a Persistent data Store 
 # (time-series like database) needs to be specified. Some example adapters can be 

--- a/scripts/templates/2.0/verifier.j2
+++ b/scripts/templates/2.0/verifier.j2
@@ -235,12 +235,3 @@ zmq_port = {{ verifier.zmq_port }}
 
 # Webhook url for revocation notifications.
 webhook_url = {{ verifier.webhook_url }}
-
-# Destination for log output, in addition to console. If left empty, the log
-# output will only be printed to console (recommended for containers to avoid
-# filling data storage). The accepted values are:
-# 'file': The log output will also be written to a file named after the
-#         component in '/var/log/keylime/verifier.log'
-# 'stream': The log output will be written to a common file in
-#           'var/log/keylime/keylime-stream.log'
-log_destination = {{ verifier.log_destination }}


### PR DESCRIPTION
The implementation had the issue that only the main loggers were added and that
the permissions were not set strict enough. Users should use the logging
provided by systemd instead.

Fixes: #1207
Fixes: #1174
