### PR TITLE
docker: use master of tpm2-tools

### DIFF
--- a/docker/release/base/Dockerfile.in
+++ b/docker/release/base/Dockerfile.in
@@ -1,8 +1,8 @@
-FROM fedora:34 AS keylime_base
+FROM fedora:37 AS keylime_base
 LABEL version="_version_" description="Keylime Base - Only used as an base image for derived packages"
 MAINTAINER Keylime Team <main@keylime.groups.io>
 
 ENV GOPATH=/root/go
-RUN --mount=target=/keylime,type=bind,source=. \
+RUN --mount=target=/keylime,type=bind,source=.,rw \
     cd /keylime && ./installer.sh -o && \
     dnf -y install python3-PyMySQL

--- a/docker/release/base/Dockerfile.in
+++ b/docker/release/base/Dockerfile.in
@@ -2,6 +2,14 @@ FROM fedora:37 AS keylime_base
 LABEL version="_version_" description="Keylime Base - Only used as an base image for derived packages"
 MAINTAINER Keylime Team <main@keylime.groups.io>
 
+RUN dnf -y install dnf-plugins-core git && dnf -y builddep tpm2-tools
+RUN git clone -b 5.4 https://github.com/tpm2-software/tpm2-tools.git && \
+    cd tpm2-tools && \
+    ./bootstrap && \
+    ./configure && \
+    make && make install && \
+    cd .. && rm -rf tpm2-tools
+
 ENV GOPATH=/root/go
 RUN --mount=target=/keylime,type=bind,source=.,rw \
     cd /keylime && ./installer.sh -o && \

--- a/docker/release/build_locally.sh
+++ b/docker/release/build_locally.sh
@@ -9,6 +9,6 @@ KEYLIME_DIR=${2:-"../../"}
 
 ./generate-files.sh ${VERSION}
 for part in base registrar verifier tenant; do
-  docker buildx build -t keylime_${part} -f ${part}/Dockerfile $KEYLIME_DIR
+  docker buildx build -t keylime_${part}:${VERSION} -f ${part}/Dockerfile $KEYLIME_DIR --progress plain ${@:3}
   rm -f ${part}/Dockerfile
 done


### PR DESCRIPTION
We need the lastest version of tpm2_eventlog to parse logs with newer Shims correctly.
