### PR TITLE
tpm_abstract: move import of measured_boot into check_pcrs(..)

### DIFF
--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from yaml import SafeLoader, SafeDumper
 
-from keylime import config, crypto, json, keylime_logging, measured_boot
+from keylime import config, crypto, json, keylime_logging
 from keylime.agentstates import AgentAttestState
 from keylime.common import algorithms
 from keylime.common.algorithms import Hash
@@ -276,6 +276,9 @@ class AbstractTPM(metaclass=ABCMeta):
         hash_alg: Hash,
     ) -> Failure:
         failure = Failure(Component.PCR_VALIDATION)
+
+        # The measured_boot code loads verifier configuration automatically and therefore cannot be imported globally.
+        from keylime import measured_boot  # pylint: disable=import-outside-toplevel
 
         if isinstance(tpm_policy, str):
             tpm_policy_dict = json.loads(tpm_policy)


### PR DESCRIPTION
This is erquired because otherwise the registrar tries to load the verifier configuration.

