### PR TITLE
Introduce a RetDictType for return type of cmd_exec.run()

### DIFF
--- a/keylime/cmd_exec.py
+++ b/keylime/cmd_exec.py
@@ -1,11 +1,26 @@
 import os
 import subprocess
+import sys
 import time
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, cast
+from typing import Dict, List, Optional, Sequence, Tuple, Union, cast
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
 
 EXIT_SUCESS = 0
 
 EnvType = Dict[str, str]
+
+
+class RetDictType(TypedDict):
+    retout: List[bytes]
+    reterr: List[bytes]
+    code: int
+    fileouts: Dict[str, bytes]
+    timing: Dict[str, float]
 
 
 def _execute(cmd: Sequence[str], env: Optional[EnvType] = None, **kwargs) -> Tuple[bytes, bytes, int]:
@@ -22,7 +37,7 @@ def run(
     outputpaths: Optional[Union[List[str], str]] = None,
     env: Optional[EnvType] = None,
     **kwargs,
-) -> Dict[str, Any]:
+) -> RetDictType:
     """Execute external command.
 
     :param cmd: a sequence of command arguments
@@ -55,7 +70,7 @@ def run(
             with open(thispath, "rb") as f:
                 fileouts[thispath] = f.read()
 
-    returnDict = {
+    returnDict: RetDictType = {
         "retout": retout_list,
         "reterr": reterr_list,
         "code": code,

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -152,7 +152,7 @@ class tpm(tpm_abstract.AbstractTPM):
             pcrs = collections.ChainMap(*retyaml["selected-pcrs"])
         return pcrs
 
-    def run(self, cmd: Sequence[str]) -> Dict[str, Any]:
+    def run(self, cmd: Sequence[str]) -> cmd_exec.RetDictType:
         return self.__run(cmd, lock=False)
 
     def __run(
@@ -162,7 +162,7 @@ class tpm(tpm_abstract.AbstractTPM):
         raiseOnError: bool = True,
         lock: bool = True,
         outputpaths: Optional[Union[List, str]] = None,
-    ) -> Dict[str, Any]:
+    ) -> cmd_exec.RetDictType:
         env = _get_cmd_env()
 
         # Convert single outputpath to list
@@ -1026,7 +1026,7 @@ class tpm(tpm_abstract.AbstractTPM):
 
     def __tpm2_checkquote(
         self, pubaik: str, nonce: str, quoteFile: str, sigFile: str, pcrFile: str, hash_alg: Union[Hash, str]
-    ) -> Dict[str, Any]:
+    ) -> cmd_exec.RetDictType:
         nonce = bytes(nonce, encoding="utf8").hex()
         if self.tools_version == "3.2":
             command = [
@@ -1065,7 +1065,7 @@ class tpm(tpm_abstract.AbstractTPM):
         retDict = self.__run(command, lock=False)
         return retDict
 
-    def __tpm2_printquote(self, quoteFile: str) -> Dict[str, Any]:
+    def __tpm2_printquote(self, quoteFile: str) -> cmd_exec.RetDictType:
         command = ["tpm2_print", "-t", "TPMS_ATTEST", quoteFile]
         retDict = self.__run(command, lock=False)
         return retDict
@@ -1376,7 +1376,7 @@ class tpm(tpm_abstract.AbstractTPM):
         return f"{jsonout[hash_alg][pcrval]:0{alg_size}x}"
 
     # tpm_random
-    def _get_tpm_rand_block(self, size: int = 32) -> Optional[str]:
+    def _get_tpm_rand_block(self, size: int = 32) -> Optional[bytes]:
         # make a temp file for the output
         rand = None
         with tempfile.NamedTemporaryFile() as randpath:


### PR DESCRIPTION
Replace Dict[str, Any] with concrete RetDictType for the return type of cmd_exec.run() and propagate the type to all callers.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>