### PR TITLE
Fix the ima_sign_verification_keys initial datatype 

### DIFF
--- a/keylime/cli/policies.py
+++ b/keylime/cli/policies.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Optional
 
 from keylime import config, keylime_logging, measured_boot
 from keylime.ima import file_signatures, ima
@@ -29,7 +30,7 @@ def process_allowlist(args):
     tpm_policy = "{}"
     ima_policy_name = ""
     mb_refstate = None
-    ima_sign_verification_keys = []
+    ima_sign_verification_keys: Optional[str] = None
     allowlist = {}
 
     # Set up PCR values

--- a/keylime/ima/file_signatures.py
+++ b/keylime/ima/file_signatures.py
@@ -188,8 +188,8 @@ class ImaKeyring:
 
         default_be = backends.default_backend()
 
-        # An empty Db entry comes as a string '[]'. A valid DB entry as a string
-        # ith escaped quotes and needs to be loaded twice
+        # An empty Db entry comes as a string 'null' or previously '[]'. A valid DB entry
+        # is a string with escaped quotes and needs to be loaded twice
         obj = json.loads(stringrepr)
         if isinstance(obj, str):
             obj = json.loads(obj)

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 import time
 import zipfile
-from typing import List
+from typing import List, Optional
 
 import requests
 from cryptography.hazmat.primitives import serialization as crypto_serialization
@@ -63,7 +63,7 @@ class Tenant:
     metadata = {}
     allowlist = {}
     ima_policy_name = ""
-    ima_sign_verification_keys = []
+    ima_sign_verification_keys: Optional[str] = None
     revocation_key = ""
     accept_tpm_hash_algs = []
     accept_tpm_encryption_algs = []


### PR DESCRIPTION
…ings

The variable ima_sign_verification_keys is a string, so initialize
it with an empty string rather than an empty list.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>