### PR TITLE
durable attestation: a simple "attestation replay" CLI utility

### DIFF
--- a/keylime/cmd/attest.py
+++ b/keylime/cmd/attest.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+
+"""
+SPDX-License-Identifier: Apache-2.0
+Copyright 2017 Massachusetts Institute of Technology.
+"""
+import sys
+
+from keylime import keylime_logging
+from keylime.da import attest
+
+logger = keylime_logging.init_logging("attest")
+
+
+def main() -> None:
+    attest.main()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logger.exception(e)
+        sys.exit(-1)

--- a/keylime/da/attest.py
+++ b/keylime/da/attest.py
@@ -1,0 +1,154 @@
+#!/usr/bin/python3
+import argparse
+from datetime import datetime
+
+from keylime import cloud_verifier_common, config, keylime_logging
+from keylime.da import record
+
+logger = keylime_logging.init_logging("durable_attestation_fetch_and_replay")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-u",
+        "--uuid",
+        action="store",
+        dest="agent_uuid",
+        default="all",
+        help='UUID for the agent to attest (default "all")',
+    )
+    parser.add_argument(
+        "-s",
+        "--start",
+        action="store",
+        dest="start_date",
+        default="first",
+        help='start date for attestation window in either IS0 8601 format (e.g., "2008-09-03T20:56:35"), or keyworkd "first"/"none"',
+    )
+    parser.add_argument(
+        "-e",
+        "--end",
+        action="store",
+        dest="end_date",
+        default="last",
+        help='end date for attestation window in IS0 8601 format (e.g., "2008-09-03T21:56:35"), or keyworkd "last"',
+    )
+
+    args = parser.parse_args()
+
+    rmcb = config.get("registrar", "durable_attestation_import", fallback="")
+    rmc = record.get_record_mgt_class(rmcb)
+    if not rmc:
+        return
+
+    rmc = rmc("registrar")
+
+    if args.end_date == "last":
+        end_date = rmc.end_of_times
+    else:
+        end_date = int(datetime.fromisoformat(args.end_date).strftime("%s"))
+
+    if args.start_date == "first":
+        start_date = rmc.start_of_times
+    elif args.start_date == "none":
+        start_date = end_date - 1
+    else:
+        start_date = int(datetime.fromisoformat(args.start_date).strftime("%s"))
+
+    if end_date != rmc.end_of_times or start_date != rmc.end_of_times - 1:
+        logger.info(
+            "=> Selected date range for attestation records is: start %d (%s) and end %d (%s)",
+            start_date,
+            datetime.fromtimestamp(start_date).strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+            end_date,
+            datetime.fromtimestamp(end_date).strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+        )
+    else:
+        logger.info("=> Will only extract the very last attestation record found on the persistent store")
+
+    if args.agent_uuid.lower() == "all":
+        logger.info("=> Getting a list of agents registered on the persistent store")
+        agent_list = rmc.agent_list_retrieval()
+    else:
+        logger.info("=> Focusing on the agent %s on the persistent store.", args.agent_uuid)
+        agent_list = [args.agent_uuid]
+
+    for agent_uuid in agent_list:
+        logger.info("===> Getting all existing registration records for agent %s...", agent_uuid)
+
+        ak_list = rmc.build_key_list(agent_uuid, "registrar")
+
+        if not ak_list:
+            logger.error("Unable to assemble a list of AKs for the agent agent %s", agent_uuid)
+            return
+
+        logger.info("===> Getting all existing attestation records for agent %s ...", agent_uuid)
+        attestation_record_list = rmc.record_read(agent_uuid, start_date, end_date, "verifier")
+
+        logger.info("=====> Verifing the state of agent %s over time...", agent_uuid)
+
+        p_tpm_ts = 0
+        c_tpm_ts = 0
+        d_tpm_ts = 0
+
+        agentAttestState = None
+        for attestation_record in attestation_record_list:
+            agent = attestation_record["agent"]
+            json_response = attestation_record["json_response"]
+            ima_policy = attestation_record["ima_policy"]
+
+            logger.info(
+                "----------- Attesting data (quote and logs from %s, captured by verifier %s (%s:%s)",
+                agent_uuid,
+                agent["verifier_id"],
+                agent["verifier_ip"],
+                agent["verifier_port"],
+            )
+
+            if not agentAttestState:
+                agentAttestState = cloud_verifier_common.get_AgentAttestStates().get_by_agent_id(agent["agent_id"])
+
+            if "tpm_clockinfo" in agent:
+                if "clock" in agent["tpm_clockinfo"]:
+                    p_tpm_ts = agent["tpm_clockinfo"]["clock"]
+
+            failure = cloud_verifier_common.process_quote_response(
+                agent, ima_policy, json_response["results"], agentAttestState
+            )
+
+            if "tpm_clockinfo" in agent:
+                if "clock" in agent["tpm_clockinfo"]:
+                    c_tpm_ts = agent["tpm_clockinfo"]["clock"]
+
+            if p_tpm_ts and c_tpm_ts:
+                d_tpm_ts = c_tpm_ts - p_tpm_ts
+
+            quote_failed = False
+            if failure:
+                if failure.events:
+                    quote_failed = True
+
+            if quote_failed:
+                f_e_id = "NA"
+                f_e_ctx = "NA"
+                if failure.highest_severity_event:
+                    f_e_id = failure.highest_severity_event.event_id
+                    f_e_ctx = failure.highest_severity_event.context
+
+                    logger.info(
+                        '---------- Agent %s was NOT in "attested" state at %s (TPM delta: %s): %s %s',
+                        agent_uuid,
+                        attestation_record["verifier" + "_timestamp"],
+                        d_tpm_ts,
+                        f_e_id,
+                        f_e_ctx,
+                    )
+                    return
+            else:
+                logger.info(
+                    '---------- Agent %s was in "attested" state at %s (TPM delta: %s)',
+                    agent_uuid,
+                    attestation_record["verifier" + "_timestamp"],
+                    d_tpm_ts,
+                )

--- a/keylime/da/record.py
+++ b/keylime/da/record.py
@@ -6,7 +6,10 @@ import os
 import pickle
 import tempfile
 from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
+
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 
 from keylime import config, crypto, json, keylime_logging, web_util
 from keylime.fs_util import ch_dir
@@ -15,7 +18,7 @@ logger = keylime_logging.init_logging("durable_attestation")
 
 
 class BaseRecordManagement(metaclass=abc.ABCMeta):
-    def __init__(self, service, key_tls_pub=None):
+    def __init__(self, service: str, key_tls_pub: Optional[str] = "") -> None:
 
         self.svc = service
 
@@ -32,21 +35,23 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
         self.rcd_enc = config.get(self.svc, "persistent_store_encoding", fallback="")
         self.rcd_sa = config.get(self.svc, "transparency_log_sign_algo", fallback="sha256")
         self.tmp_d_cl = True
-        self.key_tls_priv = None
+        self.key_tls_priv: Optional[str] = ""
         self.key_tls_pub = key_tls_pub
-        self.priv_key = None
+        self.priv_key: Optional[RSAPrivateKey] = None
+        self.start_of_times = 0
+        self.end_of_times = 99999999999
         logger.info('The "Durable Attestion" feature is stil experimental and might change in the future')
         logger.debug('Persistent store module %s imported for "Durable Attestation"', self.st_imp_module)
 
     @abc.abstractmethod
     def record_create(
         self,
-        agent_data: dict,
-        attestation_data: dict,
-        ima_policy_data: dict,
+        agent_data: Dict[Any, Any],
+        attestation_data: Dict[Any, Any],
+        ima_policy_data: Dict[Any, Any],
         service: str = "auto",
         signed_attributes: str = "auto",
-    ):
+    ) -> None:
         """Takes agent data, attestation data, ima policy data, serialize, optionally encodes it and writes to a persistent data store"""
 
     def get_record_type(self, service: str) -> str:
@@ -59,7 +64,7 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
 
         return "attestation"
 
-    def set_certs_path(self, override_service: bool = False):
+    def set_certs_path(self, override_service: Optional[str] = "") -> None:
         """Get the paths for TLS certficates and key pair (used for agent data attribute signature, optionally) from the Keylime configurations"""
         if override_service:
             self.svc = override_service
@@ -67,52 +72,52 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
         if not self.key_tls_pub:
             (_, self.key_tls_priv, _, _), _ = web_util.get_tls_options(self.svc, logger=logger)
 
-            self.key_tls_pub = self.key_tls_priv.replace("-private", "-public")
+            if self.key_tls_priv:
+                self.key_tls_pub = self.key_tls_priv.replace("-private", "-public")
 
-            if self.tl_url:
-                with open(self.key_tls_priv, "rb") as fp:
-                    self.priv_key = crypto.rsa_import_privkey(fp.read())
+                if self.tl_url:
+                    with open(self.key_tls_priv, "rb") as fp:
+                        self.priv_key = crypto.rsa_import_privkey(fp.read())
 
-    def record_serialize(self, record_object: dict) -> bytes:
+    def record_serialize(self, record_object: Dict[Any, Any]) -> Union[Any, Dict[Any, Any]]:
         """Serialize, and optionally encodes, record"""
 
-        serialized_record_object = copy.deepcopy(record_object)
+        manipulated_record_object = copy.deepcopy(record_object)
 
         if self.rcd_fmt == "pickle":
-            serialized_record_object = pickle.dumps(serialized_record_object)
+            serialized_record_object = pickle.dumps(manipulated_record_object)
 
         if self.rcd_fmt == "json":
-            serialized_record_object = json.dumps(serialized_record_object, indent=4)
-            serialized_record_object = str.encode(serialized_record_object)
+            serialized_record_object = json.dumps(manipulated_record_object, indent=4).encode("utf-8")
 
         if self.rcd_enc == "base64":
             serialized_record_object = base64.b64encode(serialized_record_object)
 
         return serialized_record_object
 
-    def record_deserialize(self, record_object: bytes) -> dict:
+    def record_deserialize(self, record_object: Union[Any, bytes]) -> Union[Any, Dict[Any, Any]]:
         """Deserialize, and optionally decodes, record"""
 
-        deserialized_record_object = copy.deepcopy(record_object)
+        manipulated_record_object = copy.deepcopy(record_object)
 
         if self.rcd_enc == "base64":
-            deserialized_record_object = base64.b64decode(deserialized_record_object)
+            manipulated_record_object = base64.b64decode(manipulated_record_object)
 
         if self.rcd_fmt == "pickle":
-            deserialized_record_object = pickle.loads(deserialized_record_object)
+            deserialized_record_object = pickle.loads(manipulated_record_object)
 
         if self.rcd_fmt == "json":
-            deserialized_record_object = deserialized_record_object.decode("utf-8")
+            deserialized_record_object = manipulated_record_object.decode("utf-8")
             deserialized_record_object = json.loads(deserialized_record_object)
 
         return deserialized_record_object
 
-    def record_sanitize(self, record_object: dict):
+    def record_sanitize(self, record_object: Dict[Any, Any]) -> Dict[Any, Any]:
         """Removes a set of pre-defined key,pairs from record"""
 
         # copy.deepcopy fails at "ssl_context"
 
-        sanitized_record_object = {}
+        sanitized_record_object: Dict[Any, Any] = {}
 
         for key in record_object:
             if isinstance(record_object[key], dict):
@@ -127,8 +132,12 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
         return sanitized_record_object
 
     def record_assemble(
-        self, record_object: dict, agent_data: dict, attestation_data: dict, ima_policy_data: dict
-    ) -> dict:
+        self,
+        record_object: Dict[Any, Any],
+        agent_data: Dict[Any, Any],
+        attestation_data: Dict[Any, Any],
+        ima_policy_data: Dict[Any, Any],
+    ) -> Dict[Any, Any]:
         """Assemble record to be created on persistent datastore"""
 
         record_object_assembled = copy.deepcopy(record_object)
@@ -143,13 +152,17 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
             sanitized_and_assembled_record_object["json_response"] = attestation_data
 
         if ima_policy_data:
-            sanitized_and_assembled_record_object["ima_policy"] = ima_policy_data.ima_policy
+            sanitized_and_assembled_record_object["ima_policy"] = ima_policy_data
 
         return sanitized_and_assembled_record_object
 
     def record_assemble_for_signing(
-        self, record_to_sign: dict, agent_data: dict, attestation_data: dict, signed_attributes: str
-    ) -> dict:
+        self,
+        record_to_sign: Dict[Any, Any],
+        agent_data: Dict[Any, Any],
+        attestation_data: Dict[Any, Any],
+        signed_attributes: str,
+    ) -> Dict[Any, Any]:
         """Builds a dictionary of attributes to dumped into a JSON file to be signed"""
         if not signed_attributes:
             return {}
@@ -170,8 +183,12 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
         return self.record_sanitize(record_to_sign)
 
     def base_record_create(
-        self, record_object: dict, agent_data: dict, attestation_data: dict, ima_policy_data: dict
-    ) -> str:
+        self,
+        record_object: Dict[Any, Any],
+        agent_data: Dict[Any, Any],
+        attestation_data: Dict[Any, Any],
+        ima_policy_data: Dict[Any, Any],
+    ) -> Union[bytes, Dict[Any, Any]]:
         """Prepares record to be stored on persistent datastore"""
         record_assembled = self.record_assemble(record_object, agent_data, attestation_data, ima_policy_data)
 
@@ -179,13 +196,18 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
 
         return self.record_serialize(record_assembled)
 
-    def base_record_read(self, attestation_record_list: list):
+    def base_record_read(self, attestation_record_list: List[Dict[Any, Any]]) -> None:
         """Accesses a persisent data store, retrieves multiple data entries, adding each entry to a provided list"""
         assert self.svc
         assert attestation_record_list
 
     def base_record_signature_create(
-        self, record_object: dict, agent_data: dict, attestation_data: dict, service: str, signed_attributes: str
+        self,
+        record_object: Dict[Any, Any],
+        agent_data: Dict[Any, Any],
+        attestation_data: Dict[Any, Any],
+        service: str,
+        signed_attributes: str,
     ) -> bytes:
         """
         Sign a record with with a private (RSA) key from Keylime
@@ -230,37 +252,47 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
 
         with tempfile.TemporaryDirectory() as _temp_dir_path:
 
-            ch_dir("/".join(self.key_tls_priv.split("/")[0:-1]))
-            if not os.path.exists(self.key_tls_pub):
+            if self.key_tls_pub:
+
+                ch_dir("/".join(self.key_tls_pub.split("/")[0:-1]))
+                if not os.path.exists(self.key_tls_pub):
+                    raise RecordManagementException(
+                        f"Unable to find public key {self.key_tls_pub} while signing data for agent {agent_data['agent_id']}"
+                    )
+
+                contents_for_signing = json.dumps(record_object_for_signing).encode("utf-8")
+                with open(f'{_temp_dir_path}/{agent_data["agent_id"]}.json', "wb") as fp:
+                    fp.write(contents_for_signing)
+
+                record_object["temp_dir"] = _temp_dir_path
+                record_object["contents_file_path"] = f'{record_object["temp_dir"]}/{agent_data["agent_id"]}.json'
+                record_object["signature_file_path"] = f'{record_object["temp_dir"]}/{agent_data["agent_id"]}.json.sig'
+
+                with open(self.key_tls_pub, encoding="utf-8") as fp:
+                    record_object["signer_pub_key"] = fp.read()
+
+                if self.priv_key:
+                    record_object["signature"] = crypto.rsa_sign(self.priv_key, contents_for_signing, "default")
+
+                with open(record_object["signature_file_path"], "wb") as fp:
+                    fp.write(base64.b64decode(record_object["signature"]))
+
+                if "contents_file_path" in record_object and "signature_file_path" in record_object:
+                    if self.tl_url.scheme == "http" and self.tl_url.netloc.count("3000"):
+                        getattr(importlib.import_module(self.st_imp_path + ".rekor"), "record_signature_create")(
+                            record_object, agent_data, self.tl_url, self.key_tls_pub
+                        )
+
+            else:
                 raise RecordManagementException(
                     f"Unable to find public key {self.key_tls_pub} while signing data for agent {agent_data['agent_id']}"
                 )
 
-            contents_for_signing = json.dumps(record_object_for_signing).encode("utf-8")
-            with open(f'{_temp_dir_path}/{agent_data["agent_id"]}.json', "wb") as fp:
-                fp.write(contents_for_signing)
-
-            record_object["temp_dir"] = _temp_dir_path
-            record_object["contents_file_path"] = f'{record_object["temp_dir"]}/{agent_data["agent_id"]}.json'
-            record_object["signature_file_path"] = f'{record_object["temp_dir"]}/{agent_data["agent_id"]}.json.sig'
-
-            with open(self.key_tls_pub, encoding="utf-8") as fp:
-                record_object["signer_pub_key"] = fp.read()
-
-            record_object["signature"] = crypto.rsa_sign(self.priv_key, contents_for_signing, "default")
-
-            with open(record_object["signature_file_path"], "wb") as fp:
-                fp.write(base64.b64decode(record_object["signature"]))
-
-            if "contents_file_path" in record_object and "signature_file_path" in record_object:
-                if self.tl_url.scheme == "http" and self.tl_url.netloc.count("3000"):
-                    getattr(importlib.import_module(self.st_imp_path + ".rekor"), "record_signature_create")(
-                        record_object, agent_data, self.tl_url, self.key_tls_pub
-                    )
-
         return contents_for_signing
 
-    def base_record_timestamp_create(self, record_object: dict, agent_data: dict, contents: bytes):
+    def base_record_timestamp_create(
+        self, record_object: Dict[Any, Any], agent_data: Dict[Any, Any], contents: bytes
+    ) -> None:
         """Accesses a Time Stamp Autorhity (TSA) and gets a signed timestamp for a given contents"""
         if self.tsa_url.scheme and contents:
             logger.debug(
@@ -285,7 +317,9 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
                     agent_data["agent_id"],
                 )
 
-    def base_record_timestamp_check(self, record_object: dict, record_identifier: str, contents: bytes):
+    def base_record_timestamp_check(
+        self, record_object: Dict[Any, Any], record_identifier: str, contents: bytes
+    ) -> None:
         """Accesses a Time Stamp Autorhity (TSA) and checks a signed timestamp for a given contents"""
         if self.tsa_url.scheme and contents:
 
@@ -299,13 +333,20 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
                 record_object, record_identifier, contents, self.tsa_url, self.tsa_cert
             )
 
-    def base_record_signature_check(self, record_object: dict, agent_data: dict) -> str:
+    def base_record_signature_check(
+        self, record_object: Dict[Any, Any], agent_data: Dict[Any, Any]
+    ) -> Optional[Dict[str, Any]]:
         """Check the signature for contents of a given record"""
 
         if not "signature" in record_object:
             return None
 
         self.set_certs_path()
+
+        if not self.key_tls_pub:
+            raise RecordManagementException(
+                f"Unable to find public key {self.key_tls_pub} while signing data for agent {agent_data['agent_id']}"
+            )
 
         with tempfile.TemporaryDirectory() as _temp_dir_path:
 
@@ -326,10 +367,10 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
             _contents_to_check = {}
             _contents_to_check["agent"] = record_object["agent"]
 
-            _contents_to_check = json.dumps(_contents_to_check).encode("utf-8")
+            _contents_to_check_bytes = json.dumps(_contents_to_check).encode("utf-8")
 
             with open(record_object["contents_file_path"], "wb") as fp:
-                fp.write(_contents_to_check)
+                fp.write(_contents_to_check_bytes)
 
             if "contents_file_path" in record_object and "signature_file_path" in record_object:
                 if self.tl_url.scheme == "http" and self.tl_url.netloc.count("3000"):
@@ -339,15 +380,20 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
 
         return _contents_to_check
 
+    def only_last_record_wanted(self, start_date: int, end_date: int) -> bool:
+        if start_date == self.end_of_times - 1 and end_date == self.end_of_times:
+            return True
+        return False
+
 
 class RecordManagementException(Exception):
     pass
 
 
-def base_build_key_list(registration_record_list: list) -> list:
+def base_build_key_list(registration_record_list: List[Dict[Any, Any]]) -> List[str]:
     """Just assembles a simple list of AIKs used by an agent"""
 
-    aik_list = []
+    aik_list: List[str] = []
     for _entry in registration_record_list:
         if _entry["agent"]["aik_tpm"] not in aik_list:
             logger.debug("New AIK added to the list")
@@ -356,7 +402,7 @@ def base_build_key_list(registration_record_list: list) -> list:
     return aik_list
 
 
-def get_record_mgt_class(store_import: str = ""):
+def get_record_mgt_class(store_import: str = "") -> Optional[Any]:
     """Dynamically imports a persistent store backend"""
     if store_import:
         return getattr(importlib.import_module(store_import), "RecordManagement")

--- a/mypy.ini
+++ b/mypy.ini
@@ -50,6 +50,9 @@ ignore_errors = True
 [mypy-keylime.tpm_bootlog_enrich]
 ignore_errors = True
 
+[mypy-keylime.da.examples.*]
+ignore_errors = True
+
 # All other files are fully checked, some with special options
 
 [mypy-keylime.ima.file_signatures]

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,5 +53,6 @@ console_scripts =
         keylime_registrar = keylime.cmd.registrar:main
         keylime_ca = keylime.cmd.ca:main
         keylime_ima_emulator = keylime.cmd.ima_emulator_adapter:main
+        keylime_attest = keylime.cmd.attest:main
         keylime_convert_ima_policy = keylime.cmd.convert_ima_policy:main
         keylime_upgrade_config = keylime.cmd.convert_config:main


### PR DESCRIPTION
Originally, I intended this to be my last PR on the enhancement #73 "Durable (Offline) Attestion". However, I have decided to split it two parts, with an early, much simpler "durable attestation replay CLI", named `keylime_attest` for two reasons:
1) It became clear that the time has come to add at least a very simple
   test for it on the CI. Thanks to @aplanas suggestion, we have a
"plain file" backend which would allow this, given this new `keylime_attest` CLI.
2) IMA (runtime) policy is (thankfully) seeing a lot of activity from
   @mbestravos and @stefanberger. It is possible that some of the
changes proposed will "break" durable attestation, but it is not fair to demand "running compatibility without a test".

In addition to smal changes to add a (`verifier`-generated epoch timestamp to each attestation record), the bulk of this PR focus on the implementation of a new CLI `keylime_attestation`

```
keylime_attest -h
Reading configuration from ['/etc/keylime/logging.conf']
usage: keylime_attest [-h] [-u AGENT_UUID] [-s START_DATE] [-e END_DATE]

optional arguments:
  -h, --help            show this help message and exit
  -u AGENT_UUID, --uuid AGENT_UUID
                        UUID for the agent to attest (default "all")
  -s START_DATE, --start START_DATE
                        start date for attestation window in either IS0 8601 format (e.g., "2008-09-03T20:56:35"), or keyworkd "first"/"none"
  -e END_DATE, --end END_DATE
                        end date for attestation window in IS0 8601 format (e.g., "2008-09-03T21:56:35"), or keyworkd "last"
```

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>