### PR TITLE
Fix that elchecking policy modules are loaded by agent or tenant

### DIFF
--- a/keylime/cmd/verifier.py
+++ b/keylime/cmd/verifier.py
@@ -1,5 +1,6 @@
 from keylime import cloud_verifier_tornado, config, keylime_logging
 from keylime.common.migrations import apply
+from keylime.elchecking.policies import load_policies
 
 logger = keylime_logging.init_logging("verifier")
 
@@ -9,6 +10,9 @@ def main() -> None:
     if config.has_option("verifier", "auto_migrate_db") and config.getboolean("verifier", "auto_migrate_db"):
         apply("cloud_verifier")
 
+    # Load explicitly the policy modules into Keylime for the verifier,
+    # so that they are not loaded accidentally from other components
+    load_policies()
     cloud_verifier_tornado.main()
 
 

--- a/keylime/elchecking/__init__.py
+++ b/keylime/elchecking/__init__.py
@@ -6,4 +6,3 @@
 
 # Basic policies are built in.
 # Additional policies are dynamically loaded according to config.
-from . import example

--- a/keylime/elchecking/__main__.py
+++ b/keylime/elchecking/__main__.py
@@ -5,6 +5,7 @@ import sys
 from ..tpm import tpm_main
 from . import policies
 
+policies.load_policies()
 # This main module is just for command-line based testing.
 # It implements a command to do one test.
 # Invoke it with `python3 -m $packagename`, for some value of

--- a/keylime/elchecking/policies.py
+++ b/keylime/elchecking/policies.py
@@ -103,9 +103,10 @@ def evaluate(policy_name: str, refstate: RefState, eventlog: tests.Data) -> str:
     return tester.why_not({}, eventlog)
 
 
-imports = config.getlist("verifier", "measured_boot_imports")
-# print(f'importing {imports!r}, __package__={__package__!r}')
-if imports:
-    for imp in imports:
-        if imp:
-            importlib.import_module(imp, __package__)
+def load_policies() -> None:
+    imports = config.getlist("verifier", "measured_boot_imports")
+    imports.append(".example")
+    if imports:
+        for imp in imports:
+            if imp:
+                importlib.import_module(imp, __package__)

--- a/keylime/tpm/tpm_abstract.py
+++ b/keylime/tpm/tpm_abstract.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from yaml import SafeLoader, SafeDumper
 
-from keylime import config, crypto, json, keylime_logging
+from keylime import config, crypto, json, keylime_logging, measured_boot
 from keylime.agentstates import AgentAttestState
 from keylime.common import algorithms
 from keylime.common.algorithms import Hash
@@ -276,9 +276,6 @@ class AbstractTPM(metaclass=ABCMeta):
         hash_alg: Hash,
     ) -> Failure:
         failure = Failure(Component.PCR_VALIDATION)
-
-        # The measured_boot code loads verifier configuration automatically and therefore cannot be imported globally.
-        from keylime import measured_boot  # pylint: disable=import-outside-toplevel
 
         if isinstance(tpm_policy, str):
             tpm_policy_dict = json.loads(tpm_policy)


### PR DESCRIPTION
- Revert "tpm_abstract: move import of measured_boot into check_pcrs(..)"
- elchecking: load policy modules explicitly

Fixes: #1262