### PR TITLE
pyright: Ignore a line in keylime/config.py due to newer pyright

### DIFF
--- a/keylime/config.py
+++ b/keylime/config.py
@@ -21,7 +21,7 @@ def convert(data: Any) -> Any:
     if isinstance(data, bytes):
         return data.decode()
     if isinstance(data, dict):
-        return dict(iter(map(convert, data.items())))
+        return dict(iter(map(convert, data.items())))  # pyright: ignore
     if isinstance(data, tuple):
         return tuple(map(convert, data))
     if isinstance(data, list):

--- a/keylime/config.py
+++ b/keylime/config.py
@@ -3,7 +3,7 @@ import logging
 import os
 import os.path
 from configparser import RawConfigParser
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, Iterator, List, Optional, cast
 
 import yaml
 
@@ -21,7 +21,7 @@ def convert(data: Any) -> Any:
     if isinstance(data, bytes):
         return data.decode()
     if isinstance(data, dict):
-        return dict(iter(map(convert, data.items())))  # pyright: ignore
+        return dict(cast(Iterator[Any], iter(map(convert, data.items()))))
     if isinstance(data, tuple):
         return tuple(map(convert, data))
     if isinstance(data, list):


### PR DESCRIPTION
Have pyright ignore a line in the code that would otherwise cause the following issue with newer versions of pyright:

  .../keylime/keylime/config.py:23:26 - error: Argument of type "map[Any]" cannot be assigned to parameter "__iterable" of type "SupportsIter[_SupportsNextT@iter]" in function "iter"
    "map[Any]" is incompatible with protocol "SupportsIter[_SupportsNextT@iter]"
      TypeVar "_T_co@SupportsIter" is covariant
        Type "map[Any]" cannot be assigned to type "SupportsKeysAndGetItem[str, Any]"
          "map[Any]" is incompatible with protocol "SupportsKeysAndGetItem[str, Any]"
            "keys" is not present
            "__getitem__" is not present (reportGeneralTypeIssues)
  .../keylime/keylime/config.py:23:26 - error: Argument of type "map[Any]" cannot be assigned to parameter "__iterable" of type "_GetItemIterable[_T@iter]" in function "iter"
    "map[Any]" is incompatible with protocol "_GetItemIterable[_T@iter]"
      "__getitem__" is not present (reportGeneralTypeIssues)

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>