### PR TITLE
tenant: Remove code hashing a public key and using hash as UUID

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -1,6 +1,5 @@
 import argparse
 import base64
-import hashlib
 import io
 import json
 import logging
@@ -1423,9 +1422,6 @@ def main() -> None:
 
     if args.agent_uuid is not None:
         mytenant.agent_uuid = args.agent_uuid
-        # if the uuid is actually a public key, then hash it
-        if mytenant.agent_uuid.startswith("-----BEGIN PUBLIC KEY-----"):
-            mytenant.agent_uuid = hashlib.sha256(mytenant.agent_uuid).hexdigest()
         if not validators.valid_agent_id(mytenant.agent_uuid):
             raise UserError("The agent ID set via agent uuid parameter use invalid characters")
     else:


### PR DESCRIPTION
Remove the code that was trying to hash a public key and use the resulting hash as agent UUID. This most likely never worked since the uuid (which is supposed to be the content of a PEM public key file) is passed from the command line as string and hashlib.sha256() does not accept a string as an argument.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>