### PR TITLE
Update and extend experimental create_policy tool

### DIFF
--- a/scripts/create_policy
+++ b/scripts/create_policy
@@ -235,10 +235,12 @@ def main(argv):
 
             # Cherry-pick from base policy what is supported and merge into policy
             policy["digests"] = base_policy.get("digests", {})
+            policy["excludes"] = base_policy.get("excludes", [])
             policy["keyrings"] = base_policy.get("keyrings", {})
             policy["ima-buf"] = base_policy.get("ima-buf", {})
             ignored_keyrings = base_policy.get("ima", {}).get("ignored_keyrings", [])
             policy["ima"]["ignored_keyrings"] = ignored_keyrings
+            policy["verification-keys"] = base_policy.get("verification-keys", "")
         except (PermissionError, FileNotFoundError) as ex:
             print(f"An error occurred while loading the policy: {ex}")
             ret = 1

--- a/scripts/create_policy
+++ b/scripts/create_policy
@@ -10,6 +10,8 @@ import sys
 from cryptography import x509
 from cryptography.hazmat import backends
 
+from keylime.ima import ima
+
 IMA_MEASUREMENT_LIST = "/sys/kernel/security/ima/ascii_runtime_measurements"
 IGNORED_KEYRINGS = []
 
@@ -179,16 +181,8 @@ def main(argv):
     )
     args = parser.parse_args(argv[1:])
 
-    policy = {
-        "meta": {"version": 4},
-        "release": 0,
-        "hashes": {},
-        "keyrings": {},
-        "ima-buf": {},
-        "ima": {
-            "ignored_keyrings": args.ignored_keyrings,
-        },
-    }
+    policy = ima.EMPTY_RUNTIME_POLICY
+    policy["ima"]["ignored_keyrings"] = args.ignored_keyrings
 
     ret = 0
 
@@ -199,7 +193,7 @@ def main(argv):
             base_policy = json.loads(basepol)
 
             # Cherry-pick from base policy what is supported and merge into policy
-            policy["hashes"] = base_policy.get("hashes", {})
+            policy["digests"] = base_policy.get("digests", {})
             policy["keyrings"] = base_policy.get("keyrings", {})
             policy["ima-buf"] = base_policy.get("ima-buf", {})
             ignored_keyrings = base_policy.get("ima", {}).get("ignored_keyrings", [])
@@ -213,11 +207,11 @@ def main(argv):
     if ret:
         sys.exit(ret)
 
-    # Add the hashes map either from the allowlist, if given, or the IMA measurement list.
+    # Add the digests map either from the allowlist, if given, or the IMA measurement list.
     if args.allowlist:
-        policy["hashes"], ret = process_flat_allowlist(args.allowlist, policy["hashes"])
+        policy["digests"], ret = process_flat_allowlist(args.allowlist, policy["digests"])
     elif not args.no_hashes:
-        policy["hashes"], ret = get_hashes_from_measurement_list(args.ima_measurement_list, policy["hashes"])
+        policy["digests"], ret = get_hashes_from_measurement_list(args.ima_measurement_list, policy["digests"])
     if ret:
         sys.exit(ret)
 

--- a/scripts/create_policy
+++ b/scripts/create_policy
@@ -162,13 +162,15 @@ def process_signature_verification_keys(verification_keys, policy):
 
 def main(argv):
     """main"""
-    parser = argparse.ArgumentParser(argv[0])
+    parser = argparse.ArgumentParser(
+        description="This is an experimental tool for adding items to a Keylime's IMA runtime policy"
+    )
     parser.add_argument(
         "-B",
         "--base-policy",
         action="store",
         dest="base_policy",
-        help='Use given JSON policy as a "base" and merge new data into it',
+        help="Merge new data into the given JSON runtime policy",
     )
     parser.add_argument(
         "-k", "--keyrings", action="store_true", dest="get_keyrings", help="Create keyrings policy entries"

--- a/scripts/create_policy
+++ b/scripts/create_policy
@@ -10,7 +10,7 @@ import sys
 from cryptography import x509
 from cryptography.hazmat import backends
 
-from keylime.ima import ima
+from keylime.ima import file_signatures, ima
 
 IMA_MEASUREMENT_LIST = "/sys/kernel/security/ima/ascii_runtime_measurements"
 IGNORED_KEYRINGS = []
@@ -131,6 +131,35 @@ def process_ima_buf_in_measurement_list(
     return keyrings_map, ima_buf_map, ret
 
 
+def process_signature_verification_keys(verification_keys, policy):
+    """Add the given keys (x509 certificates) to keyring"""
+
+    verification_key_list = None
+    if verification_keys:
+        if policy.get("verification-keys"):
+            keyring = file_signatures.ImaKeyring().from_string(policy["verification-keys"])
+            if not keyring:
+                print("Could not create IMAKeyring from JSON")
+        else:
+            keyring = file_signatures.ImaKeyring()
+        if keyring:
+            for key in verification_keys:
+                try:
+                    pubkey, keyidv2 = file_signatures.get_pubkey_from_file(key)
+                    if not pubkey:
+                        print(f"File '{key}' is not a file with a key")
+                    else:
+                        keyring.add_pubkey(pubkey, keyidv2)
+                except ValueError as e:
+                    print(f"File '{key}' does not have a supported key: {e}")
+            verification_key_list = keyring.to_string()
+
+    if verification_key_list:
+        policy["verification-keys"] = verification_key_list
+
+    return policy
+
+
 def main(argv):
     """main"""
     parser = argparse.ArgumentParser(argv[0])
@@ -179,7 +208,17 @@ def main(argv):
     parser.add_argument(
         "--no-hashes", action="store_true", dest="no_hashes", help="Do not add any hashes to the policy"
     )
-    args = parser.parse_args(argv[1:])
+    parser.add_argument(
+        "-A",
+        "--add-ima-signature-verification-key",
+        action="append",
+        dest="ima_signature_keys",
+        default=[],
+        help="Add the given IMA signature verification key to the Keylime-internal 'tenant_keyring'; "
+        "the key should be an x509 certificate in DER or PEM format but may also be a public or private key file; "
+        "this option may be passed multiple times",
+    )
+    args = parser.parse_args()
 
     policy = ima.EMPTY_RUNTIME_POLICY
     policy["ima"]["ignored_keyrings"] = args.ignored_keyrings
@@ -227,6 +266,8 @@ def main(argv):
 
     if ret:
         sys.exit(ret)
+
+    policy = process_signature_verification_keys(args.ima_signature_keys, policy)
 
     jsonpolicy = json.dumps(policy)
     if args.output:


### PR DESCRIPTION
This PR updates and extends the experimental create_policy tool that one can use to add keys or hashes to a Keylime runtime policy.