### PR TITLE
verifier: proper support for listening on 0.0.0.0 (fixes #705)

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -522,8 +522,15 @@ class AgentsHandler(BaseHandler):
                     agent_data["verifier_id"] = config.get(
                         "verifier", "uuid", fallback=cloud_verifier_common.DEFAULT_VERIFIER_ID
                     )
-                    agent_data["verifier_ip"] = config.get("verifier", "ip")
-                    agent_data["verifier_port"] = config.get("verifier", "port")
+                    if "verifier_ip" in json_body:
+                        agent_data["verifier_ip"] = json_body["verifier_ip"]
+                    else:
+                        agent_data["verifier_ip"] = config.get("verifier", "ip")
+
+                    if "verifier_port" in json_body:
+                        agent_data["verifier_port"] = json_body["verifier_port"]
+                    else:
+                        agent_data["verifier_port"] = config.get("verifier", "port")
                     agent_data["attestation_count"] = 0
                     agent_data["last_received_quote"] = 0
 

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -544,6 +544,8 @@ class Tenant:
             "v": b64_v,
             "cloudagent_ip": self.cv_cloudagent_ip,
             "cloudagent_port": self.agent_port,
+            "verifier_ip": self.verifier_ip,
+            "verifier_port": self.verifier_port,
             "tpm_policy": json.dumps(self.tpm_policy),
             "runtime_policy": self.runtime_policy,
             "runtime_policy_name": self.runtime_policy_name,


### PR DESCRIPTION
This PR fixes the problem of having a `verifier` listening on 0.0.0.0 (a case we aim to support, as pointed out by @mpeters) and then adding and deleting (with specific CLI options) an `agent`.

The error stems from the fact that the "verifier_ip" column on the database was populated from the value (0.0.0.0) found on the configuration file (`/etc/keylime/verfier.conf`), which is wrong/useless as a network endpoint. Given the need for an IP address whenever the `tenant` wishes to contact the `verifier` (option -v/--cv on CLI) the contents of the aforementioned column should reflect the value supplied by the former, rather than what is read from the configuration file for the latter. This ensures we will not end up with 0.0.0.0 on the "verifier_ip" column.

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>