### PR TITLE
Various documentation updates

### DIFF
--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -1,5 +1,5 @@
 ===================
-KeyLime Development
+Keylime Development
 ===================
 
 Contributing
@@ -118,75 +118,16 @@ to github)::
 
    git push origin your-branch --force
 
-Docker Development Environment
-------------------------------
 
-The following is a guide to mounting your local repository as a Docker volume
-and performing a test run using a TPM simulator. This will replicate the same
-test that occurs within the KeyLime CI gate for keylime.
+Docker Test Environment
+-----------------------
 
-This requires a working installation of Docker. See your distributions guide on
-how to set that up.
+Python Keylime with a TPM emulator can be deployed using Docker.
+Since this docker configuration uses a TPM emulator, it should only be
+used for development or testing and NOT in production.
 
-As an example, on Fedora 29::
-
-    sudo dnf -y install dnf-plugins-core
-    sudo dnf install docker-ce docker-ce-cli containerd.io
-    sudo usermod -aG docker $USER
-    sudo systemctl enable docker
-    sudo systemctl start docker
-
-Note: login and out of your shell, if you want to run docker as `$USER`
-
-Save the following script to your local machine (tip: create an alias to call the
-script in an easy to remember way)::
-
-    #!/bin/bash
-
-    # Your local keylime (you should likely change this)
-    REPO="/home/${USER}/keylime"
-
-    # keylime images
-    tpm12image="lukehinds/keylime-ci-tpm12"
-    tpm12tag="v550"
-    tpm20image="lukehinds/keylime-ci-tpm20"
-    tpm20tag="v301"
-
-    echo -e "Grabbing latest images"
-
-    docker pull ${tpm12image}:${tpm12tag}
-    docker pull ${tpm20image}:${tpm20tag}
-
-    function tpm1 {
-        container_id=$(mktemp)
-        docker run --detach --privileged \
-            -v $REPO:/root/keylime \
-            -it ${tpm12image}:${tpm12tag} >> ${container_id}
-        docker exec -u 0 -it --tty "$(cat ${container_id})" \
-            /bin/sh -c 'cd /root/keylime/test; chmod +x ./run_tests.sh; ./run_tests.sh -s openssl'
-        docker stop "$(cat ${container_id})"
-        docker rm "$(cat ${container_id})"
-    }
-
-    function tpm2 {
-        container_id=$(mktemp)
-        docker run --detach --privileged \
-            -v $REPO:/root/keylime \
-            -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-            -it ${tpm20image}:${tpm20tag} >> ${container_id}
-        docker exec -u 0 -it --tty "$(cat ${container_id})" \
-            /bin/bash /root/keylime/.ci/test_wrapper.sh
-        docker stop "$(cat ${container_id})"
-        docker rm "$(cat ${container_id})"
-    }
-
-    while true; do
-        echo -e ""
-        read -p "Do you wish to test against TPM1.2(a) / TPM 2.0(b) or q(quit): " abq
-        case $abq in
-            [a]* ) tpm1;;
-            [b]* ) tpm2;;
-            [q]* ) exit;;
-            * ) echo "Please answer 1, 2 q(quit)";;
-        esac
-    done
+Please see either the Dockerfiles
+`here <https://github.com/keylime/keylime/tree/master/docker/ci>`_ or our
+local CI script
+`here <https://github.com/keylime/keylime/blob/master/.ci/run_local.sh>`_
+which will automate the build and pull of Keylime.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,9 @@ This Documentation site contains guides to install, use and administer keylime
 as well as guides to enable developers to make contributions to keylime
 or develop services against Keylime's Rest API(s).
 
+We recommend newcomers to read the :doc:`design section <design>` to get an understanding
+what the goals of Keylime are and how they are implemented.
+
 
 .. toctree::
    :maxdepth: 2
@@ -35,5 +38,4 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,7 +33,7 @@ TPM Version Control (Software TPM)
 versions.
 
 TPM 2.0 support can be configured by simply adding
-the role in the `playbook.yml` file `here <https://github.com/keylime/ansible-keylime/blob/master/playbook.yml#L11>`_
+the role in the :code:`playbook.yml` file `here <https://github.com/keylime/ansible-keylime/blob/master/playbook.yml#L11>`_
 
 For TPM 2.0 use::
 
@@ -45,7 +45,7 @@ This rule uses the TPM 2.0 Emulator (IBM software TPM).
 Vagrant
 ~~~~~~~
 
-If you prefer, a `Vagrantfile` is available for provisioning.
+If you prefer, a :code:`Vagrantfile` is available for provisioning.
 
 Clone the repository and then simply run::
 
@@ -74,7 +74,7 @@ Rust agent
 ~~~~~~~~~~~~~~~
 .. note::
     The Rust agent is the official agent for Keylime and replaces the Python implementation.
-    For the rust agent a different configuration file is used (by default `/etc/keylime/agent.conf`)
+    For the rust agent a different configuration file is used (by default :code:`/etc/keylime/agent.conf`)
     which is **not** interchangeable with the old Python configuration.
 
 Installation instructions can be found in the `README.md <https://github.com/keylime/rust-keylime>`_ for the Rust agent.
@@ -84,7 +84,7 @@ Keylime Bash installer
 
 Keylime requires Python 3.6 or greater.
 
-Installation can be performed via an automated shell script, `installer.sh`. The
+Installation can be performed via an automated shell script, :code:`installer.sh`. The
 following command line options are available::
 
     Usage: ./installer.sh [option...]
@@ -136,7 +136,7 @@ The following Python packages are required:
 The current list of required packages can be found `here <https://github.com/keylime/keylime/blob/master/requirements.txt>`_.
 
 All of them should be available as distro packages. See `installer.sh <https://github.com/keylime/keylime/blob/master/installer.sh>`_
-for more information if you want to install them this way. You can also let Keylime's `setup.py`
+for more information if you want to install them this way. You can also let Keylime's :code:`setup.py`
 install them via PyPI.
 
 
@@ -168,14 +168,14 @@ The brief synopsis of a quick build/install (after installing dependencies) is::
 
 
 To ensure that you have the recent version installed ensure that you have
-the `tpm2_checkquote` utility in your path.
+the :code:`tpm2_checkquote` utility in your path.
 
 .. note::
     Keylime by default (all versions after 6.2.0) uses the kernel TPM resource
     manager. For kernel versions older than 4.12 we recommend to use the tpm2-abrmd
     resource manager (available `here <https://github.com/tpm2-software/tpm2-abrmd>`_).
 
-How the TPM is accessed by tpm2-tools can be set using the `TPM2TOOLS_TCTI` environment
+How the TPM is accessed by tpm2-tools can be set using the :code:`TPM2TOOLS_TCTI` environment
 variable. More information about that can be found
 `here <https://github.com/tpm2-software/tpm2-tools/blob/master/man/common/tcti.md>`_.
 
@@ -197,6 +197,25 @@ You're finally ready to install Keylime::
     sudo python setup.py install
 
 
+Configuring basic (m)TLS setup
+------------------------------
+Keylime uses mTLS authentication between the different components.
+By default the verifier creates a CA for this under :code:`/var/lib/keylime/cv_ca/` on first startup.
+The directory contains files for three different components:
+
+* *Root CA*: :code:`cacert.crt` contains the root CA certificate.
+  **Important:** this certificate needs to be also be deployed on the agent, otherwise the tenant and verifier cannot
+  connect to the agent!
+* *Server certificate and key*: :code:`server-cert.crt` and :code:`server-{private,public}.pem` are used by the registrar
+  and verifier for their HTTPS interface.
+* *Client certificate and key*: :code:`client-cert.crt` and :code:`client-{private,public}.pem` are used
+  by the tenant to authenticate against the verifier, registrar and agent. The verifier uses this key and certificate
+  to authenticate against the agent.
+
+Keylime allows each component to use their own server and client keys and
+also a list of trusted certificates for mTLS connections.
+Please refer to options the the respective configuration files for more details.
+
 Database support
 ---------------------
 
@@ -207,7 +226,7 @@ Keylime supports the following databases:
 * MySQL
 * MariaDB
 
-SQLite is configured as default (`database_url = sqlite`) where the databases are stored under `/var/lib/keylime`.
+SQLite is configured as default (:code:`database_url = sqlite`) where the databases are stored under :code:`/var/lib/keylime`.
 
 Starting with Keylime version 6.4.0 only supports SQLAlchemy's URL format to allow a more flexible configuration.
 The format for the supported databases can be found in the SQLAlchemy

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -106,20 +106,6 @@ Those are automatically generated for every commit and release.
 For building those images locally see
 `here <https://github.com/keylime/keylime/blob/master/docker/release/build_locally.sh>`_.
 
-
-Docker - Development
---------------------
-
-Python Keylime and with a TPM emulator can also be deployed using Docker.
-Since this docker configuration uses a TPM emulator, it should only be
-used for development or testing and NOT in production.
-
-Please see either the Dockerfiles
-`here <https://github.com/keylime/keylime/tree/master/docker/ci>`_ or our
-local CI script
-`here <https://github.com/keylime/keylime/blob/master/.ci/run_local.sh>`_
-which will automate the build and pull of Keylime.
-
 Manual
 ------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 sphinxcontrib-httpdomain>=1.7.0
 sphinx-tabs
 sphinx-prompt>=1.0.0
-sphinx_rtd_theme>=0.3.1
+sphinx_rtd_theme>=1.1.0
 recommonmark>=0.5.0
 sphinx-notfound-page>=0.2.1
 commonmark>=0.8.1

--- a/docs/rest_apis.rst
+++ b/docs/rest_apis.rst
@@ -5,34 +5,27 @@ All Keylime APIs use `REST (Representational State Transfer)`.
 
 Authentication
 --------------
-Most API interactions are secured using mTLS connections.
-There are up to three different CAs involved.
-(The revocation process also uses a CA, but this is a different to those CAs)
+Most API interactions are secured using mTLS connections. By default there are two CAs involved,
+but the components can be configured to accommodate more complex setups.
 
-Verifier CA (CV CA)
-~~~~~~~~~~~~~~~~~~~
-This CA is used by the verifier to authenticate connections to it.
-The tenant requires a certificate from this CA to add/delete/list agents at the CV.
+(The revocation process also uses a CA, but this is different to those CAs)
 
-Registrar CA
-~~~~~~~~~~~~
-This CA is used by the registrar to authenticate connections to it.
-The tenant and the verifier require certificate from this CA to get or delete agent information from the registrar.
-By default it is the same CA as the CV CA.
-
-Note that the API endpoints from the registrar for the agent are unprotected by design.
+Server Components CA
+~~~~~~~~~~~~~~~~~~~~
+This CA is created by verifier on startup.
+It contains the server certificates and keys used by the verifier and registrar for their respective HTTPS interfaces.
+Then it also contains the client certificates and keys that are used by the tenant to connect to the registrar, verifier
+and agent. Also the verifier uses that certificate to authenticate itself against the agent.
 
 Agent Keylime CA
 ~~~~~~~~~~~~~~~~
-The agent runs a HTTPS server and provides it's certificate to the registrar (`mtls_cert`).
-All connections done to the agent are verified against the CA specified in the `keylime_ca` option.
-This ensures that only trusted systems can interact with the agents.
-By default the CV CA is used, but the CA certificate (`cacert.crt`) needs to be copied to the agents.
+The agent runs an HTTPS server and provides its certificate to the registrar (:code:`mtls_cert`).
 
-Registrar, tenant and verifier can configure this CA separately using the `agent_mtls_*` options.
+The server component CA certificate is also required on the agent to authenticate connections
+from the tenant and verifier. By default :code:`/var/lib/keylime/cv_ca/cacert.crt` is used.
 
 RESTful API for Keylime (v2.1)
-----------------------------
+------------------------------
 Keylime API is versioned. More information can be found here: https://github.com/keylime/enhancements/blob/master/45_api_versioning.md
 
 .. warning::

--- a/docs/user_guide/runtime_ima.rst
+++ b/docs/user_guide/runtime_ima.rst
@@ -12,35 +12,35 @@ system, the file is situated in `/etc/ima/ima-policy`.
 
 For configuration of your IMA policy, please refer to the `IMA Documentation <https://github.com/torvalds/linux/blob/6f0d349d922ba44e4348a17a78ea51b7135965b1/Documentation/ABI/testing/ima_policy>`_
 
-Within Keylime we use the following for demonstration (found in `demo/ima-policies/ima-policy-keylime`):
+Within Keylime we use the following for demonstration (found in `demo/ima-policies/ima-policy-keylime`)::
 
-  # PROC_SUPER_MAGIC
-  dont_measure fsmagic=0x9fa0
-  # SYSFS_MAGIC
-  dont_measure fsmagic=0x62656572
-  # DEBUGFS_MAGIC
-  dont_measure fsmagic=0x64626720
-  # TMPFS_MAGIC
-  dont_measure fsmagic=0x01021994
-  # RAMFS_MAGIC
-  dont_measure fsmagic=0x858458f6
-  # SECURITYFS_MAGIC
-  dont_measure fsmagic=0x73636673
-  # SELINUX_MAGIC
-  dont_measure fsmagic=0xf97cff8c
-  # CGROUP_SUPER_MAGIC
-  dont_measure fsmagic=0x27e0eb
-  # OVERLAYFS_MAGIC
-  # when containers are used we almost always want to ignore them
-  dont_measure fsmagic=0x794c7630
-  # Don't measure log, audit or tmp files
-  dont_measure obj_type=var_log_t
-  dont_measure obj_type=auditd_log_t
-  dont_measure obj_type=tmp_t
-  # MEASUREMENTS
-  measure func=BPRM_CHECK
-  measure func=FILE_MMAP mask=MAY_EXEC
-  measure func=MODULE_CHECK uid=0
+    # PROC_SUPER_MAGIC
+    dont_measure fsmagic=0x9fa0
+    # SYSFS_MAGIC
+    dont_measure fsmagic=0x62656572
+    # DEBUGFS_MAGIC
+    dont_measure fsmagic=0x64626720
+    # TMPFS_MAGIC
+    dont_measure fsmagic=0x01021994
+    # RAMFS_MAGIC
+    dont_measure fsmagic=0x858458f6
+    # SECURITYFS_MAGIC
+    dont_measure fsmagic=0x73636673
+    # SELINUX_MAGIC
+    dont_measure fsmagic=0xf97cff8c
+    # CGROUP_SUPER_MAGIC
+    dont_measure fsmagic=0x27e0eb
+    # OVERLAYFS_MAGIC
+    # when containers are used we almost always want to ignore them
+    dont_measure fsmagic=0x794c7630
+    # Don't measure log, audit or tmp files
+    dont_measure obj_type=var_log_t
+    dont_measure obj_type=auditd_log_t
+    dont_measure obj_type=tmp_t
+    # MEASUREMENTS
+    measure func=BPRM_CHECK
+    measure func=FILE_MMAP mask=MAY_EXEC
+    measure func=MODULE_CHECK uid=0
 
 This default policy measures all executables in `bprm_check` and all files `mmapped`
 executable in `file_mmap` and module checks and skips several irrelevant files


### PR DESCRIPTION
Now from the correct branch

- docs: fix formatting of example IMA-policy
- docs: update theme to min 1.1.0
- docs: remove old development instructions, move dev conainter section
- docs: update REST APIs TLS documentation to match new default setup
- docs: add basic (m)TLS instructions to the installation guide
- docs: point newcomers to the design document
- docs: Update IMA instructions to new runtime policy format
