### PR TITLE
pylint: Fix some newly reported issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
   style-checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.3
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0
   tpm-tests:
     runs-on: ubuntu-latest
     container:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 exclude: 'test/data/template-invalid-adjust/2.0/adjust.py'
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
       - id: black

--- a/keylime/db/registrar_db.py
+++ b/keylime/db/registrar_db.py
@@ -6,7 +6,7 @@ from keylime.json import JSONPickler
 Base = declarative_base()
 
 
-class JSONPickleType(PickleType):  # pylint: disable=abstract-method
+class JSONPickleType(PickleType):  # pylint: disable=abstract-method,too-many-ancestors
     impl = Text
     cache_ok = True
 

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -7,7 +7,7 @@ from keylime.json import JSONPickler
 Base = declarative_base()
 
 
-class JSONPickleType(PickleType):  # pylint: disable=abstract-method
+class JSONPickleType(PickleType):  # pylint: disable=abstract-method,too-many-ancestors
     impl = Text
     cache_ok = True
 

--- a/keylime/migrations/versions/4329e2d14944_associate_moved_allowlists_to_agents.py
+++ b/keylime/migrations/versions/4329e2d14944_associate_moved_allowlists_to_agents.py
@@ -34,8 +34,8 @@ def downgrade_registrar():
 def upgrade_cloud_verifier():
     # get existing table metadata
     conn = op.get_bind()
-    meta = sa.MetaData(bind=conn)
-    meta.reflect(only=("verifiermain",))
+    meta = sa.MetaData()
+    meta.reflect(bind=conn, only=("verifiermain",))
     verifiermain = meta.tables["verifiermain"]
 
     res = conn.execute("SELECT id, name FROM allowlists")

--- a/keylime/migrations/versions/8c0f8ded1f90_convert_allowlists_to_ima_policies.py
+++ b/keylime/migrations/versions/8c0f8ded1f90_convert_allowlists_to_ima_policies.py
@@ -44,8 +44,8 @@ def downgrade_registrar():
 def upgrade_cloud_verifier():
     # get existing table metadata
     conn = op.get_bind()
-    meta = sa.MetaData(bind=conn)
-    meta.reflect(only=("allowlists",))
+    meta = sa.MetaData()
+    meta.reflect(bind=conn, only=("allowlists",))
     allowlists = meta.tables["allowlists"]
     results = conn.execute("SELECT id, ima_policy FROM allowlists").fetchall()
 
@@ -89,8 +89,8 @@ def upgrade_cloud_verifier():
 def downgrade_cloud_verifier():
     # get existing table metadata
     conn = op.get_bind()
-    meta = sa.MetaData(bind=conn)
-    meta.reflect(only=("allowlists",))
+    meta = sa.MetaData()
+    meta.reflect(bind=conn, only=("allowlists",))
     allowlists = meta.tables["allowlists"]
     results = conn.execute("SELECT id, ima_policy FROM allowlists").fetchall()
 

--- a/keylime/migrations/versions/a72aec03d720_migrate_allowlists_to_separate_table.py
+++ b/keylime/migrations/versions/a72aec03d720_migrate_allowlists_to_separate_table.py
@@ -41,8 +41,8 @@ def upgrade_cloud_verifier():
     old_policy = [{"name": r[0], "tpm_policy": r[1], "ima_policy": r[2]} for r in results]
 
     # get existing table metadata
-    meta = sa.MetaData(bind=conn)
-    meta.reflect(only=("allowlists",))
+    meta = sa.MetaData()
+    meta.reflect(bind=conn, only=("allowlists",))
     allowlists = meta.tables["allowlists"]
 
     op.bulk_insert(allowlists, old_policy)
@@ -57,8 +57,8 @@ def upgrade_cloud_verifier():
 def downgrade_cloud_verifier():
     # Migrate existing agent info to the allowlist column in verifiermain.
     conn = op.get_bind()
-    meta = sa.MetaData(bind=conn)
-    meta.reflect(only=("verifiermain", "allowlists"))
+    meta = sa.MetaData()
+    meta.reflect(bind=conn, only=("verifiermain", "allowlists"))
     verifiermain = meta.tables["verifiermain"]
     allowlists = meta.tables["allowlists"]
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import setuptools
 from setuptools.command.build_py import build_py
 
 
-class keylime_build(build_py):
+class keylime_build(build_py):  # pylint: disable=too-many-ancestors
     def run(self):
 
         # Generate the split configuration files, if not present


### PR DESCRIPTION
This PR fixes some newly reported pylint issues:

```
pylint 2.15.10
astroid 2.13.3
Python 3.9.10 (main, Jan 17 2022, 00:00:00) 
[GCC 11.2.1 20210728 (Red Hat 11.2.1-1)]
************* Module keylime.db.verifier_db
keylime/db/verifier_db.py:10:0: R0901: Too many ancestors (9/7) (too-many-ancestors)
************* Module keylime.db.registrar_db
keylime/db/registrar_db.py:9:0: R0901: Too many ancestors (9/7) (too-many-ancestors)
************* Module keylime.migrations.versions.8c0f8ded1f90_convert_allowlists_to_ima_policies
keylime/migrations/versions/8c0f8ded1f90_convert_allowlists_to_ima_policies.py:47:11: E1123: Unexpected keyword argument 'bind' in constructor call (unexpected-keyword-arg)
keylime/migrations/versions/8c0f8ded1f90_convert_allowlists_to_ima_policies.py:48:4: E1120: No value for argument 'bind' in method call (no-value-for-parameter)
keylime/migrations/versions/8c0f8ded1f90_convert_allowlists_to_ima_policies.py:92:11: E1123: Unexpected keyword argument 'bind' in constructor call (unexpected-keyword-arg)
keylime/migrations/versions/8c0f8ded1f90_convert_allowlists_to_ima_policies.py:93:4: E1120: No value for argument 'bind' in method call (no-value-for-parameter)
************* Module keylime.migrations.versions.a72aec03d720_migrate_allowlists_to_separate_table
keylime/migrations/versions/a72aec03d720_migrate_allowlists_to_separate_table.py:44:11: E1123: Unexpected keyword argument 'bind' in constructor call (unexpected-keyword-arg)
keylime/migrations/versions/a72aec03d720_migrate_allowlists_to_separate_table.py:45:4: E1120: No value for argument 'bind' in method call (no-value-for-parameter)
keylime/migrations/versions/a72aec03d720_migrate_allowlists_to_separate_table.py:60:11: E1123: Unexpected keyword argument 'bind' in constructor call (unexpected-keyword-arg)
keylime/migrations/versions/a72aec03d720_migrate_allowlists_to_separate_table.py:61:4: E1120: No value for argument 'bind' in method call (no-value-for-parameter)
************* Module keylime.migrations.versions.4329e2d14944_associate_moved_allowlists_to_agents
keylime/migrations/versions/4329e2d14944_associate_moved_allowlists_to_agents.py:37:11: E1123: Unexpected keyword argument 'bind' in constructor call (unexpected-keyword-arg)
keylime/migrations/versions/4329e2d14944_associate_moved_allowlists_to_agents.py:38:4: E1120: No value for argument 'bind' in method call (no-value-for-parameter)
```