### PR TITLE
fixing linter non-W0719 issues

### DIFF
--- a/keylime/elchecking/example.py
+++ b/keylime/elchecking/example.py
@@ -393,7 +393,7 @@ def digests_strip0x(digests: typing.List[typing.Dict[str, str]]) -> typing.List[
 
 def sig_strip0x(sig: typing.Dict[str, str]) -> tests.Signature:
     tests.obj_test(SignatureOwner=tests.type_test(str), SignatureData=tests.type_test(str))(sig)
-    return dict(SignatureOwner=sig["SignatureOwner"], SignatureData=string_strip0x(sig["SignatureData"]))
+    return {"SignatureOwner": sig["SignatureOwner"], "SignatureData=string_strip0x": sig["SignatureData"]}
 
 
 def sigs_strip0x(sigs: typing.Iterable[typing.Dict[str, str]]) -> typing.List[tests.Signature]:

--- a/keylime/keylime_agent.py
+++ b/keylime/keylime_agent.py
@@ -452,7 +452,7 @@ class CloudAgentHTTPServer(ThreadingMixIn, HTTPServer):
                     agent_ips.append(contact_ip)
                 with open(cert_path, "wb") as f:
                     # By default generate a TLS certificate valid for 5 years
-                    valid_util = datetime.datetime.utcnow() + datetime.timedelta(days=(360 * 5))
+                    valid_util = datetime.datetime.utcnow() + datetime.timedelta(days=360 * 5)
                     cert = crypto.generate_selfsigned_cert(agent_uuid, private_key, valid_util, agent_ips)
                     f.write(cert.public_bytes(serialization.Encoding.PEM))
 

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -256,5 +256,6 @@ def main():
     print("exiting...")
     sys.exit(0)
 
+
 if __name__ == "__main__":
     main()

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -255,8 +255,6 @@ def main():
     stop_broker()
     print("exiting...")
     sys.exit(0)
-    print("done")
-
 
 if __name__ == "__main__":
     main()

--- a/pylintrc
+++ b/pylintrc
@@ -3,7 +3,7 @@ jobs=0
 ignore-paths=^.*test/data/template-invalid-adjust/.*$
 
 [MESSAGES CONTROL]
-disable=C0103,C0111,C0115,C0116,C0301,C0302,W0511,W0603,W0703,R0801,R0902,R0903,R0904,R0911,R0912,R0913,R0914,R0915
+disable=C0103,C0111,C0115,C0116,C0301,C0302,W0511,W0603,W0703,R0801,R0902,R0903,R0904,R0911,R0912,R0913,R0914,R0915,W0719
 
 [TYPECHECK]
 ignored-modules=zmq,alembic.op,alembic.context,cryptography.hazmat.primitives.asymmetric.rsa,gpg


### PR DESCRIPTION
Ignoring W0719 for now in `pylintrc`, as fixing all of them will be a separate substantial PR. See #1293 