### PR TITLE
verifier,tenant : fix IMA runtime policy bug (issue #1306)

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -774,8 +774,9 @@ class Tenant:
                 )
                 return
 
-            self.verifier_ip = cvresponse["results"][self.agent_uuid]["verifier_ip"]
-            self.verifier_port = cvresponse["results"][self.agent_uuid]["verifier_port"]
+            if self.agent_uuid in cvresponse["results"]:
+                self.verifier_ip = cvresponse["results"][self.agent_uuid]["verifier_ip"]
+                self.verifier_port = cvresponse["results"][self.agent_uuid]["verifier_port"]
 
         do_cvdelete = RequestsClient(self.verifier_base_url, True, tls_context=self.tls_context)
         response = do_cvdelete.delete(f"/v{self.api_version}/agents/{self.agent_uuid}", timeout=self.request_timeout)


### PR DESCRIPTION
A bit of context: some runtime-policy tests were accidentally disabled (fixed by PR #1307) were accidentally disabled. Once re-enabled they show a couple of bugs on the `verifier` and `tenant` code.

This PR contains fixes for all these (basically need for checking for the presence of certain attributes/keys before referring to and use it)

Signed-off-by: Marcio Silva <marcio.a.silva@ibm.com>