### PR TITLE
da: fixes for breakages on durable Attestation

### DIFF
--- a/keylime/da/examples/file.py
+++ b/keylime/da/examples/file.py
@@ -118,7 +118,7 @@ class RecordManagement(BaseRecordManagement):
         self.base_record_timestamp_create(record_object, agent_data, contents)
 
     def record_create(
-        self, agent_data, attestation_data, ima_policy_data=None, service="auto", signed_attributes="auto"
+        self, agent_data, attestation_data, runtime_policy_data=None, service="auto", signed_attributes="auto"
     ):
         record_object = {}
 
@@ -135,6 +135,8 @@ class RecordManagement(BaseRecordManagement):
         ) as fp:
             ts = str(int(time.time())).encode()
             fp.write(
-                ts + self.ts_sep + self.base_record_create(record_object, agent_data, attestation_data, ima_policy_data)
+                ts
+                + self.ts_sep
+                + self.base_record_create(record_object, agent_data, attestation_data, runtime_policy_data)
             )
             fp.write(self.line_sep)

--- a/keylime/da/examples/redis.py
+++ b/keylime/da/examples/redis.py
@@ -113,7 +113,7 @@ class RecordManagement(BaseRecordManagement):
         self.base_record_timestamp_create(record_object, agent_data, contents)
 
     def record_create(
-        self, agent_data, attestation_data, ima_policy_data=None, service="auto", signed_attributes="auto"
+        self, agent_data, attestation_data, runtime_policy_data=None, service="auto", signed_attributes="auto"
     ):
         record_object = {}
 
@@ -129,5 +129,7 @@ class RecordManagement(BaseRecordManagement):
             agent_data["agent_id"],
         )
         self.redis_multi_version_zadd(
-            key, self.base_record_create(record_object, agent_data, attestation_data, ima_policy_data), int(time.time())
+            key,
+            self.base_record_create(record_object, agent_data, attestation_data, runtime_policy_data),
+            int(time.time()),
         )

--- a/keylime/da/examples/sqldb.py
+++ b/keylime/da/examples/sqldb.py
@@ -64,7 +64,7 @@ class RecordManagement(BaseRecordManagement):
         return agent_list
 
     def record_create(
-        self, agent_data, attestation_data, ima_policy_data=None, service="auto", signed_attributes="auto"
+        self, agent_data, attestation_data, runtime_policy_data=None, service="auto", signed_attributes="auto"
     ):
         agentid = agent_data["agent_id"]
         recordtime = str(int(time.time()))
@@ -73,7 +73,7 @@ class RecordManagement(BaseRecordManagement):
         # create the record, and sign it.
         record_object = {}
         self.record_signature_create(record_object, agent_data, attestation_data, service, signed_attributes)
-        rcrd = self.base_record_create(record_object, agent_data, attestation_data, ima_policy_data)
+        rcrd = self.base_record_create(record_object, agent_data, attestation_data, runtime_policy_data)
 
         d = {"time": recordtime, "agentid": agentid, "record": rcrd}
 

--- a/keylime/da/record.py
+++ b/keylime/da/record.py
@@ -47,7 +47,7 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
         self,
         agent_data: Dict[Any, Any],
         attestation_data: Dict[Any, Any],
-        ima_policy_data: Dict[Any, Any],
+        runtime_policy_data: Dict[Any, Any],
         service: str = "auto",
         signed_attributes: str = "auto",
     ) -> None:
@@ -135,7 +135,7 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
         record_object: Dict[Any, Any],
         agent_data: Dict[Any, Any],
         attestation_data: Dict[Any, Any],
-        ima_policy_data: Dict[Any, Any],
+        runtime_policy_data: Dict[Any, Any],
     ) -> Dict[Any, Any]:
         """Assemble record to be created on persistent datastore"""
 
@@ -150,8 +150,8 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
         if attestation_data:
             sanitized_and_assembled_record_object["json_response"] = attestation_data
 
-        if ima_policy_data:
-            sanitized_and_assembled_record_object["ima_policy"] = ima_policy_data
+        if runtime_policy_data:
+            sanitized_and_assembled_record_object["runtime_policy"] = runtime_policy_data
 
         return sanitized_and_assembled_record_object
 
@@ -186,10 +186,10 @@ class BaseRecordManagement(metaclass=abc.ABCMeta):
         record_object: Dict[Any, Any],
         agent_data: Dict[Any, Any],
         attestation_data: Dict[Any, Any],
-        ima_policy_data: Dict[Any, Any],
+        runtime_policy_data: Dict[Any, Any],
     ) -> Union[bytes, Dict[Any, Any]]:
         """Prepares record to be stored on persistent datastore"""
-        record_assembled = self.record_assemble(record_object, agent_data, attestation_data, ima_policy_data)
+        record_assembled = self.record_assemble(record_object, agent_data, attestation_data, runtime_policy_data)
 
         record_assembled[self.svc + "_timestamp"] = datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
 


### PR DESCRIPTION
The last couple of patches caused some breakages on Durable Attestation (DA), and given the absence of a proper CI test (will work on it after this PR is merged) it remained undetected. Here we have all the fixes needed to bring it back into operational state.

In addition to it, there are some small improvements on logging for the `check_pcrs` method, which benefits both DA and regular operations (basically, include agent ID on all messages, plus the actual name of measured boot policy used)