### PR TITLE
db: switch to pessimistic disconnect handling

### DIFF
--- a/keylime/db/keylime_db.py
+++ b/keylime/db/keylime_db.py
@@ -82,6 +82,7 @@ class DBEngineManager:
             if not url.count("sqlite:"):
                 engine_args["pool_size"] = int(p_sz)
                 engine_args["max_overflow"] = int(m_ovfl)
+                engine_args["pool_pre_ping"] = True
 
         # Enable DB debugging
         if config.DEBUG_DB and config.INSECURE_DEBUG:


### PR DESCRIPTION
If sessions are idle for a long time, the SQL server might no longer have that
connection open. This causes the Keylime to error when its tries to query the
database.

This enabled pool_pre_ping which checks if the connection is still active and
uses a new connection if not.

More details can be found here:
https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic

