### PR TITLE
Add timestamp of last successful attestation to verifier API (enhancement #74) and address some missing documentation

### DIFF
--- a/docs/rest_apis.rst
+++ b/docs/rest_apis.rst
@@ -88,7 +88,10 @@ Cloud verifier (CV)
             "verifier_ip": "127.0.0.1",
             "verifier_port": 8881,
             "severity_level": 6,
-            "last_event_id": "qoute_validation.quote_validation"
+            "last_event_id": "qoute_validation.quote_validation",
+            "attestation_count": 240,
+            "last_received_quote": 1676644582,
+            "last_successful_attestation": 1676644462
           }
         }
 
@@ -114,6 +117,9 @@ Cloud verifier (CV)
     :>json int verifier_port: Port of the verifier that is used.
     :>json int severity_level: Severity level of the agent. Might be `null`. Levels are the numeric representation of the severity labels.
     :>json string last_event_id: ID of the last revocation event. Might be `null`.
+    :>json int attestation_count: Number of quotes received from the agent which have verified successfully.
+    :>json int last_received_quote: Timestamp of the last quote received from the agent irrespective of validity. A value of 0 indicates no quotes have been received. May be `null` after upgrading from a previous Keylime version.
+    :>json int last_successful_attestation: Timestamp of the last quote received from the agent which verified successfully. A value of 0 indicates no valid quotes have been received. May be `null` after upgrading from a previous Keylime version.
 
 
 .. http:post::  /v2.1/agents/{agent_id:UUID}

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -204,7 +204,7 @@ def process_quote_response(
 
     if not failure:
         agent["attestation_count"] += 1
-
+        agent["last_successful_attestation"] = int(time.time())
         agent["tpm_clockinfo"] = agentAttestState.get_tpm_clockinfo().to_dict()
 
         # has public key changed? if so, clear out b64_encrypted_V, it is no longer valid
@@ -296,6 +296,7 @@ def process_get_status(agent: VerfierMain) -> Dict[str, Any]:
         "last_event_id": agent.last_event_id,
         "attestation_count": agent.attestation_count,
         "last_received_quote": agent.last_received_quote,
+        "last_successful_attestation": agent.last_successful_attestation,
     }
     return response
 

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -115,6 +115,7 @@ def _from_db_obj(agent_db_obj: VerfierMain) -> Dict[str, Any]:
         "ak_tpm",
         "attestation_count",
         "last_received_quote",
+        "last_successful_attestation",
         "tpm_clockinfo",
     ]
     agent_dict = {}
@@ -557,6 +558,10 @@ class AgentsHandler(BaseHandler):
                     agent_data["verifier_id"] = config.get(
                         "verifier", "uuid", fallback=cloud_verifier_common.DEFAULT_VERIFIER_ID
                     )
+                    agent_data["attestation_count"] = 0
+                    agent_data["last_received_quote"] = 0
+                    agent_data["last_successful_attestation"] = 0
+
                     if "verifier_ip" in json_body:
                         agent_data["verifier_ip"] = json_body["verifier_ip"]
                     else:
@@ -566,8 +571,6 @@ class AgentsHandler(BaseHandler):
                         agent_data["verifier_port"] = json_body["verifier_port"]
                     else:
                         agent_data["verifier_port"] = config.get("verifier", "port")
-                    agent_data["attestation_count"] = 0
-                    agent_data["last_received_quote"] = 0
 
                     agent_mtls_cert_enabled = config.getboolean("verifier", "enable_agent_mtls", fallback=False)
 

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -48,6 +48,7 @@ class VerfierMain(Base):
     mtls_cert = Column(String(2048), nullable=True)
     attestation_count = Column(Integer)
     last_received_quote = Column(Integer)
+    last_successful_attestation = Column(Integer)
     tpm_clockinfo = Column(JSONPickleType(pickler=JSONPickler))
 
 

--- a/keylime/migrations/versions/f838d3cdeead_add_last_successful_attestation.py
+++ b/keylime/migrations/versions/f838d3cdeead_add_last_successful_attestation.py
@@ -1,0 +1,39 @@
+"""add last_successful_attestation
+
+Revision ID: f838d3cdeead
+Revises: 8c0f8ded1f90
+Create Date: 2023-02-15 10:51:25.948918
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f838d3cdeead"
+down_revision = "8c0f8ded1f90"
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()[f"upgrade_{engine_name}"]()
+
+
+def downgrade(engine_name):
+    globals()[f"downgrade_{engine_name}"]()
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+    op.add_column("verifiermain", sa.Column("last_successful_attestation", sa.Integer(), nullable=True))
+
+
+def downgrade_cloud_verifier():
+    op.drop_column("verifiermain", "last_successful_attestation")


### PR DESCRIPTION
This pull request fulfills https://github.com/keylime/enhancements/issues/74 by adding a new database column (`last_successful_quote`) and exposing it through the verifier's REST API. Many thanks to @maugustosilva for his help with this [in the Slack channel](https://cloud-native.slack.com/archives/C01ARE2QUTZ/p1676370102354909).

Additionally, I've adding some descriptions to the API documentation for the `last_successful_quote` field and a couple other fields that were missing documentation (namely, `attestation_count` and `last_received_quote`).

See commit messages for further details.