### PR TITLE
Add JSON schema for runtime policy and validate user-provided runtime policies against it

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -677,7 +677,15 @@ class AgentsHandler(BaseHandler):
                         if not runtime_policy_name:
                             runtime_policy_name = agent_id
 
-                        runtime_policy_db_format = ima.runtime_policy_db_contents(runtime_policy_name, runtime_policy)
+                        try:
+                            runtime_policy_db_format = ima.runtime_policy_db_contents(
+                                runtime_policy_name, runtime_policy
+                            )
+                        except ima.ImaValidationError as e:
+                            message = f"Runtime policy is malformatted: {e.message}"
+                            web_util.echo_json_response(self, e.code, message)
+                            logger.warning(message)
+                            return
 
                         try:
                             runtime_policy_stored = (
@@ -961,7 +969,13 @@ class AllowlistHandler(BaseHandler):
 
         tpm_policy = json_body.get("tpm_policy")
 
-        runtime_policy_db_format = ima.runtime_policy_db_contents(runtime_policy_name, runtime_policy, tpm_policy)
+        try:
+            runtime_policy_db_format = ima.runtime_policy_db_contents(runtime_policy_name, runtime_policy, tpm_policy)
+        except ima.ImaValidationError as e:
+            message = f"Runtime policy is malformatted: {e.message}"
+            web_util.echo_json_response(self, e.code, message)
+            logger.warning(message)
+            return None
 
         return runtime_policy_db_format
 

--- a/keylime/ima/ima.py
+++ b/keylime/ima/ima.py
@@ -6,6 +6,8 @@ import hashlib
 import json
 from typing import Any, Dict, List, Optional, Pattern, Set, TextIO, Tuple, Type
 
+import jsonschema
+
 from keylime import config, keylime_logging, signing
 from keylime.agentstates import AgentAttestState
 from keylime.common import algorithms, validators
@@ -50,6 +52,55 @@ EMPTY_RUNTIME_POLICY: RuntimePolicyType = {
     "ima": {"ignored_keyrings": [], "log_hash_alg": "sha1", "dm_policy": None},
     "ima-buf": {},
     "verification-keys": "",
+}
+
+
+RUNTIME_POLICY_SCHEMA = {
+    "type": "object",
+    "required": ["meta", "release", "digests", "excludes", "keyrings", "ima", "ima-buf", "verification-keys"],
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["version", "generator"],
+            "properties": {
+                "version": {"type": "integer", "minimum": 0},
+                "generator": {
+                    "type": "integer",
+                    "minimum": min(list(RUNTIME_POLICY_GENERATOR)),
+                    "maximum": max(list(RUNTIME_POLICY_GENERATOR)),
+                },
+                "timestamp": {"type": "string"},
+            },
+        },
+        "release": {"type": "integer", "minimum": 0},
+        "digests": {"$ref": "#/definitions/digests-object"},
+        "excludes": {"type": "array", "items": {"type": "string"}},
+        "keyrings": {"$ref": "#/definitions/digests-object"},
+        "ima": {
+            "type": "object",
+            "required": ["ignored_keyrings", "log_hash_alg", "dm_policy"],
+            "properties": {
+                "ignored_keyrings": {"type": "array", "items": {"type": "string"}},
+                "log_hash_alg": {"type": "string", "enum": ["sha1", "sha256", "sha384", "sha512"]},
+                "dm_policy": {"type": "null"},
+            },
+        },
+        "ima-buf": {"$ref": "#/definitions/digests-object"},
+        "verification-keys": {"type": "string"},
+    },
+    "definitions": {
+        "digests-object": {
+            "type": "object",
+            "patternProperties": {
+                "^": {
+                    "type": "array",
+                    "items": {"type": "string", "pattern": "^[0-9a-f]{40,128}$"},
+                    "minItems": 1,
+                    "uniqueItems": False,
+                }
+            },
+        }
+    },
 }
 
 
@@ -481,6 +532,9 @@ def runtime_policy_db_contents(runtime_policy_name: str, runtime_policy: str, tp
         runtime_policy_db_format["ima_policy"] = runtime_policy
     runtime_policy_bytes = runtime_policy.encode()
     runtime_policy_dict = deserialize_runtime_policy(runtime_policy)
+
+    validate_runtime_policy(runtime_policy_dict)
+
     if "meta" in runtime_policy_dict:
         if "generator" in runtime_policy_dict["meta"]:
             runtime_policy_db_format["generator"] = runtime_policy_dict["meta"]["generator"]
@@ -554,3 +608,14 @@ def deserialize_runtime_policy(runtime_policy: str) -> RuntimePolicyType:
     # TODO: Extract IMA policy JSON from DSSE envelope, if applicable.
     runtime_policy_deserialized: RuntimePolicyType = json.loads(runtime_policy)
     return runtime_policy_deserialized
+
+
+def validate_runtime_policy(runtime_policy: RuntimePolicyType) -> None:
+    """
+    Validate a runtime policy against the schema.
+    """
+    try:
+        jsonschema.validate(instance=runtime_policy, schema=RUNTIME_POLICY_SCHEMA)
+    except Exception as error:
+        msg = str(error).split("\n", 1)[0]
+        raise ImaValidationError(message=f"{msg}", code=400) from error

--- a/keylime/ima/ima.py
+++ b/keylime/ima/ima.py
@@ -1,5 +1,6 @@
 import codecs
 import copy
+import enum
 import functools
 import hashlib
 import json
@@ -21,7 +22,7 @@ logger = keylime_logging.init_logging("ima")
 RUNTIME_POLICY_CURRENT_VERSION = 1
 
 
-class RUNTIME_POLICY_GENERATOR:
+class RUNTIME_POLICY_GENERATOR(enum.IntEnum):
     Unknown = 0
     EmptyAllowList = 1
     CompatibleAllowList = 2

--- a/keylime/ima/ima_test.py
+++ b/keylime/ima/ima_test.py
@@ -1,7 +1,9 @@
 import tempfile
 import unittest
+from typing import cast
 
 from keylime.ima import ima
+from keylime.ima.types import RuntimePolicyType
 
 
 class TestIMA(unittest.TestCase):
@@ -35,6 +37,12 @@ class TestIMA(unittest.TestCase):
                 self.assertIsNotNone(ml)
                 assert ml is not None  # redundant but it makes type-checking happy
                 self.assertTrue(ml.startswith("0-entry"))
+
+    def test_json_schema(self) -> None:
+        with self.assertRaises(ima.ImaValidationError):
+            ima.validate_runtime_policy(cast(RuntimePolicyType, {}))
+
+        ima.validate_runtime_policy(ima.EMPTY_RUNTIME_POLICY)
 
 
 if __name__ == "__main__":

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -1239,7 +1239,10 @@ class Tenant:
         response = cv_client.post(
             f"/v{self.api_version}/allowlists/{self.runtime_policy_name}", data=body, timeout=self.request_timeout
         )
-        Tenant._jsonify_response(response)
+        response_json = Tenant._jsonify_response(response)
+
+        if response.status_code == 401:
+            raise UserError(response_json)
 
     def do_update_runtime_policy(self, args: Dict[str, str]) -> None:
         body = self.__convert_runtime_policy(args)
@@ -1248,7 +1251,10 @@ class Tenant:
         response = cv_client.put(
             f"/v{self.api_version}/allowlists/{self.runtime_policy_name}", data=body, timeout=self.request_timeout
         )
-        Tenant._jsonify_response(response)
+        response_json = Tenant._jsonify_response(response)
+
+        if response.status_code == 401:
+            raise UserError(response_json)
 
     def do_delete_runtime_policy(self, name: Optional[str]) -> None:
         if not name:

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ jinja2>=3.0.0 # BSD
 # typing-extensions is required for TypedDict and Literal on Python < 3.8
 # as well as NotRequired on Python < 3.11
 typing-extensions>=4.0.1 ; python_version < '3.11' #PSF-2.0
+jsonschema>=2.6.0 # MIT

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -192,7 +192,13 @@ echo "==========================================================================
 echo $'\t\t\tRunning Unit Tests'
 echo "=================================================================================="
 # Run separate unit tests
-python3 -m unittest discover -s keylime -p '*_test.py' -v
+python3 -m unittest discover -s keylime/ima -p '*_test.py' -v
+if [ $? -ne 0 ]; then
+    echo "Error: Unit tests failed"
+    exit 1
+fi
+
+python3 -m unittest discover -s keylime/tpm -p '*_test.py' -v
 if [ $? -ne 0 ]; then
     echo "Error: Unit tests failed"
     exit 1


### PR DESCRIPTION
This PR adds a JSON schema for the runtime policy along with its package dependency on jsonschema. It then uses the JSON schema to validate the user-provided runtime policies before they are written to the Db.

