### PR TITLE
Redefine the list of maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,12 +3,9 @@ Project Lead:
 
 Maintainers:
 
-@ashcrow
-@axelsimon
-@font
-@lukehinds
-@jetwhiz
-@kaifeng
 @mpeters
-@nabilschear
 @THS-on
+@stefanberger
+@ansasaki
+@aplanas
+@sergio-correia


### PR DESCRIPTION
Redefine the list of maintainers taking into account activity on the last 12 months, proposing a few new names to be added (please feel free to decline)

The main motivation for this commit is the upcoming architecture redesign, and the need for the definition of a core team of active maintainers which will have to agree (at least simple majority) on the implementation in PRs.

We fully expect members of the companies directly involved with Keylime (e.g., RedHat and IBM) and others who approached us demonstrating interesting in the framework (e.g., HP and TwoSigma) to actively participate on the discussion and high-level design, but we want to leave them free from the burden of code review and PR approval (they are welcome to do so, of course)

To the former maintainers who moved on to other projects, we signal our thank you, and hope to have you back here someday :-).

I would like to have as many approvals as possible before merging it.