### PR TITLE
tests: Use Rust agent from COPR for e2e tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,7 +3,7 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-stable
-#    - fedora-rawhide
+    - fedora-37
+#    - fedora-all
     - centos-stream-9-x86_64
     skip_build: true

--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -23,7 +23,7 @@
     test:
      - /setup/configure_tpm_emulator
      - /setup/install_upstream_keylime
-     - /setup/install_upstream_rust_keylime
+     - /setup/install_rust_keylime_from_copr
      - /setup/enable_keylime_coverage
      # change IMA policy to simple and run one attestation scenario
      # this is to utilize also a different parser
@@ -109,7 +109,7 @@
     test:
      - /setup/configure_tpm_emulator
      - /setup/install_upstream_keylime
-     - /setup/install_upstream_rust_keylime
+     - /setup/install_rust_keylime_from_copr
      - /functional/basic-attestation-on-localhost
      - /functional/basic-attestation-with-custom-certificates
      - /functional/basic-attestation-without-mtls


### PR DESCRIPTION
The COPR repo contains up-to-date RPMs of the upstream Rust agent and using these RPMs will speed up e2e tests.