### PR TITLE
build-sys: Use comma-separated list for running multiple linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check check-rebuild
 check:
-	tox -epylint -epyright -emypy -eblack -eisort
+	tox -e pylint,pyright,mypy,black,isort
 
 check-rebuild:
-	tox -r -vv -epylint -epyright -emypy -eblack -eisort
+	tox -r -vv -e pylint,pyright,mypy,black,isort


### PR DESCRIPTION
Passing multiple -e options doesn't seem to be supported anymore by tox, so switch to a comma-separated list.