### PR TITLE
installer.sh: support Alibaba Cloud Linux OS whose ID is alinux

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -148,6 +148,26 @@ case "$ID" in
         fi
     ;;
 
+    # Alibaba Cloud Linux
+    alinux)
+        case "${VERSION_ID}" in
+            3*)
+                echo "${ID} selected."
+                PACKAGE_MGR=$(command -v dnf)
+                PYTHON_PREIN="python3 python3-devel python3-setuptools git wget patch rust cargo"
+                PYTHON_DEPS="python3-pip gcc gcc-c++ openssl-devel swig python3-pyyaml python3-zmq python3-cryptography python3-tornado python3-requests python3-gpg yaml-cpp-devel procps-ng python3-psutil python3-lark-parser python3-alembic python3-setuptools"
+                if [ "$(uname -m)" = "x86_64" ]; then
+                     PYTHON_DEPS+=" efivar-libs"
+                fi
+                pip3 install setuptools_rust
+                TPM2_TOOLS_PKGS="tpm2-tools tpm2-tss"
+            ;;
+            *)
+                echo "Version ${VERSION_ID} of ${ID} not supported"
+                exit 1
+        esac
+    ;;
+
     *)
         echo "${ID} is not currently supported."
         exit 1


### PR DESCRIPTION
This patch fix the following problem:

![image](https://user-images.githubusercontent.com/6824093/236411681-b7dcfe9e-4bda-4b2a-896e-cf267cbea67b.png)

and the `/etc/os-release` of Alibaba Cloud Linux OS is like

![image](https://user-images.githubusercontent.com/6824093/236411933-126365e9-736c-47e8-b292-328e24b0b08e.png)


Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>