### PR TITLE
README.md: remove the invalid URL about IMA stub service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Please, see [TESTING.md](TESTING.md) for details.
 * See the HotCloud 2018 paper: [docs/old/hotcloud18.pdf](https://github.com/keylime/keylime/blob/master/docs/old/hotcloud18.pdf)
 * Details about Keylime REST API: [docs/old/keylime RESTful API.docx](https://github.com/keylime/keylime/raw/master/docs/old/keylime%20RESTful%20API.docx)
 * [Demo files](demo/) - Some pre-packaged demos to show off what Keylime can do.
-* [IMA stub service](ima_stub_service/) - Allows you to test IMA and Keylime on a machine without a TPM.  Service keeps emulated TPM synchronized with IMA.
+* [IMA stub service](https://github.com/keylime/rust-keylime/tree/master/keylime-ima-emulator) - Allows you to test IMA and Keylime on a machine without a TPM.  Service keeps emulated TPM synchronized with IMA.
 
 #### Errata from the ACSAC Paper
 


### PR DESCRIPTION
IMA stubbing support is removed already and the URL in README.md is invalid. so we need to remove the invalid URL correspondingly.

Fixes: #1368 

Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>