### PR TITLE
Replace tpm2_makecredential with a python implementation

### DIFF
--- a/keylime/registrar_common.py
+++ b/keylime/registrar_common.py
@@ -267,8 +267,6 @@ class UnprotectedHandler(BaseHandler):
             ekcert = json_body["ekcert"]
             aik_tpm = json_body["aik_tpm"]
 
-            initialize_tpm = Tpm()
-
             if ekcert is None or ekcert == "emulator":
                 logger.warning("Agent %s did not submit an ekcert", agent_id)
                 ek_tpm = json_body["ek_tpm"]
@@ -300,7 +298,7 @@ class UnprotectedHandler(BaseHandler):
                 return
 
             # try to encrypt the AIK
-            aik_enc = initialize_tpm.encryptAIK(
+            aik_enc = Tpm.encryptAIK(
                 agent_id,
                 base64.b64decode(ek_tpm),
                 base64.b64decode(aik_tpm),

--- a/keylime/tpm/tpm2_objects.py
+++ b/keylime/tpm/tpm2_objects.py
@@ -555,3 +555,13 @@ def unmarshal_tpml_pcr_selection(tpml_pcr_selection: bytes) -> Tuple[Dict[int, i
         o = o + sz
 
     return selections, o
+
+
+def tpms_ecc_point_marshal(public_key: EllipticCurvePublicKey) -> bytes:
+    pn = public_key.public_numbers()
+
+    sz = (pn.x.bit_length() + 7) // 8
+    secret = struct.pack(">H", sz) + pn.x.to_bytes(sz, "big")
+
+    sz = (pn.y.bit_length() + 7) // 8
+    return secret + struct.pack(">H", sz) + pn.y.to_bytes(sz, "big")

--- a/keylime/tpm/tpm2_objects.py
+++ b/keylime/tpm/tpm2_objects.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.primitives.asymmetric.ec import (
     EllipticCurvePublicNumbers,
 )
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey, RSAPublicNumbers
+from cryptography.hazmat.primitives.ciphers import algorithms
 
 from keylime.tpm.types import TpmsAttestType
 
@@ -76,6 +77,10 @@ HASH_FUNCS: Dict[int, hashes.HashAlgorithm] = {
     TPM_ALG_SHA256: hashes.SHA256(),
     TPM_ALG_SHA384: hashes.SHA384(),
     TPM_ALG_SHA512: hashes.SHA512(),
+}
+
+SYMCIPHER_FUNCS = {
+    TPM_ALG_AES: algorithms.AES,
 }
 
 

--- a/keylime/tpm/tpm2_objects_test.py
+++ b/keylime/tpm/tpm2_objects_test.py
@@ -17,11 +17,15 @@ from keylime.tpm.tpm2_objects import (
     OA_SIGN_ENCRYPT,
     OA_STCLEAR,
     OA_USERWITHAUTH,
+    TPM_ALG_AES,
+    TPM_ALG_SHA256,
     ek_low_tpm2b_public_from_pubkey,
     get_tpm2b_public_name,
     get_tpm2b_public_object_attributes,
+    get_tpm2b_public_symkey_params,
     object_attributes_description,
     pubkey_from_tpm2b_public,
+    pubkey_parms_from_tpm2b_public,
     unmarshal_tpms_attest,
 )
 
@@ -183,6 +187,10 @@ class TestTpm2Objects(unittest.TestCase):
         self.assertEqual(new_rsa_pubkey_n.e, correct_rsa_pubkey_n.e)  # pylint: disable=no-member
         self.assertEqual(new_rsa_pubkey_n.n, correct_rsa_pubkey_n.n)  # pylint: disable=no-member
 
+        sym_alg, symkey_bits = get_tpm2b_public_symkey_params(correct_rsa_obj)
+        self.assertEqual(sym_alg, TPM_ALG_AES)
+        self.assertEqual(symkey_bits, 128)
+
     def test_pubkey_from_tpm2b_public_rsa_without_encryption(self) -> None:
         new_rsa_pubkey = pubkey_from_tpm2b_public(
             bytes.fromhex(
@@ -242,8 +250,9 @@ class TestTpm2Objects(unittest.TestCase):
             "wGqmoOwgqQSByVBrADgEVHlhS9J2tJQNMQ=="
         )
         test_ec_cert = load_der_x509_certificate(test_ec_cert_bytes, backend=default_backend())
-        new_ec_pubkey = pubkey_from_tpm2b_public(correct_ec_obj)
+        new_ec_pubkey, name_alg = pubkey_parms_from_tpm2b_public(correct_ec_obj)
         assert isinstance(new_ec_pubkey, ec.EllipticCurvePublicKey)
+        self.assertEqual(name_alg, TPM_ALG_SHA256)
 
         correct_ec_pubkey = test_ec_cert.public_key()
         assert isinstance(correct_ec_pubkey, ec.EllipticCurvePublicKey)

--- a/keylime/tpm/tpm_util.py
+++ b/keylime/tpm/tpm_util.py
@@ -1,13 +1,15 @@
+import os
 import struct
 from typing import Dict, List, Tuple, Union
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat import backends
-from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives import hashes, hmac, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, padding
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+from cryptography.hazmat.primitives.ciphers import Cipher, modes
 
 from keylime import keylime_logging
 from keylime.tpm import tpm2_objects
@@ -176,3 +178,192 @@ def checkquote(
         raise Exception("The digest of the quoteblob differs from the quote's digest")
 
     return pcrs_dict
+
+
+def label_to_bytes(label: str) -> bytes:
+    return bytes(label, "UTF-8") + b"\x00"
+
+
+def makecredential(ek_tpm: bytes, challenge: bytes, aik_name: bytes) -> bytes:
+    """TPM_MakeCredential implementation
+
+    Parameters
+    ----------
+    ek_tpm: marshalled TPMT_PUBKEY
+    challenge: random 'password'
+    aik_name: name of the object (AIK)
+    """
+    public_key, hash_alg = tpm2_objects.pubkey_parms_from_tpm2b_public(ek_tpm)
+    # python crypto only supports encryption with RSA public key
+    if not isinstance(public_key, RSAPublicKey):
+        raise ValueError(f"Unsupported public key type {type(public_key)} for makecredential")
+
+    hashfunc = tpm2_objects.HASH_FUNCS.get(hash_alg)
+    if not hashfunc:
+        raise ValueError(f"Unsupported hash with id {hash_alg:#x} in signature blob")
+
+    random = os.urandom(hashfunc.digest_size)
+
+    secret = public_key.encrypt(
+        random,
+        padding.OAEP(mgf=padding.MGF1(algorithm=hashfunc), algorithm=hashfunc, label=label_to_bytes("IDENTITY")),
+    )
+
+    credentialblob = secret_to_credential(challenge, aik_name, random, ek_tpm, hashfunc)
+
+    # Create tpm2-tools-specific result format
+    hdr = struct.pack(">II", 0xBADCC0DE, 1)
+    tail = struct.pack(f">H{len(secret)}s", len(secret), secret)
+
+    return hdr + credentialblob + tail
+
+
+def secret_to_credential(
+    secret: bytes, name: bytes, seed: bytes, ek_tpm: bytes, hashfunc: hashes.HashAlgorithm
+) -> bytes:
+    """TPM 2's SecretToCredential
+
+    Parameters
+    ----------
+    secret: the secret
+    name: name of the object
+    seed: external seed
+    ek_tpm: marshalled TPMT_PUBKEY
+    hashfunc: the hash function used by the public key (extracted from ek_tpm)
+    """
+    # sensitive data is the 2nd part in TPM2B_ID_OBJECT
+    sensitive_data_2b = struct.pack(f">H{len(secret)}s", len(secret), secret)
+    integrity, sensitive_data_enc = produce_outer_wrap(ek_tpm, name, hashfunc, seed, sensitive_data_2b)
+
+    tpms_id_object = struct.pack(
+        f">H{len(integrity)}s{len(sensitive_data_enc)}s",
+        len(integrity),
+        integrity,
+        sensitive_data_enc,
+    )
+
+    return struct.pack(f">H{len(tpms_id_object)}s", len(tpms_id_object), tpms_id_object)
+
+
+def produce_outer_wrap(
+    ek_tpm: bytes,
+    name: bytes,
+    hashfunc: hashes.HashAlgorithm,
+    seed: bytes,
+    sensitive_data_2b: bytes,
+) -> Tuple[bytes, bytes]:
+    """TPM 2's ProduceOuterWrap implementing encrypt-then-MAC of a secret
+
+    Parameters
+    ----------
+    ek_tpm: marshalled TPMT_PUBKEY
+    name: name of the object
+    hashfunc: the hash function used by the public key (extracted from ek_tpm)
+    seed: external seed
+    sensitive_data_2b: marshalled TPM2B buffer holding a secret
+    """
+    symkey, sym_alg = compute_protection_key_parms(ek_tpm, hashfunc, name, seed)
+
+    # Encrypt inner buffer
+    symcipherfunc = tpm2_objects.SYMCIPHER_FUNCS.get(sym_alg)
+    if not symcipherfunc:
+        raise ValueError(f"Unsupported symmetric cipher with Id {sym_alg:#x} was requested")
+
+    symcipher = symcipherfunc(symkey)
+    block_size = symcipher.block_size >> 3
+    encryptor = Cipher(symcipher, modes.CFB(b"\x00" * block_size)).encryptor()
+    ciphertext = encryptor.update(sensitive_data_2b) + encryptor.finalize()
+
+    # Compute outer integrity
+    hmac_signature = compute_outer_integrity(name, hashfunc, seed, ciphertext)
+
+    return hmac_signature, ciphertext
+
+
+def compute_outer_integrity(
+    name: bytes,
+    hashfunc: hashes.HashAlgorithm,
+    seed: bytes,
+    ciphertext: bytes,
+) -> bytes:
+    """TPM 2's ComputeOuterIntegrity HMAC'ing a ciphertext
+
+    Parameters
+    ----------
+    name: name of the object; this will be part of the HMAC'ed data
+    hashfunc: hash function to use for HMAC
+    seed: external seed
+    ciphertext: ciphertext to HMAC
+    """
+    digest_size = hashfunc.digest_size
+
+    hmac_key = crypt_kdfa(hashfunc, seed, "INTEGRITY", b"", b"", digest_size << 3)
+
+    h = hmac.HMAC(hmac_key, hashfunc)
+    h.update(ciphertext)
+    h.update(name)
+    return h.finalize()
+
+
+def compute_protection_key_parms(
+    ek_tpm: bytes, hashfunc: hashes.HashAlgorithm, name: bytes, seed: bytes
+) -> Tuple[bytes, int]:
+    """TPM 2's ComputeProtectionKeyParms deriving a symmetric key using KDFa
+
+    Parameters
+    ----------
+    ek_tpm: marshalled TPMT_PUBKEY
+    hashfunc: hash function to use for key derivation
+    name: name of the object
+    seed: external seed
+    """
+    assert len(seed) > 0
+
+    sym_alg, symkey_bits = tpm2_objects.get_tpm2b_public_symkey_params(ek_tpm)
+
+    symkey = crypt_kdfa(hashfunc, seed, "STORAGE", name, b"", symkey_bits)
+
+    return symkey, sym_alg
+
+
+def crypt_kdfa(
+    hashfunc: hashes.HashAlgorithm,
+    key: bytes,
+    label: str,
+    context_u: bytes,
+    context_v: bytes,
+    size_in_bits: int,
+) -> bytes:
+    """TPM 2's KDFa
+
+    Parameters
+    ----------
+    hashfunc: hash function
+    key: key to use for HMAC
+    label: a label to add to the HMAC
+    context_u: context to add to the HMAC
+    context_v: context to add to the HMAC
+    size_in_bits: how many bits of random data to generate
+    """
+    size_in_bytes = (size_in_bits + 7) >> 3
+    label_bytes = label_to_bytes(label)
+    context = context_u + context_v
+
+    ctr = 0
+    result = b""
+
+    size = size_in_bytes
+
+    while size > 0:
+        h = hmac.HMAC(key, hashfunc)
+        ctr += 1
+        h.update(struct.pack(">I", ctr))
+        h.update(label_bytes)
+        if context:
+            h.update(context)
+        h.update(struct.pack(">I", size_in_bits))
+        result += h.finalize()
+
+        size -= hashfunc.digest_size
+
+    return result[:size_in_bytes]


### PR DESCRIPTION
This PR implements the algorithms necessary for running TPM2_MakeCredential outside of a TPM 2 but follows the TPM 2 reference implementation. It then replaces the tpm2_makecredential command line tool invocation with a call to the python function that returns its result in the same format as tpm2_makecredential did.