### PR TITLE
tpm+ima: Convert tables to hold instances of hashers

### DIFF
--- a/keylime/ima/file_signatures.py
+++ b/keylime/ima/file_signatures.py
@@ -71,16 +71,16 @@ class MyStreebog512(hashes.HashAlgorithm):
     block_size = 64  # type: ignore
 
 
-HASH_FUNCS = {
+HASH_FUNCS: Dict[int, hashes.HashAlgorithm] = {
     # The list of hash functions we need for signature verification.
-    HashAlgo.HASH_ALGO_MD5: hashes.__dict__.get("MD5"),
-    HashAlgo.HASH_ALGO_SHA1: hashes.__dict__.get("SHA1"),
-    HashAlgo.HASH_ALGO_SHA256: hashes.__dict__.get("SHA256"),
-    HashAlgo.HASH_ALGO_SHA384: hashes.__dict__.get("SHA384"),
-    HashAlgo.HASH_ALGO_SHA512: hashes.__dict__.get("SHA512"),
-    HashAlgo.HASH_ALGO_SHA224: hashes.__dict__.get("SHA224"),
-    HashAlgo.HASH_ALGO_STREEBOG_256: MyStreebog256,
-    HashAlgo.HASH_ALGO_STREEBOG_512: MyStreebog512,
+    HashAlgo.HASH_ALGO_MD5: hashes.MD5(),
+    HashAlgo.HASH_ALGO_SHA1: hashes.SHA1(),
+    HashAlgo.HASH_ALGO_SHA256: hashes.SHA256(),
+    HashAlgo.HASH_ALGO_SHA384: hashes.SHA384(),
+    HashAlgo.HASH_ALGO_SHA512: hashes.SHA512(),
+    HashAlgo.HASH_ALGO_SHA224: hashes.SHA224(),
+    HashAlgo.HASH_ALGO_STREEBOG_256: MyStreebog256(),
+    HashAlgo.HASH_ALGO_STREEBOG_512: MyStreebog512(),
 }
 
 
@@ -328,10 +328,8 @@ class ImaKeyrings:
             logger.warning("Unsupported hash algo with id '%d'", hash_algo)
             return False
 
-        if filehash_type != hashfunc().name:
-            logger.warning(
-                "Mismatching filehash type %s and ima signature hash used %s", filehash_type, hashfunc().name
-            )
+        if filehash_type != hashfunc.name:
+            logger.warning("Mismatching filehash type %s and ima signature hash used %s", filehash_type, hashfunc.name)
             return False
 
         # Try all the keyrings until we find one with a key with the given keyidv2
@@ -346,7 +344,7 @@ class ImaKeyrings:
             return False
 
         try:
-            ImaKeyrings._verify(pubkey, signature[hdrlen:], filehash, hashfunc())
+            ImaKeyrings._verify(pubkey, signature[hdrlen:], filehash, hashfunc)
         except InvalidSignature:
             return False
         return True

--- a/keylime/tpm/tpm2_objects.py
+++ b/keylime/tpm/tpm2_objects.py
@@ -71,11 +71,11 @@ AK_EXPECTED_ATTRS = (
 
 
 # The hash functions used by TPM
-HASH_FUNCS = {
-    TPM_ALG_SHA1: hashes.__dict__.get("SHA1"),
-    TPM_ALG_SHA256: hashes.__dict__.get("SHA256"),
-    TPM_ALG_SHA384: hashes.__dict__.get("SHA384"),
-    TPM_ALG_SHA512: hashes.__dict__.get("SHA512"),
+HASH_FUNCS: Dict[int, hashes.HashAlgorithm] = {
+    TPM_ALG_SHA1: hashes.SHA1(),
+    TPM_ALG_SHA256: hashes.SHA256(),
+    TPM_ALG_SHA384: hashes.SHA384(),
+    TPM_ALG_SHA512: hashes.SHA512(),
 }
 
 

--- a/keylime/tpm/tpm_util.py
+++ b/keylime/tpm/tpm_util.py
@@ -87,7 +87,7 @@ def __hash_pcr_banks(
     if not hashfunc:
         raise ValueError(f"Unsupported hash with id {hash_alg:#x} in signature blob")
 
-    digest = hashes.Hash(hashfunc(), backend=backends.default_backend())
+    digest = hashes.Hash(hashfunc, backend=backends.default_backend())
 
     idx = 0
     pcrs_dict: Dict[int, str] = {}
@@ -145,15 +145,15 @@ def checkquote(
     hashfunc = tpm2_objects.HASH_FUNCS.get(hash_alg)
     if not hashfunc:
         raise ValueError(f"Unsupported hash with id {hash_alg:#x} in signature blob")
-    if hashfunc().name != exp_hash_alg:
-        raise ValueError(f"Quote was expected to use {exp_hash_alg} but used {hashfunc().name} instead")
+    if hashfunc.name != exp_hash_alg:
+        raise ValueError(f"Quote was expected to use {exp_hash_alg} but used {hashfunc.name} instead")
 
-    digest = hashes.Hash(hashfunc(), backend=backends.default_backend())
+    digest = hashes.Hash(hashfunc, backend=backends.default_backend())
     digest.update(quoteblob)
     quote_digest = digest.finalize()
 
     try:
-        verify(pubkey, signature, quote_digest, hashfunc())
+        verify(pubkey, signature, quote_digest, hashfunc)
     except InvalidSignature:
         logger.error("Invalid quote signature!")
 
@@ -168,7 +168,7 @@ def checkquote(
     if retDict["attested.quote.pcrDigest"] != compare_digest:
         raise Exception("The digest used for quoting is different than the one that was calculated")
 
-    digest = hashes.Hash(hashfunc(), backend=backends.default_backend())
+    digest = hashes.Hash(hashfunc, backend=backends.default_backend())
     digest.update(quoteblob)
     quoteblob_digest = digest.finalize()
 


### PR DESCRIPTION
Convert the hasher lookup tables to hold instances of hashers rather than references to classes that have to be instantiated to get an object. The driving for behind this conversion is to be able to apply proper type-checking for the hashers when they are passed around between functions.