### PR TITLE
installer.sh: update TPM2TOOLS_VER to 5.5 and cherry-pick patches to fix the bug of parsing for most newer logs with the tpm2_eventlog command.

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -12,7 +12,7 @@ TPM2SIM_SRC=http://sourceforge.net/projects/ibmswtpm2/files/ibmtpm1119.tar.gz/do
 KEYLIME_VER="master"
 TPM4720_VER="master"
 TPM2TSS_VER="3.2.x"
-TPM2TOOLS_VER="5.1.X"
+TPM2TOOLS_VER="5.5"
 
 # Minimum version requirements
 MIN_PYTHON_VERSION="3.6.7"
@@ -375,6 +375,8 @@ else
     git clone $TPM2TOOLS_GIT tpm2-tools
     pushd tpm2-tools
     git checkout $TPM2TOOLS_VER
+    # cherry-pick tpm2-software/tpm2-tools@9735dc3 and tpm2-software/tpm2-tools@576a31b to cover parsing for most newer logs.
+    git cherry-pick -n 9735dc3 576a31b
     ./bootstrap
     if [[ -n $CENTOS7_TSS_FLAGS ]] ; then
         export SAPI_CFLAGS=' '


### PR DESCRIPTION
In tpm2-tools, https://github.com/tpm2-software/tpm2-tools/commit/b3dac7d32f9cdc6154720ecb01d0220cca6d2f79 fix the error `Cannot allocate memory when using --eventlog-version=2`. In keylime, https://github.com/keylime/keylime/blob/master/keylime/tpm/tpm_main.py#L711 also uses the tpm2_eventlog command to pasre MokListTrusted, which gets a similar error ` - root - ERROR - Parsing of binary boot measurements failed with: ['{"message": "running tpm2_eventlog failed"}']`

So we need to 5.4 to fix the bug of parsing for MokListTrusted using the tpm2_eventlog command.

Fixes: #1396 

Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>