### PR TITLE
[tests] Enable basic allowlist/excludelist test

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -76,6 +76,7 @@ adjust:
      - /functional/tpm-issuer-cert-using-ecc
      - /functional/tpm_policy-sanity-on-localhost
      - /functional/use-multiple-ima-sign-verification-keys
+     - /compatibility/basic-attestation-on-localhost-with-allowlist-excludelist
      - /upstream/run_keylime_tests
      - /setup/generate_coverage_report
 


### PR DESCRIPTION
Despite the runtime policy rewrite the basic functionality of allowlist and excludelist has been preserved. This test uses keylime_tenant's  --allowlist and --exludelist parameters to verify they are still functional.