### PR TITLE
migrations: use sa.text for raw SQL

### DIFF
--- a/keylime/migrations/versions/4329e2d14944_associate_moved_allowlists_to_agents.py
+++ b/keylime/migrations/versions/4329e2d14944_associate_moved_allowlists_to_agents.py
@@ -38,7 +38,7 @@ def upgrade_cloud_verifier():
     meta.reflect(bind=conn, only=("verifiermain",))
     verifiermain = meta.tables["verifiermain"]
 
-    res = conn.execute("SELECT id, name FROM allowlists")
+    res = conn.execute(sa.text("SELECT id, name FROM allowlists"))
     results = res.fetchall()
 
     # Update new foreign key column with associated items in the "allowlists" table

--- a/keylime/migrations/versions/8c0f8ded1f90_convert_allowlists_to_ima_policies.py
+++ b/keylime/migrations/versions/8c0f8ded1f90_convert_allowlists_to_ima_policies.py
@@ -47,7 +47,7 @@ def upgrade_cloud_verifier():
     meta = sa.MetaData()
     meta.reflect(bind=conn, only=("allowlists",))
     allowlists = meta.tables["allowlists"]
-    results = conn.execute("SELECT id, ima_policy FROM allowlists").fetchall()
+    results = conn.execute(sa.text("SELECT id, ima_policy FROM allowlists")).fetchall()
 
     # Update allowlist entries with converted IMA policies
     for old_ima_policy_id, old_ima_policy in results:
@@ -92,7 +92,7 @@ def downgrade_cloud_verifier():
     meta = sa.MetaData()
     meta.reflect(bind=conn, only=("allowlists",))
     allowlists = meta.tables["allowlists"]
-    results = conn.execute("SELECT id, ima_policy FROM allowlists").fetchall()
+    results = conn.execute(sa.text("SELECT id, ima_policy FROM allowlists")).fetchall()
 
     # Update allowlist entries with converted IMA policies
     for ima_policy_id, ima_policy in results:

--- a/keylime/migrations/versions/a72aec03d720_migrate_allowlists_to_separate_table.py
+++ b/keylime/migrations/versions/a72aec03d720_migrate_allowlists_to_separate_table.py
@@ -35,7 +35,7 @@ def upgrade_cloud_verifier():
     # Migrate existing agent info to the allowlists table.
     conn = op.get_bind()
 
-    res = conn.execute("SELECT agent_id, tpm_policy, allowlist FROM verifiermain")
+    res = conn.execute(sa.text("SELECT agent_id, tpm_policy, allowlist FROM verifiermain"))
     results = res.fetchall()
     old_policy = [{"name": r[0], "tpm_policy": r[1], "ima_policy": r[2]} for r in results]
 
@@ -61,7 +61,7 @@ def downgrade_cloud_verifier():
     verifiermain = meta.tables["verifiermain"]
     allowlists = meta.tables["allowlists"]
 
-    res = conn.execute("SELECT name, ima_policy FROM allowlists")
+    res = conn.execute(sa.text("SELECT name, ima_policy FROM allowlists"))
     results = res.fetchall()
 
     # Put allowlists back into the "allowlist" column, and delete from the "allowlists" database


### PR DESCRIPTION
Since version 2.0 of SQLAlchemy we cannot pass strings into the execute method.  We need to use the `text` wrapper type.