### PR TITLE
templates: Set empty string as default value for tpm_ownerpassword

### DIFF
--- a/templates/2.0/mapping.json
+++ b/templates/2.0/mapping.json
@@ -100,7 +100,7 @@
             "tpm_ownerpassword": {
                 "section": "cloud_agent",
                 "option": "tpm_ownerpassword",
-                "default": "keylime"
+                "default": ""
             },
             "extract_payload_zip": {
                 "section": "cloud_agent",


### PR DESCRIPTION
The default value for the TPM owner password should be the empty string to avoid authentication failure on machines with default TPM owner password configuration.

Resolves: #1404