### PR TITLE
mba: making MBA policy parser and checker pluggable

### DIFF
--- a/keylime/cli/policies.py
+++ b/keylime/cli/policies.py
@@ -164,7 +164,7 @@ def process_policy(args: ArgsType) -> Tuple[Dict[str, Any], Optional[str], str, 
         if isinstance(args["mb_refstate"], str):
             if args["mb_refstate"] == "default":
                 args["mb_refstate"] = config.get("tenant", "mb_refstate")
-            mb_refstate_data = mba.load_policy_file(args["mb_refstate"])
+            mb_refstate_data = mba.policy_load(args["mb_refstate"])
         else:
             raise UserError("Invalid measured boot reference state (intended state) provided")
 

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -10,6 +10,7 @@ from keylime.db.verifier_db import VerfierMain
 from keylime.failure import Component, Event, Failure
 from keylime.ima import file_signatures
 from keylime.ima.types import RuntimePolicyType
+from keylime.mba import mba
 from keylime.tpm import tpm_util
 from keylime.tpm.tpm_main import Tpm
 
@@ -259,8 +260,7 @@ def prepare_get_quote(agent: Dict[str, Any]) -> Dict[str, Union[str, int]]:
 def process_get_status(agent: VerfierMain) -> Dict[str, Any]:
     has_mb_refstate = 0
     try:
-        mb_refstate = json.loads(cast(str, agent.mb_refstate))
-        if mb_refstate and mb_refstate.keys():
+        if mba.policy_is_valid(cast(str, agent.mb_refstate)):
             has_mb_refstate = 1
     except Exception as e:
         logger.warning(

--- a/keylime/cmd/verifier.py
+++ b/keylime/cmd/verifier.py
@@ -10,10 +10,8 @@ def main() -> None:
     if config.has_option("verifier", "auto_migrate_db") and config.getboolean("verifier", "auto_migrate_db"):
         apply("cloud_verifier")
 
-    # Load explicitly the policy modules into Keylime for the verifier,
-    # so that they are not loaded accidentally from other components
-    mba.load_policy_engine()
-    mba.load_parser_engine()
+    # Explicitly load and initialize measured boot components
+    mba.load_imports()
     cloud_verifier_tornado.main()
 
 

--- a/keylime/da/attest.py
+++ b/keylime/da/attest.py
@@ -40,8 +40,7 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    mba.load_policy_engine()
-    mba.load_parser_engine()
+    mba.load_imports()
 
     rmcb = config.get("registrar", "durable_attestation_import", fallback="")
     rmc = record.get_record_mgt_class(rmcb)

--- a/keylime/mba/elchecking/__main__.py
+++ b/keylime/mba/elchecking/__main__.py
@@ -2,11 +2,11 @@ import argparse
 import json
 import sys
 
+from keylime.mba import mba
 from keylime.mba.elparsing import tpm2_tools_elparser
 
 from . import policies
 
-policies.load_policies()
 # This main module is just for command-line based testing.
 # It implements a command to do one test.
 # Invoke it with `python3 -m $packagename`, for some value of
@@ -18,6 +18,7 @@ parser.add_argument("policy_name", choices=policies.get_policy_names())
 parser.add_argument("refstate_file", type=argparse.FileType("rt"))
 parser.add_argument("eventlog_file", type=argparse.FileType("rb"), default=sys.stdin)
 args = parser.parse_args()
+mba.load_imports()
 policy = policies.get_policy(args.policy_name)
 if policy is None:
     print(

--- a/keylime/mba/elchecking/elchecker.py
+++ b/keylime/mba/elchecking/elchecker.py
@@ -3,17 +3,63 @@ from typing import Optional, Set
 
 from keylime import config, keylime_logging
 from keylime.failure import Component, Failure
-from keylime.mba.elchecking import tests
+from keylime.mba.elchecking import policies, tests
 
 logger = keylime_logging.init_logging("measured_boot")
 
 
-def evaluate_bootlog(
+def policy_load(policy_path: Optional[str] = None) -> str:
+    """
+    Load (and validates) an actual policy file.
+    :param policy_path: <optional> name of policy file to load
+    :returns: a string defining the policy.
+    Errors: if the policy file cannot be read, or contains errors, this function may
+    cause exceptions. Validation in this case is to confirm that the file
+    is formatted as proper JSON; nothing more.
+
+    TODO: default policy should probably not be defined, because it depends on the policy engine itself?
+    """
+    try:
+        if policy_path is None:
+            policy_path = config.get("tenant", "mb_refstate")
+        with open(policy_path, encoding="utf-8") as f:
+            mb_policy_data = json.load(f)
+            return json.dumps(mb_policy_data)
+    except Exception as e:
+        raise ValueError from e
+
+
+def policy_is_valid(mb_refstate: Optional[str]) -> bool:
+    """
+    Returns true if the policy argument is a valid nonempty policy
+    """
+    if not mb_refstate:
+        return False
+    try:
+        mb_refstate_obj = json.loads(mb_refstate)
+    except Exception as _:
+        return False
+    if not mb_refstate_obj:
+        return False
+    if len(mb_refstate_obj) == 0:
+        return False
+    return True
+
+
+def bootlog_evaluate(
     mb_refstate_str: Optional[str],
     mb_measurement_data: tests.Data,
     pcrs_inquote: Set[int],
     agent_id: str,
 ) -> Failure:
+    """
+    Evaluating a measured boot event log against a policy
+    :param policy_data: policy definition (aka "refstate") (as a string).
+    :param measurement_data: parsed measured boot event log as produced by `parse_bootlog`
+    :param pcrsInQuote: a set of PCRs provided by the quote.
+    :param agent_id: the UUID of the keylime agent sending this data.
+    :returns: list of all failures encountered while evaluating the boot log against the policy.
+    """
     failure = Failure(Component.MEASURED_BOOT)
 
     # no evaluation if the refstate is an empty string
@@ -29,18 +75,15 @@ def evaluate_bootlog(
     # load policy name
     mb_policy_name = config.get("verifier", "measured_boot_policy_name", fallback="accept-all")
 
-    # pylint: disable=import-outside-toplevel
-    from keylime.mba.elchecking import policies as eventlog_policies
-
     # pylint: enable=import-outside-toplevel
-    mb_policy = eventlog_policies.get_policy(mb_policy_name)
+    mb_policy = policies.get_policy(mb_policy_name)
 
     # fallback if we cannot find policy
     # Should not happen in the verifier because we check on startup if the policy exists
     if mb_policy is None:
         logger.warning("Invalid measured boot policy name %s -- using reject-all instead.", mb_policy_name)
         mb_policy_name = "reject-all"
-        mb_policy = eventlog_policies.RejectAll()
+        mb_policy = policies.RejectAll()
 
     # figure out whether the quote contains all quotes to evaluate the policy
     # if there are any PCRs in the policy that are not in the quote, we canot evaluate.
@@ -76,3 +119,6 @@ def evaluate_bootlog(
             True,
         )
     return failure
+
+
+logger.debug("mba.elchecking.elchecker: policy names = %s", str(policies.get_policy_names()))

--- a/keylime/mba/elchecking/policies.py
+++ b/keylime/mba/elchecking/policies.py
@@ -1,8 +1,5 @@
 import abc
-import importlib
 import typing
-
-from keylime import config
 
 from . import tests
 
@@ -101,12 +98,3 @@ def evaluate(policy_name: str, refstate: RefState, eventlog: tests.Data) -> str:
     """
     tester = refstate_to_test(policy_name, refstate)
     return tester.why_not({}, eventlog)
-
-
-def load_policies() -> None:
-    imports = config.getlist("verifier", "measured_boot_imports")
-    imports.append(".example")
-    if imports:
-        for imp in imports:
-            if imp:
-                importlib.import_module(imp, __package__)

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -21,6 +21,7 @@ from keylime.cli import options, policies
 from keylime.cmd import user_data_encrypt
 from keylime.common import algorithms, retry, states, validators
 from keylime.ip_util import bracketize_ipv6
+from keylime.mba import mba
 from keylime.requests_client import RequestsClient
 from keylime.tpm import tpm2_objects, tpm_util
 from keylime.tpm.tpm_main import Tpm
@@ -155,6 +156,8 @@ class Tenant:
             logger.info("TLS is enabled.")
         else:
             logger.warning("TLS is disabled.")
+
+        mba.load_imports()
 
     @property
     def verifier_base_url(self) -> str:

--- a/test/test_mba_parsing.py
+++ b/test/test_mba_parsing.py
@@ -8,12 +8,13 @@ from keylime.mba import mba
 class TestMBAParsing(unittest.TestCase):
     def test_parse_bootlog(self):
         """Test parsing binary measured boot event log"""
+        mba.load_imports()
         # Use the file that triggered https://github.com/keylime/keylime/issues/1153
         mb_log_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "data/mb_log.b64"))
         with open(mb_log_path, encoding="utf-8") as f:
             # Read the base64 input and remove the newlines
             b64 = "".join(f.read().splitlines())
-            pcr_hashes, boot_aggregates, measurement_data, failure = mba.parse_bootlog(b64, Hash.SHA256)
+            pcr_hashes, boot_aggregates, measurement_data, failure = mba.bootlog_parse(b64, Hash.SHA256)
 
             self.assertFalse(
                 failure, f"Parsing of measured boot log failed with: {list(map(lambda x: x.context, failure.events))}"


### PR DESCRIPTION
## Pluggable MBA theory of operations

The module `keylime/mba/mba` provides an interface for measured boot attestation verification that consists of four functions.

* `bootlog_parse()`
   * converts a boot log from binary to JSON.
   * authenticates the log by checking the consistency of its digests.
   * provides a set of PCRs that can be verified against the TPM quote.
   * provides a boot aggregate for use by Keylime IMA verification.
* `policy_load()`
   * load a policy from a file into a Python string
   * optionally validate that the policy is syntactically correct (this is TBD)
*  `policy_is_valid()`
   *  test whether a string is valid policy
* `bootlog_evaluate()`
   * check the parsed boot log against the loaded policy, and return a list of policy failures.

A default implementation for all four functions is predefined in Keylime, and is backwards compatible (i.e. this is *not* a breaking change). The functions are implemented in `keylime/mba/elparsing` and `keylime/mba/elchecking` respectively.

However, these functions can be overridden by specifying a list of modules to load in the configuration option `verifier.measured_boot_imports`. Upon initialization MBA loads the modules as specified by the verifier option. These modules can contain implementations of the four functions above.

At runtime keylime chooses the active implementation for each of the functions described above by enumerating the ordered list of imported modules and picking the first implementation of the function it can find.