### PR TITLE
Several improvements for the "create_runtime_policy.sh" script

### DIFF
--- a/demo/demo_setup.sh
+++ b/demo/demo_setup.sh
@@ -264,8 +264,8 @@ if [[ "$IMA_ENABLE" -eq "1" ]] ; then
     # Generating IMA allowlist
     echo
     echo "=================================================================================="
-    echo $'\t\t\t\tGenerating IMA allowlist'
+    echo $'\t\t\t\tGenerating Runtime Policy'
     echo "=================================================================================="
     cd $KEYLIME_DIR/scripts
-    ./create_runtime_policy.sh allowlist.txt
+    ./create_runtime_policy.sh -o runtime_policy.json
 fi

--- a/docs/user_guide/runtime_ima.rst
+++ b/docs/user_guide/runtime_ima.rst
@@ -90,19 +90,33 @@ Keylime provides two helper scripts for getting started.
 
 Create Runtime Policy from a Running System
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The first script generates a runtime policy from the :code:`initramfs`, IMA log and
-files located on the root filesystem of a running system.
+The first script generates a runtime policy from the :code:`initramfs`, IMA log
+(just for the :code:`boot aggregate`) and files located on the root filesystem of a running
+system.
 
 The :code:`create_runtime_policy.sh` script is `available here <https://github.com/keylime/keylime/blob/master/scripts/create_runtime_policy.sh>`_
 
 Run the script as follows::
 
-  # create_runtime_policy.sh -o [filename] -h [hash-algo]
+  # create_runtime_policy.sh -o runtime_policy_keylime.json 
+  
+For more options see the help page :code:`create_runtime_policy.sh`::
 
-With :code:`[hash-algo]` being :code:`sha1sum`, :code:`sha256sum` (note, you need the OpenSSL app
-installed to have the shasum CLI applications available).
+    Usage: $0 -o/--output_file FILENAME [-a/--algo ALGO] [-x/--ramdisk-location PATH] [-y/--boot_aggregate-location PATH] [-z/--rootfs-location PATH] [-e/--exclude_list FILENAME] [-s/--skip-path PATH]"
 
-This will then result in `[filename]` being available for agent provisioning.
+    optional arguments:
+    -a/--algo                    (checksum algorithmi to be used, default: sha1sum)
+    -x/--ramdisk-location        (path to initramdisk, default: /boot/, set to "none" to skip)
+    -y/--boot_aggregate-location (path for IMA log, used for boot aggregate extraction, default: /sys/kernel/security/ima/ascii_runtime_measurements, set to "none" to skip)
+    -z/--rootfs-location         (path to root filesystem, default: /, cannot be skipped)
+    -e/--exclude_list            (filename containing a list of paths to be excluded (i.e., verifier will not try to match checksums), default: none)
+    -s/--skip-path               (comma-separated path list, files found there will not have checksums calculated, default: none)
+    -h/--help                    show this message and exit
+
+Note: note, you need the OpenSSL installed to have the sha*sum CLI executables available
+
+The resulting `runtime_policy_keylime.json` file can be directly used by
+:code:`keylime_tenant` (option :code:`--runtime-policy`)
 
 .. warning::
     It’s best practice to create the runtime policy in a secure environment.
@@ -122,7 +136,7 @@ A basic policy can be easily created by using a IMA measurement log from system:
 
   keylime_create_policy -m /path/to/ascii_runtime_measurements -o runtime_policy.json
 
-For the more options see the help page :code:`keylime_create_policy -h`::
+For more options see the help page :code:`keylime_create_policy -h`::
 
     usage: keylime_create_policy [-h] [-B BASE_POLICY] [-k] [-b] [-a ALLOWLIST] [-m IMA_MEASUREMENT_LIST] [-i IGNORED_KEYRINGS] [-o OUTPUT] [--no-hashes] [-A IMA_SIGNATURE_KEYS]
 

--- a/scripts/create_runtime_policy.sh
+++ b/scripts/create_runtime_policy.sh
@@ -1,8 +1,23 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ################################################################################
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2017 Massachusetts Institute of Technology.
 ################################################################################
+
+function announce {
+    # 1 - MESSAGE
+
+	MESSAGE=$(echo "${1}" | tr '\n' ' ')
+	MESSAGE=$(echo $MESSAGE | sed "s/\t\t*/ /g")
+
+	echo "==> $(date) - ${0} - $MESSAGE"
+}
+
+function valid_algo {
+        local algo=$1
+
+        [[ " ${ALGO_LIST[@]} " =~ " ${algo} " ]]
+}
 
 # Configure the installer here
 INITRAMFS_TOOLS_GIT=https://salsa.debian.org/kernel-team/initramfs-tools.git
@@ -11,128 +26,220 @@ INITRAMFS_TOOLS_VER="master"
 WORKING_DIR=$(readlink -f "$0")
 WORKING_DIR=$(dirname "$WORKING_DIR")
 
+# All defaults
+ALGO=sha1sum
+INITRAMFS_LOC="/boot/"
+INITRAMFS_STAGING_DIR=/tmp/ima/
+INITRAMFS_TOOLS_DIR=/tmp/initramfs-tools
+BOOT_AGGREGATE_LOC="/sys/kernel/security/ima/ascii_runtime_measurements"
+ROOTFS_LOC="/"
+EXCLUDE_LIST="none"
+SKIP_PATH="none"
+ALGO_LIST=("sha1sum" "sha256sum" "sha512sum")
+
 # Grabs Debian's initramfs_tools from Git repo if no other options exist
 if [[ ! `command -v unmkinitramfs` && ! -x "/usr/lib/dracut/skipcpio" ]] ; then
     # Create temp dir for pulling in initramfs-tools
-    TMPDIR=`mktemp -d` || exit 1
-    echo "INFO: Downloading initramfs-tools: $TMPDIR"
+    announce "INFO: Downloading initramfs-tools: $INITRAMFS_TOOLS_DIR"
 
+    mkdir -p $INITRAMFS_TOOLS_DIR
     # Clone initramfs-tools repo
-    pushd $TMPDIR
-    git clone $INITRAMFS_TOOLS_GIT initramfs-tools
-    pushd initramfs-tools
-    git checkout $INITRAMFS_TOOLS_VER
-    popd # $TMPDIR
-    popd
+    pushd $INITRAMFS_TOOLS_DIR > /dev/null 2>&1
+    git clone $INITRAMFS_TOOLS_GIT initramfs-tools > /dev/null 2>&1
+    pushd initramfs-tools > /dev/null 2>&1
+    git checkout $INITRAMFS_TOOLS_VER > /dev/null 2>&1
+    popd > /dev/null 2>&1
+    popd > /dev/null 2>&1
 
     shopt -s expand_aliases
-    alias unmkinitramfs=$TMPDIR/initramfs-tools/unmkinitramfs
-fi
+    alias unmkinitramfs=$INITRAMFS_TOOLS_DIR/initramfs-tools/unmkinitramfs
 
+    which unmkinitramfs > /dev/null 2>&1 || exit 1
+fi
 
 if [[ $EUID -ne 0 ]]; then
     echo "This script must be run as root" 1>&2
     exit 1
 fi
 
-if [ $# -lt 1 ]
-then
-    echo "No arguments provided" >&2
-    echo "Usage:  `basename $0` -o [filename] -h [hash-algo]" >&2
-    exit $NOARGS;
-fi
+USAGE=$(cat <<-END
+    Usage: $0 -o/--output_file FILENAME [-a/--algo ALGO] [-x/--ramdisk-location PATH] [-y/--boot_aggregate-location PATH] [-z/--rootfs-location PATH] [-e/--exclude_list FILENAME] [-s/--skip-path PATH] [-h/--help]
 
-ALGO=sha1sum
+    optional arguments:
+        -a/--algo                    (checksum algorithm to be used, default: $ALGO)
+        -x/--ramdisk-location        (path to initramdisk, default: $INITRAMFS_LOC, set to "none" to skip)
+        -y/--boot_aggregate-location (path for IMA log, used for boot aggregate extraction, default: $BOOT_AGGREGATE_LOC, set to "none" to skip)
+        -z/--rootfs-location         (path to root filesystem, default: $ROOTFS_LOC, cannot be skipped)
+        -e/--exclude_list            (filename containing a list of paths to be excluded (i.e., verifier will not try to match checksums, default: $EXCLUDE_LIST)
+        -s/--skip-path               (comma-separated path list, files found there will not have checksums calculated, default: $SKIP_PATH)
+        -h/--help                    (show this message and exit)
+END
+)
 
-ALGO_LIST=("sha1sum" "sha256sum" "sha512sum")
+while [[ $# -gt 0 ]]
+do
+    key="$1"
 
-valid_algo() {
-        local algo=$1
-
-        [[ " ${ALGO_LIST[@]} " =~ " ${algo} " ]]
-}
-
-while getopts ":o:h:" opt; do
-    case $opt in
-        o)
-            OUTPUT=$(readlink -f $OPTARG)
-            rm -f $OUTPUT
-            ;;
-        h)
-            if valid_algo $OPTARG; then
-                ALGO=$OPTARG
-            else
-                echo "Invalid hash function argument: use sha1sum, sha256sum, or sha512sum"
-                exit 1
-            fi
-            ;;
-    esac
+    case $key in
+        -a|--algo)
+        ALGO="$2"
+        shift
+        ;;
+        -a=*|--algo=*)
+        ALGO=$(echo $key | cut -d '=' -f 2)
+        ;;
+        -x|--ramdisk-location)
+        INITRAMFS_LOC="$2"
+        shift
+        ;;
+        -x=*|--ramdisk-location=*)
+        INITRAMFS_LOC=$(echo $key | cut -d '=' -f 2)
+        ;;
+        -y|--boot_aggregate-location)
+        BOOT_AGGREGATE_LOC=$2
+        shift
+        ;;
+        -y=*|--boot_aggregate-location=*)
+        BOOT_AGGREGATE_LOC=$(echo $key | cut -d '=' -f 2)
+        ;;
+        -z|--rootfs-location)
+        ROOTFS_LOC=$2
+        shift
+        ;;
+        -z=*|--rootfs-location=*)
+        ROOTFS_LOC=$(echo $key | cut -d '=' -f 2)
+        ;;
+        -e|--exclude_list)
+        EXCLUDE_LIST=$2
+        shift
+        ;;
+        -e=*|--exclude_list=*)
+        EXCLUDE_LIST=$(echo $key | cut -d '=' -f 2)
+        ;;        
+        -o=*|--output_file=*)
+        OUTPUT=$(echo $key | cut -d '=' -f 2)
+        ;;
+        -o|--output_file)
+        OUTPUT=$2
+        shift
+        ;;
+        -s=*|--skip-path=*)
+        SKIP_PATH=$(echo $key | cut -d '=' -f 2)
+        ;;
+        -s|--skip-path)
+        SKIP_PATH=$2
+        shift
+        ;;        
+        -h|--help)
+        printf "%s\n" "$USAGE"
+        exit 0
+        shift
+        ;;
+        *)
+                # unknown option
+        ;;
+        esac
+        shift
 done
 
-if [ ! "$OUTPUT" ]
+if ! valid_algo $ALGO; then
 then
-    echo "Missing argument for -o" >&2;
-    echo "Usage: $0 -o [filename] -h [hash-algo]" >&2;
+    echo "Invalid hash function argument: pick from \"${ALGO_LIST[@]}\""
     exit 1
 fi
 
-
-# Where to look for initramfs image
-INITRAMFS_LOC="/boot/"
-if [ -d "/ostree" ]; then
-    # If we are on an ostree system change where we look for initramfs image
-    loc=$(grep -E "/ostree/[^/]([^/]*)" -o /proc/cmdline | head -n 1 | cut -d / -f 3)
-    INITRAMFS_LOC="/boot/ostree/${loc}/"
+if [[ -z $OUTPUT ]]
+then
+    printf "%s\n" "$USAGE"
+    exit 1
 fi
 
+rm -rf ${OUTPUT}_allowlist
+rm -rf ${OUTPUT}
 
-echo "Writing allowlist to $OUTPUT with $ALGO..."
+announce "Writing allowlist to $OUTPUT with $ALGO..."
 
+if [[ $BOOT_AGGREGATE_LOC != "none" ]]
+then
+    announce "    Adding boot agregate from $BOOT_AGGREGATE_LOC on allowlist $OUTPUT..."
 # Add boot_aggregate from /sys/kernel/security/ima/ascii_runtime_measurements (IMA Log) file.
 # The boot_aggregate measurement is always the first line in the IMA Log file.
 # The format of the log lines is the following:
 #     <PCR_ID> <PCR_Value> <IMA_Template> <File_Digest> <File_Name> <File_Signature>
 # File_Digest may start with the digest algorithm specified (e.g "sha1:", "sha256:") depending on the template used.
-head -n 1 /sys/kernel/security/ima/ascii_runtime_measurements | awk '{ print $4 "  boot_aggregate" }' | sed 's/.*://' >> $OUTPUT
+    head -n 1 $BOOT_AGGREGATE_LOC | awk '{ print $4 "  boot_aggregate" }' | sed 's/.*://' >> ${OUTPUT}_allowlist
+else
+    announce "    Skipping boot aggregate..."
+fi
 
+announce "    Adding all appropriate files from $ROOTFS_LOC on allowlist $OUTPUT..."
 # Add all appropriate files under root FS to allowlist
-cd /
-find `ls / | grep -v "\bsys\b\|\brun\b\|\bproc\b\|\blost+found\b\|\bdev\b\|\bmedia\b\|\bsnap\b\|mnt"` \( -fstype rootfs -o -xtype f -type l -o -type f \) -uid 0 -exec $ALGO '/{}' >> $OUTPUT \;
+pushd $ROOTFS_LOC > /dev/null 2>&1
+ls . | wc -l
+BASE_EXCLUDE_DIRS="\bsys\b\|\brun\b\|\bproc\b\|\blost+found\b\|\bdev\b\|\bmedia\b\|\bsnap\b\|\bmnt\b\|\bvar\b\|\btmp\b"
+ROOTFS_FILE_LIST=$(ls | grep -v $BASE_EXCLUDE_DIRS)
+if [[ $SKIP_PATH != "none" ]]
+then
+    SKIP_PATH=$(echo $SKIP_PATH | sed -e "s#^$ROOTFS_LOC##g" -e "s#,$ROOTFS_LOC##g" -e "s#,#\\\|#g")
+    ROOTFS_FILE_LIST=$(echo "$ROOTFS_FILE_LIST" | grep -v "$SKIP_PATH")
+fi
+find $ROOTFS_FILE_LIST \( -fstype rootfs -o -xtype f -type l -o -type f \) -uid 0 -exec $ALGO "$ROOTFS_LOC/{}" >> ${OUTPUT}_allowlist \;
+popd > /dev/null 2>&1
 
 # Create staging area for init ram images
-rm -rf /tmp/ima/
-mkdir -p /tmp/ima
+rm -rf $INITRAMFS_STAGING_DIR
+mkdir -p $INITRAMFS_STAGING_DIR
 
-# Iterate through init ram disks and add files to allowlist
-echo "Creating allowlist for init ram disk"
-for i in `ls ${INITRAMFS_LOC}/initr*`
-do
-    echo "extracting $i"
-    mkdir -p /tmp/ima/$i-extracted
-    cd /tmp/ima/$i-extracted
-
-    # platform-specific handling of init ram disk images
-    if [[ `command -v unmkinitramfs` ]] ; then
-        mkdir -p /tmp/ima/$i-extracted-unmk
-        unmkinitramfs $i /tmp/ima/$i-extracted-unmk
-        if [[ -d "/tmp/ima/$i-extracted-unmk/main/" ]] ; then
-            cp -r /tmp/ima/$i-extracted-unmk/main/. /tmp/ima/$i-extracted
-        else
-            cp -r /tmp/ima/$i-extracted-unmk/. /tmp/ima/$i-extracted
-        fi
-    elif [[ -x "/usr/lib/dracut/skipcpio" ]] ; then
-        /usr/lib/dracut/skipcpio $i | gunzip -c | cpio -i -d 2> /dev/null
-    else
-        echo "ERROR: No tools for initramfs image processing found!"
-        break
+if [[ $INITRAMFS_LOC != "none" ]]
+then
+    # Where to look for initramfs image
+    if [[ -d "/ostree" ]] 
+    then
+        X=$INITRAMFS_LOC
+        # If we are on an ostree system change where we look for initramfs image
+        loc=$(grep -E "/ostree/[^/]([^/]*)" -o /proc/cmdline | head -n 1 | cut -d / -f 3)
+        INITRAMFS_LOC="/boot/ostree/${loc}/"
+        announce "    The location of initramfs was overrode from \"${X}\" to \"$INITRAMFS_LOC\""
     fi
 
-    find -type f -exec $ALGO "./{}" \; | sed "s| \./\./| /|" >> $OUTPUT
-done
+    announce "     Creating allowlist for init ram disks found under \"$INITRAMFS_LOC\"..."
+    for i in $(ls ${INITRAMFS_LOC}/initr* 2> /dev/null)
+    do
+        announce "            extracting $i"
+        mkdir -p $INITRAMFS_STAGING_DIR/$i-extracted
+        cd $INITRAMFS_STAGING_DIR/$i-extracted
+
+        # platform-specific handling of init ram disk images
+        if [[ `command -v unmkinitramfs` ]] ; then
+            mkdir -p $INITRAMFS_STAGING_DIR/$i-extracted-unmk
+            unmkinitramfs $i $INITRAMFS_STAGING_DIR/$i-extracted-unmk
+            if [[ -d "$INITRAMFS_STAGING_DIR/$i-extracted-unmk/main/" ]] ; then
+                cp -r $INITRAMFS_STAGING_DIR/$i-extracted-unmk/main/. /tmp/ima/$i-extracted
+            else
+                cp -r $INITRAMFS_STAGING_DIR/$i-extracted-unmk/. /tmp/ima/$i-extracted
+            fi
+        elif [[ -x "/usr/lib/dracut/skipcpio" ]] ; then
+            /usr/lib/dracut/skipcpio $i | gunzip -c | cpio -i -d 2> /dev/null
+        else
+            echo "ERROR: No tools for initramfs image processing found!"
+            break
+        fi
+
+        find -type f -exec $ALGO "./{}" \; | sed "s| \./\./| /|" >> ${OUTPUT}_allowlist
+    done
+fi
+
+# A bit of cleanup on the resulting file (among other problems, sha256sum might output a hash with the prefix '//')
+sed -i "s^ //^ /^g"  ${OUTPUT}_allowlist 
+sed -i 's^"\\\\^"^g' ${OUTPUT}_allowlist
 
 # Convert to runtime policy
-echo "Converting created allowlist to Keylime runtime policy"
-python3 $WORKING_DIR/../keylime/cmd/convert_runtime_policy.py -a $OUTPUT -o $OUTPUT
+announce "Converting created allowlist to Keylime runtime policy"
+CONVERT_CMD_OPTS="--allowlist ${OUTPUT}_allowlist --output_file $OUTPUT"
+
+[ -f $EXCLUDE_LIST ] && CONVERT_CMD_OPTS="$CONVERT_CMD_OPTS --excludelist $EXCLUDE_LIST"
+
+python3 $WORKING_DIR/../keylime/cmd/convert_runtime_policy.py $CONVERT_CMD_OPTS
 
 # Clean up
-rm -rf /tmp/ima
+rm -rf $INITRAMFS_STAGING_DIR


### PR DESCRIPTION
In addition to introducing parametrization for all paths, there is now the possibility for the user to supply an exclude list (-e/--exclude_list), which will be automatically incorporated into the policy

Usage: /KL/keylime/scripts/create_runtime_policy.sh -o/output_file FILENAME [-a/--algo ALGO] [-x/--ramdisk-location PATH] [-y/--boot_aggregate-location PATH] [-z/--rootfs-location PATH] [-e/--exclude_list FILENAME] [-s/--skip-path PATH]" optional arguments:
    -a/--algo (default sha1sum)
    -x/--ramdisk-location (default /boot/, set to "none" to skip)
    -y/--boot_aggregate-location (default
/sys/kernel/security/ima/ascii_runtime_measurements, set to "none" to skip)
    -z/--rootfs-location (default /, cannot be skipped)
    -e/--exclude_list (default none)
    -s/--skip-path (default none)

Not extensively tested (and AFAIK, not part of the testing CI)