### PR TITLE
tests: Disable Packit CI on Rawhide due to infra issues

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,6 +3,6 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-all
+    - fedora-branched
     - centos-stream-9-x86_64
     skip_build: true


### PR DESCRIPTION
dnf5 used in Rawhide doesnt work well with the Testing Farm infrastructure and therefore we need to disable testing on Rawhide temporarily.