### PR TITLE
create_runtime_policy: fix bash typo

### DIFF
--- a/scripts/create_runtime_policy.sh
+++ b/scripts/create_runtime_policy.sh
@@ -142,7 +142,7 @@ do
         shift
 done
 
-if ! valid_algo $ALGO; then
+if ! valid_algo $ALGO
 then
     echo "Invalid hash function argument: pick from \"${ALGO_LIST[@]}\""
     exit 1


### PR DESCRIPTION
Remove extra "then" missed during review.

Fix #1424