### PR TITLE
Changes to script create_runtime_policy.sh, fixes #1426

### DIFF
--- a/scripts/create_runtime_policy.sh
+++ b/scripts/create_runtime_policy.sh
@@ -4,6 +4,30 @@
 # Copyright 2017 Massachusetts Institute of Technology.
 ################################################################################
 
+
+if [ $0 != "-bash" ] ; then
+    pushd `dirname "$0"` > /dev/null 2>&1
+fi
+KCRP_BASE_DIR=$(pwd)
+if [ $0 != "-bash" ] ; then
+    popd 2>&1 > /dev/null
+fi
+KCRP_BASE_DIR=$KCRP_BASE_DIR/..
+
+function detect_hash {
+    local hashstr=$1
+
+    case "${#hashstr}" in
+      32) hashalgo=md5sum ;;
+      40) hashalgo=sha1sum ;;
+      64) hashalgo=sha256sum ;;
+      128) hashalgo=sha512sum ;;
+      *) hashalgo="na";;
+    esac
+
+    echo $hashalgo
+}
+
 function announce {
     # 1 - MESSAGE
 
@@ -23,14 +47,14 @@ function valid_algo {
 INITRAMFS_TOOLS_GIT=https://salsa.debian.org/kernel-team/initramfs-tools.git
 INITRAMFS_TOOLS_VER="master"
 
-WORKING_DIR=$(readlink -f "$0")
-WORKING_DIR=$(dirname "$WORKING_DIR")
-
 # All defaults
 ALGO=sha1sum
+WORK_DIR=/tmp/kcrp
+OUTPUT_DIR=${WORK_DIR}/output
+ALLOWLIST_DIR=${WORK_DIR}/allowlist
 INITRAMFS_LOC="/boot/"
-INITRAMFS_STAGING_DIR=/tmp/ima/
-INITRAMFS_TOOLS_DIR=/tmp/initramfs-tools
+INITRAMFS_STAGING_DIR=${WORK_DIR}/ima_ramfs/
+INITRAMFS_TOOLS_DIR=${WORK_DIR}/initramfs-tools
 BOOT_AGGREGATE_LOC="/sys/kernel/security/ima/ascii_runtime_measurements"
 ROOTFS_LOC="/"
 EXCLUDE_LIST="none"
@@ -154,28 +178,36 @@ then
     exit 1
 fi
 
-rm -rf ${OUTPUT}_allowlist
-rm -rf ${OUTPUT}
+rm -rf $ALLOWLIST_DIR
+rm -rf $INITRAMFS_STAGING_DIR
+rm -rf $OUTPUT_DIR
 
-announce "Writing allowlist to $OUTPUT with $ALGO..."
+announce "Writing allowlist $ALLOWLIST_DIR/${OUTPUT} with $ALGO..."
+mkdir -p $ALLOWLIST_DIR
 
 if [[ $BOOT_AGGREGATE_LOC != "none" ]]
 then
-    announce "    Adding boot agregate from $BOOT_AGGREGATE_LOC on allowlist $OUTPUT..."
+    announce "--- Adding boot agregate from $BOOT_AGGREGATE_LOC on allowlist $ALLOWLIST_DIR/${OUTPUT} ..."
 # Add boot_aggregate from /sys/kernel/security/ima/ascii_runtime_measurements (IMA Log) file.
 # The boot_aggregate measurement is always the first line in the IMA Log file.
 # The format of the log lines is the following:
 #     <PCR_ID> <PCR_Value> <IMA_Template> <File_Digest> <File_Name> <File_Signature>
 # File_Digest may start with the digest algorithm specified (e.g "sha1:", "sha256:") depending on the template used.
-    head -n 1 $BOOT_AGGREGATE_LOC | awk '{ print $4 "  boot_aggregate" }' | sed 's/.*://' >> ${OUTPUT}_allowlist
+    head -n 1 $BOOT_AGGREGATE_LOC | awk '{ print $4 "  boot_aggregate" }' | sed 's/.*://' >> $ALLOWLIST_DIR/${OUTPUT}
+
+    bagghash=$(detect_hash $(cat $ALLOWLIST_DIR/${OUTPUT} | cut -d ' ' -f 1))
+    if [[ $ALGO != $bagghash ]]
+    then
+        announce "ERROR: \"boot aggregate\" has was calculated with $bagghash, but files will be calculated with $ALGO. Use option -a $bagghash"
+        exit 1
+    fi
 else
-    announce "    Skipping boot aggregate..."
+    announce "--- Skipping boot aggregate..."
 fi
 
-announce "    Adding all appropriate files from $ROOTFS_LOC on allowlist $OUTPUT..."
+announce "--- Adding all appropriate files from $ROOTFS_LOC on allowlist $ALLOWLIST_DIR/${OUTPUT} ..."
 # Add all appropriate files under root FS to allowlist
 pushd $ROOTFS_LOC > /dev/null 2>&1
-ls . | wc -l
 BASE_EXCLUDE_DIRS="\bsys\b\|\brun\b\|\bproc\b\|\blost+found\b\|\bdev\b\|\bmedia\b\|\bsnap\b\|\bmnt\b\|\bvar\b\|\btmp\b"
 ROOTFS_FILE_LIST=$(ls | grep -v $BASE_EXCLUDE_DIRS)
 if [[ $SKIP_PATH != "none" ]]
@@ -183,11 +215,10 @@ then
     SKIP_PATH=$(echo $SKIP_PATH | sed -e "s#^$ROOTFS_LOC##g" -e "s#,$ROOTFS_LOC##g" -e "s#,#\\\|#g")
     ROOTFS_FILE_LIST=$(echo "$ROOTFS_FILE_LIST" | grep -v "$SKIP_PATH")
 fi
-find $ROOTFS_FILE_LIST \( -fstype rootfs -o -xtype f -type l -o -type f \) -uid 0 -exec $ALGO "$ROOTFS_LOC/{}" >> ${OUTPUT}_allowlist \;
+find $ROOTFS_FILE_LIST \( -fstype rootfs -o -xtype f -type l -o -type f \) -uid 0 -exec $ALGO "$ROOTFS_LOC/{}" >> $ALLOWLIST_DIR/${OUTPUT} \;
 popd > /dev/null 2>&1
 
 # Create staging area for init ram images
-rm -rf $INITRAMFS_STAGING_DIR
 mkdir -p $INITRAMFS_STAGING_DIR
 
 if [[ $INITRAMFS_LOC != "none" ]]
@@ -199,10 +230,10 @@ then
         # If we are on an ostree system change where we look for initramfs image
         loc=$(grep -E "/ostree/[^/]([^/]*)" -o /proc/cmdline | head -n 1 | cut -d / -f 3)
         INITRAMFS_LOC="/boot/ostree/${loc}/"
-        announce "    The location of initramfs was overrode from \"${X}\" to \"$INITRAMFS_LOC\""
+        announce "--- The location of initramfs was overriden from \"${X}\" to \"$INITRAMFS_LOC\""
     fi
 
-    announce "     Creating allowlist for init ram disks found under \"$INITRAMFS_LOC\"..."
+    announce "--- Creating allowlist for init ram disks found under \"$INITRAMFS_LOC\" to $ALLOWLIST_DIR/${OUTPUT} ..."
     for i in $(ls ${INITRAMFS_LOC}/initr* 2> /dev/null)
     do
         announce "            extracting $i"
@@ -221,25 +252,31 @@ then
         elif [[ -x "/usr/lib/dracut/skipcpio" ]] ; then
             /usr/lib/dracut/skipcpio $i | gunzip -c | cpio -i -d 2> /dev/null
         else
-            echo "ERROR: No tools for initramfs image processing found!"
-            break
+            announce "ERROR: No tools for initramfs image processing found!"
+            exit 1
         fi
 
-        find -type f -exec $ALGO "./{}" \; | sed "s| \./\./| /|" >> ${OUTPUT}_allowlist
+        find -type f -exec $ALGO "./{}" \; | sed "s| \./\./| /|" >> $ALLOWLIST_DIR/${OUTPUT}
     done
 fi
 
-# A bit of cleanup on the resulting file (among other problems, sha256sum might output a hash with the prefix '//')
-sed -i "s^ //^ /^g"  ${OUTPUT}_allowlist 
-sed -i 's^"\\\\^"^g' ${OUTPUT}_allowlist
+# Non-critical cleanup on the resulting file (when ROOTFS_LOC = '/', the path starts on allowlist ends up with double '//' )
+sed -i "s^ //^ /^g"  $ALLOWLIST_DIR/${OUTPUT}
+# A bit of cleanup on the resulting file (among other problems, sha256sum might output a hash with the prefix '\\')
+sed -i "s/^\\\//g" $ALLOWLIST_DIR/${OUTPUT}
 
 # Convert to runtime policy
-announce "Converting created allowlist to Keylime runtime policy"
-CONVERT_CMD_OPTS="--allowlist ${OUTPUT}_allowlist --output_file $OUTPUT"
-
+mkdir -p $OUTPUT_DIR
+announce "Converting created allowlist ($ALLOWLIST_DIR/${OUTPUT}) to Keylime runtime policy ($OUTPUT_DIR/${OUTPUT}) ..."
+CONVERT_CMD_OPTS="--allowlist $ALLOWLIST_DIR/${OUTPUT} --output_file $OUTPUT_DIR/${OUTPUT}"
 [ -f $EXCLUDE_LIST ] && CONVERT_CMD_OPTS="$CONVERT_CMD_OPTS --excludelist $EXCLUDE_LIST"
 
-python3 $WORKING_DIR/../keylime/cmd/convert_runtime_policy.py $CONVERT_CMD_OPTS
-
-# Clean up
-rm -rf $INITRAMFS_STAGING_DIR
+pushd $KCRP_BASE_DIR  > /dev/null 2>&1
+export PYTHONPATH=$KCRP_BASE_DIR:$PYTHONPATH
+# only 3 dependencies required: pip3 install cryptography lark packaging
+python3 ./keylime/cmd/convert_runtime_policy.py $CONVERT_CMD_OPTS; echo " "
+if [[ $? -eq 0 ]]
+then
+    announce "Done, new runtime policy file present at ${OUTPUT_DIR}/$OUTPUT. It can be used on the tenant keylime host with \"keylime_tenant -c add --runtime-policy ${OUTPUT_DIR}/$OUTPUT <other options>"
+fi
+popd  > /dev/null 2>&1


### PR DESCRIPTION
In addition to that, automatically detects the algorithm used for boot aggregate (if one is specified) and exits with error if this differs from the one used with the -a/--algo option