### PR TITLE
tpm_util: Add the BSD license to the file due to functions from TPM 2 code

### DIFF
--- a/keylime/tpm/tpm_util.py
+++ b/keylime/tpm/tpm_util.py
@@ -1,3 +1,41 @@
+# Some of the functions in this file were adapted from Microsoft's TPM 2
+# reference implementation that states the following:
+#
+# Microsoft Reference Implementation for TPM 2.0
+#
+#  The copyright in this software is being made available under the BSD License,
+#  included below. This software may be subject to other third party and
+#  contributor rights, including patent rights, and no such rights are granted
+#  under this license.
+#
+#  Copyright (c) Microsoft Corporation
+#
+#  All rights reserved.
+#
+#  BSD License
+#
+#  Redistribution and use in source and binary forms, with or without modification,
+#  are permitted provided that the following conditions are met:
+#
+#  Redistributions of source code must retain the above copyright notice, this list
+#  of conditions and the following disclaimer.
+#
+#  Redistributions in binary form must reproduce the above copyright notice, this
+#  list of conditions and the following disclaimer in the documentation and/or
+#  other materials provided with the distribution.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ""AS IS""
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+#  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+#  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
 import os
 import string
 import struct


### PR DESCRIPTION
The functions to implement TPM2's MakeCredential were taken from the TPM 2 reference implementation that requires that the license and notices be kept but allows for distribution and creation of detrivative works.