### PR TITLE
codestyle: Fix access to possibly not available package 'rpm' (pyright)

### DIFF
--- a/keylime/cmd/create_policy.py
+++ b/keylime/cmd/create_policy.py
@@ -26,9 +26,8 @@ from cryptography.hazmat import backends
 try:
     import rpm
 
-    HAS_RPM = True
 except ModuleNotFoundError:
-    HAS_RPM = False
+    rpm = None
 
 from keylime.common import validators
 from keylime.ima import file_signatures, ima
@@ -218,6 +217,8 @@ def process_exclude_list_file(exclude_list_file: str, excludes: List[str]) -> Tu
 
 def analyze_rpm_pkg(pkg: PathLike_str) -> Dict[str, List[str]]:
     """Analyze a single RPM package."""
+    if rpm is None:
+        raise Exception("rpm module is not available")
     ts = rpm.TransactionSet()
     ts.setVSFlags(rpm.RPMVSF_MASK_NOSIGNATURES | rpm.RPMVSF_MASK_NODIGESTS)
 
@@ -238,6 +239,9 @@ def analyze_rpm_pkg_url(url: str) -> Dict[str, List[Any]]:
     # first a sizeable blob, adjusted from the median of some repo
     # analysis, and if the hdrFromFdno fails, try to expand it
     # iteratively.
+
+    if rpm is None:
+        raise Exception("rpm module is not available")
 
     # Hide errors while fetching partial headers
     rpm.setLogFile(open(os.devnull, "wb"))  # pylint: disable=consider-using-with
@@ -535,7 +539,7 @@ def main() -> None:
     if ret:
         sys.exit(ret)
 
-    if (args.local_repo or args.remote_repo) and not HAS_RPM:
+    if (args.local_repo or args.remote_repo) and rpm is None:
         print('To analyze RPM repositories the "rpm" Python module is required', file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
Initialize an rpm variable in case the rpm module could not be imported and replace HAS_RPM with it. This fixes the following newly detected issues reported by pyright (false positives):

/home/stefanb/keylime/keylime/cmd/create_policy.py
  /home/stefanb/keylime/keylime/cmd/create_policy.py:221:10 - error: "rpm" is possibly unbound (reportUnboundVariable)
  /home/stefanb/keylime/keylime/cmd/create_policy.py:222:19 - error: "rpm" is possibly unbound (reportUnboundVariable)
  /home/stefanb/keylime/keylime/cmd/create_policy.py:222:50 - error: "rpm" is possibly unbound (reportUnboundVariable)
  /home/stefanb/keylime/keylime/cmd/create_policy.py:243:5 - error: "rpm" is possibly unbound (reportUnboundVariable)
  /home/stefanb/keylime/keylime/cmd/create_policy.py:259:18 - error: "rpm" is possibly unbound (reportUnboundVariable)
  /home/stefanb/keylime/keylime/cmd/create_policy.py:260:27 - error: "rpm" is possibly unbound (reportUnboundVariable)
  /home/stefanb/keylime/keylime/cmd/create_policy.py:260:58 - error: "rpm" is possibly unbound (reportUnboundVariable)