### PR TITLE
tpm_cert_store: add the Alibaba Cloud vTPM EK x509 cert

### DIFF
--- a/tpm_cert_store/Alibaba_Cloud_vTPM_EK.pem
+++ b/tpm_cert_store/Alibaba_Cloud_vTPM_EK.pem
@@ -1,0 +1,93 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2 (0x2)
+    Signature Algorithm: sha384WithRSAEncryption
+        Issuer: C=CN, O=Aliyun, OU=Aliyun TPM Root CA, CN=Aliyun TPM Root CA
+        Validity
+            Not Before: Sep 16 05:48:24 2021 GMT
+            Not After : Dec 31 23:59:59 2030 GMT
+        Subject: C=CN, O=Aliyun, OU=Aliyun TPM Endorsement Key Manufacture CA, CN=Aliyun TPM EKMF CA
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:e5:59:24:2b:c3:ac:32:47:71:76:11:bf:d3:c5:
+                    c3:05:13:07:81:a8:3a:4b:9a:c3:b4:7f:79:a9:bc:
+                    57:c0:4e:03:88:eb:df:50:02:14:89:9f:b9:d4:a7:
+                    bc:f6:34:2f:69:05:f4:1b:21:f4:71:cd:f0:5e:0b:
+                    0a:4e:bb:10:14:cd:17:46:8e:3f:26:3d:a9:80:cc:
+                    c9:4a:a5:4e:82:10:cf:08:4d:82:9b:5a:a0:b0:e4:
+                    be:62:a0:56:37:d0:cd:6d:35:85:97:94:e1:6b:ff:
+                    9f:ee:67:bc:d1:fc:f9:70:e7:53:bd:80:cb:ec:ad:
+                    86:c7:fd:a2:1a:b5:d8:3f:2e:ed:bc:1b:ec:d6:98:
+                    90:73:39:1f:fc:d5:9b:7f:29:e9:c0:d2:b2:83:bb:
+                    b0:ca:25:dd:dd:df:5e:ff:45:7e:d1:bf:7e:93:af:
+                    2d:75:d1:87:f0:7d:f4:b9:f7:46:bf:f4:e4:74:32:
+                    9a:0f:9a:0d:dc:43:a2:43:6c:9b:0d:58:1a:3c:6f:
+                    38:62:67:9a:f9:bc:2a:47:f6:03:b2:8b:48:41:25:
+                    39:85:57:c6:a5:84:4a:0d:b4:1d:19:e2:24:aa:6e:
+                    8f:6a:95:06:7d:60:4b:4e:cc:bf:6e:74:52:93:57:
+                    3a:b9:14:0e:85:54:35:2c:75:51:a5:44:7d:fe:21:
+                    e2:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            Authority Information Access: 
+                CA Issuers - URI:https://aliyun-tpm-ca.oss-cn-beijing.aliyuncs.com/pki001/root-ca.crt
+
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:https://aliyun-tpm-ca.oss-cn-beijing.aliyuncs.com/pki001/root-ca.crl
+
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Subject Key Identifier: 
+                81:AA:9A:64:92:88:FF:07:07:07:50:9A:CF:97:4E:FF:66:59:50:C8
+            X509v3 Authority Key Identifier: 
+                keyid:58:33:7A:9C:D0:E8:C3:61:21:67:43:91:3E:FC:21:7D:63:81:9B:1D
+
+    Signature Algorithm: sha384WithRSAEncryption
+         9e:03:04:94:17:88:9c:8f:23:81:9a:95:c3:21:2d:9e:6e:6c:
+         e3:18:08:7c:2d:aa:2c:dd:87:1d:0a:30:a9:7f:1f:76:83:37:
+         a8:b6:d4:8e:d9:68:b8:e6:53:45:e6:5b:41:d1:35:34:11:21:
+         04:95:13:b7:23:06:e2:e8:4f:18:22:49:cc:aa:e0:b9:9c:ed:
+         c6:72:93:c7:07:ae:bb:3b:93:19:d4:b8:66:bf:1d:03:82:cd:
+         e3:ec:e0:0a:ba:2b:a7:77:b0:fa:11:1b:84:e6:ed:08:0b:32:
+         dc:be:4a:70:d9:b7:39:62:16:e4:b7:52:5c:2a:94:d8:2a:fe:
+         55:f4:c7:62:66:fa:54:67:2c:7b:8f:70:d5:12:33:97:ae:cc:
+         ab:87:69:7d:66:4e:82:1b:e0:e9:4f:6d:a4:52:1e:06:e9:83:
+         6e:a1:e0:5f:24:09:d6:37:60:0c:28:ec:cd:95:b0:6a:06:60:
+         5b:d2:0e:c9:2c:34:e1:4d:7c:1d:8c:ec:61:ce:e1:36:d7:90:
+         c0:44:b4:52:80:89:77:31:36:7d:73:dd:af:44:cc:97:81:5b:
+         07:ae:7f:f4:df:d8:b6:2f:1d:f3:65:de:f5:2f:c0:2a:26:de:
+         04:b9:f9:f3:ef:c4:97:37:67:b6:fc:f5:7b:e2:ca:fd:5c:82:
+         af:b1:50:1a
+-----BEGIN CERTIFICATE-----
+MIIEZDCCA0ygAwIBAgIBAjANBgkqhkiG9w0BAQwFADBYMQswCQYDVQQGEwJDTjEP
+MA0GA1UECgwGQWxpeXVuMRswGQYDVQQLDBJBbGl5dW4gVFBNIFJvb3QgQ0ExGzAZ
+BgNVBAMMEkFsaXl1biBUUE0gUm9vdCBDQTAgFw0yMTA5MTYwNTQ4MjRaGA8yMDMw
+MTIzMTIzNTk1OVowbzELMAkGA1UEBhMCQ04xDzANBgNVBAoMBkFsaXl1bjEyMDAG
+A1UECwwpQWxpeXVuIFRQTSBFbmRvcnNlbWVudCBLZXkgTWFudWZhY3R1cmUgQ0Ex
+GzAZBgNVBAMMEkFsaXl1biBUUE0gRUtNRiBDQTCCASIwDQYJKoZIhvcNAQEBBQAD
+ggEPADCCAQoCggEBAOVZJCvDrDJHcXYRv9PFwwUTB4GoOkuaw7R/eam8V8BOA4jr
+31ACFImfudSnvPY0L2kF9Bsh9HHN8F4LCk67EBTNF0aOPyY9qYDMyUqlToIQzwhN
+gptaoLDkvmKgVjfQzW01hZeU4Wv/n+5nvNH8+XDnU72Ay+ythsf9ohq12D8u7bwb
+7NaYkHM5H/zVm38p6cDSsoO7sMol3d3fXv9FftG/fpOvLXXRh/B99Ln3Rr/05HQy
+mg+aDdxDokNsmw1YGjxvOGJnmvm8Kkf2A7KLSEElOYVXxqWESg20HRniJKpuj2qV
+Bn1gS07Mv250UpNXOrkUDoVUNSx1UaVEff4h4ncCAwEAAaOCAR4wggEaMGAGCCsG
+AQUFBwEBBFQwUjBQBggrBgEFBQcwAoZEaHR0cHM6Ly9hbGl5dW4tdHBtLWNhLm9z
+cy1jbi1iZWlqaW5nLmFsaXl1bmNzLmNvbS9wa2kwMDEvcm9vdC1jYS5jcnQwVQYD
+VR0fBE4wTDBKoEigRoZEaHR0cHM6Ly9hbGl5dW4tdHBtLWNhLm9zcy1jbi1iZWlq
+aW5nLmFsaXl1bmNzLmNvbS9wa2kwMDEvcm9vdC1jYS5jcmwwDgYDVR0PAQH/BAQD
+AgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFIGqmmSSiP8HBwdQms+XTv9m
+WVDIMB8GA1UdIwQYMBaAFFgzepzQ6MNhIWdDkT78IX1jgZsdMA0GCSqGSIb3DQEB
+DAUAA4IBAQCeAwSUF4icjyOBmpXDIS2ebmzjGAh8Laos3YcdCjCpfx92gzeottSO
+2Wi45lNF5ltB0TU0ESEElRO3Iwbi6E8YIknMquC5nO3GcpPHB667O5MZ1Lhmvx0D
+gs3j7OAKuiund7D6ERuE5u0ICzLcvkpw2bc5Yhbkt1JcKpTYKv5V9MdiZvpUZyx7
+j3DVEjOXrsyrh2l9Zk6CG+DpT22kUh4G6YNuoeBfJAnWN2AMKOzNlbBqBmBb0g7J
+LDThTXwdjOxhzuE215DARLRSgIl3MTZ9c92vRMyXgVsHrn/039i2Lx3zZd71L8Aq
+Jt4Eufnz78SXN2e2/PV74sr9XIKvsVAa
+-----END CERTIFICATE-----


### PR DESCRIPTION
Adding the Alibaba Cloud vTPM EK Cert to the tpm_cert_store directory can reduce the need for users to manually import certificates when using keylime on Alibaba Cloud, making it more user-friendly.

Besides, the Alibaba Cloud vTPM EK x509 cert can be downloaded at https://aliyun-tpm-ca.oss-cn-beijing.aliyuncs.com/pki001/ekmf-ca.crt

Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>