### PR TITLE
ima: Emit a warning when a file signature could not be parsed

### DIFF
--- a/keylime/ima/ast.py
+++ b/keylime/ima/ast.py
@@ -95,7 +95,7 @@ class Signature(HexData):
         _, _, _, _, sig_size = struct.unpack(fmt, self.data[:hdrlen])
 
         if hdrlen + sig_size != len(self.data):
-            raise ParserError("Invalid signature: malformed header")
+            raise ParserError(f"Invalid signature: malformed header ({hdrlen} + {sig_size} != {len(self.data)})")
 
 
 class Buffer(HexData):
@@ -269,8 +269,9 @@ class ImaSig(Mode):
         """Create the Signature object if the hexstring is a valid signature"""
         try:
             return Signature(hexstring)
-        except ParserError:
-            pass
+        except ParserError as e:
+            if hexstring:
+                logger.error("Failed to parse signature %s : %s", hexstring, e)
         return None
 
     def bytes(self) -> bytes:

--- a/test/test_ima_verification.py
+++ b/test/test_ima_verification.py
@@ -87,6 +87,9 @@ SIGNATURES = (
 
 COMBINED = MEASUREMENTS + SIGNATURES
 
+# Malformatted signature with bad size indicator
+BAD_SIGNATURES = "10 5d4d5141ccd5066d50dc3f21d79ba02fedc24256 ima-sig sha256:b8ae0b8dd04a5935cd8165aa2260cd11b658bd71629bdb52256a675a1f73907b /usr/bin/zmore 030204531f402548003046022100fe24678d21083ead47660e1a2d553a592d777c478d1b0466de6ed484b54956b3022100cad3adb37f277bbb03544d6107751b4cd4f2289d8353fa36257400a99334d5c3\n"
+
 KEYRINGS = "10 978351440c6c8a17568f0c366b9ede28efd14f8c ima-buf sha256:a7d52aaa18c23d2d9bb2abb4308c0eeee67387a42259f4a6b1a42257065f3d5a .ima 308201d130820178a003020102020101300906072a8648ce3d0401301b3119301706035504030c1054657374696e672d45434453412d4341301e170d3231303631313133353831365a170d3232303631313133353831365a3021311f301d06035504030c1665636473612d63612d7369676e65642d65632d6b65793059301306072a8648ce3d020106082a8648ce3d030107034200044ce55be36765b59de2767f6d6721be8bea8e3db4ccc25ab76c30f5d1c11752ae1699cc39d31b378f69fecbe65ce1eb09e075f840fe4c052bafb9039742b76202a381a73081a430090603551d1304023000301d0603551d0e04160414b6fb3c083d19695be441c5f59afb95742cb6058c30560603551d23044f304d80140a51da379e45bd7ac623c3f765b53e1e2dde5195a11fa41d301b3119301706035504030c1054657374696e672d45434453412d434182142bb351b0d645e4d8594316ac3c96fc6d9c83791530130603551d25040c300a06082b06010505070302300b0603551d0f040403020780300906072a8648ce3d04010348003045022033d47b623c9feefab7d6e68b001ac6463433f99b61ce7b951a32da065a5d17af022100f3d73e38070053aec63a941ed36ae0dcfa25ed9cd538c459732a7e782132a4ca"
 
 # END TEST DATA
@@ -258,6 +261,20 @@ class TestIMAVerification(unittest.TestCase):
             ima_keyrings=ima_keyrings,
         )
         self.assertTrue(not failure)
+
+        # The signature is malformatted and the file is in the exclude list -> this must not pass
+        ima_keyrings.set_tenant_keyring(empty_keyring)
+        _, failure = ima.process_measurement_list(
+            AgentAttestState("1"), BAD_SIGNATURES.splitlines(), RUNTIME_POLICY_WITH_EXCLUDES, ima_keyrings=ima_keyrings
+        )
+        self.assertTrue(failure)
+
+        # The signature is malformatted and the file is in the accept list -> this must not pass
+        ima_keyrings.set_tenant_keyring(empty_keyring)
+        _, failure = ima.process_measurement_list(
+            AgentAttestState("1"), BAD_SIGNATURES.splitlines(), RUNTIME_POLICY_TEST, ima_keyrings=ima_keyrings
+        )
+        self.assertTrue(failure)
 
     def test_read_allowlist(self):
         """Test reading and processing of the IMA allow-list"""


### PR DESCRIPTION
CentOS currently has file signatures where the signature length indicator seems to be written in little endian. A failure to parse the length indicator causes Keylime to silently discard the signature and the result then is that the pcr template hash is not calculated correctly for the file and the running hash becomes wrong and one ends up with this error message in the log:

IMA measurement list does not match TPM PCR f5e0272e4....

Log the failure if a non zero-length signature was attempted to be parsed.

Resolves: https://github.com/keylime/keylime/issues/1462