### PR TITLE
Fix an inappropriate test expression to remove a logical short circuit

### DIFF
--- a/keylime/web_util.py
+++ b/keylime/web_util.py
@@ -413,7 +413,7 @@ def get_restful_params(urlstring: str) -> Dict[str, Union[str, None]]:
 
     # If first token looks like an API version, validate it and make sure it's supported
     api_version = "0"
-    if path_tokens[0] and len(path_tokens[0]) >= 0 and re.match(r"^v?[0-9]+(\.[0-9]+)?", path_tokens[0]):
+    if path_tokens[0] and re.match(r"^v?[0-9]+(\.[0-9]+)?", path_tokens[0]):
         version = keylime_api_version.normalize_version(path_tokens[0])
 
         if keylime_api_version.is_supported_version(version):


### PR DESCRIPTION
In file: web_util.py, the comparison of Collection length creates a logical short circuit. I suggested that the Collection length comparison should be done without creating a logical short circuit. 

Per feedback, I removed the test expression that was creating the logical short circuit.

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.