### PR TITLE
Fix for key parse error in tpm2_objects

### DIFF
--- a/keylime/tpm/tpm2_objects.py
+++ b/keylime/tpm/tpm2_objects.py
@@ -285,10 +285,13 @@ def pubkey_parms_from_tpm2b_public(
     (_, sym_parms) = _extract_tpm2b(public[8:])
     # Ignore the non-asym-alg parameters
     (sym_alg,) = struct.unpack(">H", sym_parms[0:2])
+    (scheme_alg,) = struct.unpack(">H", sym_parms[2:4])
     # Ignore the sym_mode and keybits (4 bytes), possibly symmetric (2) and sign
     #  scheme (2)
-    to_skip = 4 + 2  # sym_mode, keybits and sign scheme
+    to_skip = 4  # sym_mode, keybits
     if sym_alg != TPM2_ALG_NULL:
+        to_skip = to_skip + 2
+    if scheme_alg != TPM2_ALG_NULL:
         to_skip = to_skip + 2
     asym_parms = sym_parms[to_skip:]
 

--- a/keylime/tpm/tpm2_objects_test.py
+++ b/keylime/tpm/tpm2_objects_test.py
@@ -262,6 +262,21 @@ class TestTpm2Objects(unittest.TestCase):
         self.assertEqual(new_ec_pubkey_n.x, correct_ec_pubkey_n.x)
         self.assertEqual(new_ec_pubkey_n.y, correct_ec_pubkey_n.y)
 
+    def test_pubkey_from_tpm2b_public_rsa_2(self) -> None:
+        # This key has Null set for the RSA scheme algorithm
+        test_pubkey_bytes = base64.b64decode(
+            "ATYAAQALAAQA8gAgrWs6IoT9aYoHEL9cwbm98V4lMuP2AfpLk6ao+o3leeoAEAAQCA"
+            "AAAAAAAQCUcktf2f6TOoVE94USfvExBIRumw5AOD2ahxDLXvYgTZoCEfIo4B1y/9o5"
+            "4aKs8eclm1ez1huCcSklaI07MQnSFv+YgmMsmGd9CQNe0b5uL9nGXDDHVEUeRERj/i"
+            "ZU82KEiXMYGs/8RfocrdFihsSKD/Xmgary+HU1HwkxWWPHYtFRLTlQgrqKJ1CckUaf"
+            "BHKyWvjjRLEhZC0YOZWAtbGN3bOJZ3FzBV21lx7e7RsBxBwUhQrRPbWh6UTb/lKBn8"
+            "pQgRLqb/wB5m99O7HzpKIy/trAQDnalPg2izgt7MByesMwTpJ0KGlwo69xus/UaE9a"
+            "apMZTnYR6W2mM2H6vrKl"
+        )
+        new_rsa_pubkey, name_alg = pubkey_parms_from_tpm2b_public(test_pubkey_bytes)
+        self.assertIsInstance(new_rsa_pubkey, rsa.RSAPublicKey)
+        self.assertEqual(name_alg, TPM_ALG_SHA256)
+
     def test_pubkey_from_tpm2b_public_ec_without_encryption(self) -> None:
         new_ec_pubkey = pubkey_from_tpm2b_public(
             bytes.fromhex(


### PR DESCRIPTION
Currently if a tpm key uses a Null scheme `pubkey_parms_from_tpm2b_public()` from `tpm2_objects.py` returns `Error: Misparsed either modulus or keybits` when processing the key. This is because too much is being skipped  when the scheme algorithm is null.

This is fixed by checking for the scheme and only skipping if not null.

Resolves: [Issue 1471](https://github.com/keylime/keylime/issues/1471)