### PR TITLE
remove prov_db_filename from config

### DIFF
--- a/keylime.conf
+++ b/keylime.conf
@@ -625,10 +625,6 @@ database_pool_sz_ovfl=5,10
 
 auto_migrate_db = True
 
-
-# The file to use for SQLite persistence of provider hypervisor data.
-prov_db_filename = provider_reg_data.sqlite
-
 # Durable Attestation is currently marked as an experimental feature
 # In order to enable Durable Attestation, an "adapter" for a Persistent data Store 
 # (time-series like database) needs to be specified. Some example adapters can be 

--- a/templates/2.0/mapping.json
+++ b/templates/2.0/mapping.json
@@ -590,11 +590,6 @@
                 "option": "auto_migrate_db",
                 "default": "True"
             },
-            "prov_db_filename": {
-                "section": "registrar",
-                "option": "prov_db_filename",
-                "default": "provider_reg_data.sqlite"
-            },
             "durable_attestation_import" : {
                 "section": "registrar",
                 "option": "durable_attestation_import",

--- a/templates/2.0/registrar.j2
+++ b/templates/2.0/registrar.j2
@@ -69,9 +69,6 @@ database_pool_sz_ovfl = {{ registrar.database_pool_sz_ovfl }}
 # Whether to automatically update the DB schema using alembic
 auto_migrate_db = {{ registrar.auto_migrate_db }}
 
-# The file to use for SQLite persistence of provider hypervisor data.
-prov_db_filename: {{ registrar.prov_db_filename }}
-
 # Durable Attestation is currently marked as an experimental feature
 # In order to enable Durable Attestation, an "adapter" for a Persistent data Store 
 # (time-series like database) needs to be specified. Some example adapters can be 


### PR DESCRIPTION
The database was introduced as part of the original layered architecture (ref Fig.3
https://github.com/keylime/keylime/raw/master/docs/old/tci-acm.pdf) to record instances registered with the "Provider Registrar". However, with 605bba0e46e7db9fea0b2ad7d97e67604535fb14, both provider and vTPMs are no longer supported on Keylime.
The usage of 'prov_db_filename' from the config got dropped when the DB was ported to SQLAlchemy 4d8d8cd9acc8bc929af8bef0d4fca7b8a47b8d24 and the last remaining artifact was nuked as part of the style fixes be07edb59517dfd4e335ec356b0ca531e0e294af.

Fixes #1465