### PR TITLE
test-requirements: remove types-atomicwrites

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,6 @@ dbus-python
 # packages required for mypy
 sqlalchemy-stubs
 typed-ast
-types-atomicwrites
 types-python-dateutil
 types-PyYAML
 types-redis


### PR DESCRIPTION
`types-atomicwrites` is archived and deprecated (refer https://github.com/python/mypy/pull/14265 and
https://github.com/python/typeshed/pull/8925)