### PR TITLE
types: Fix a deprecation warning from recent cryptography

### DIFF
--- a/keylime/types.py
+++ b/keylime/types.py
@@ -3,10 +3,15 @@ import sys
 import typing
 
 try:
-    # The following only exists with python-cryptography v37.0.x
-    from cryptography.hazmat.primitives.asymmetric.types import CERTIFICATE_PRIVATE_KEY_TYPES as cpke
+    # The following only exists with python-cryptography v40.0.x
+    from cryptography.hazmat.primitives.asymmetric.types import CertificateIssuerPrivateKeyTypes as cpke
 except ImportError:
-    cpke = typing.Any  # type: ignore
+    # fall back to older version
+    try:
+        # The following only exists with python-cryptography v37.0.x
+        from cryptography.hazmat.primitives.asymmetric.types import CERTIFICATE_PRIVATE_KEY_TYPES as cpke
+    except ImportError:
+        cpke = typing.Any  # type: ignore
 
 CERTIFICATE_PRIVATE_KEY_TYPES = cpke
 


### PR DESCRIPTION
Fix the following deprecation warning by importing a more recent type if possible, otherwise fall back to the older type.

/usr/local/lib/python3.12/site-packages/keylime/types.py:7: \
    CryptographyDeprecationWarning: Use CertificateIssuerPrivateKeyTypes instead
  from cryptography.hazmat.primitives.asymmetric.types import CERTIFICATE_PRIVATE_KEY_TYPES as cpke