### PR TITLE
Add require_allow_list_signature to the verfier config file

### DIFF
--- a/keylime/dsse/dsse.py
+++ b/keylime/dsse/dsse.py
@@ -63,7 +63,7 @@ def b64dec(m_str: str) -> bytes:
         try:
             decoded = base64.b64decode(m, validate=True)
         except binascii.Error:
-            decoded = base64.b64decode(m, altchars="-_", validate=True)  # type: ignore
+            decoded = base64.b64decode(m, altchars="-_", validate=True)
     return decoded
 
 

--- a/keylime/ima/ima.py
+++ b/keylime/ima/ima.py
@@ -501,6 +501,11 @@ def verify_runtime_policy(
     except Exception as error:
         raise ImaValidationError(message="Runtime policy is not valid JSON!", code=400) from error
 
+    if verify_sig and not runtime_policy_key:
+        raise ImaValidationError(
+            message="Runtime policy signature verification required but no key was given!", code=401
+        )
+
     # detect if runtime policy is DSSE
     if runtime_policy_json.get("payload"):
         if verify_sig:

--- a/keylime/ima/ima.py
+++ b/keylime/ima/ima.py
@@ -509,6 +509,9 @@ def verify_runtime_policy(
             logger.info("Runtime policy passed DSSE signature verification")
         else:
             runtime_policy = dsse.b64dec(runtime_policy_json["payload"])
+    else:
+        if verify_sig:
+            raise ImaValidationError(message="Runtime policy is not signed!", code=400)
 
     # Validate exclude list contains valid regular expressions
     _, excl_err_msg = validators.valid_exclude_list(runtime_policy_json.get("exclude"))

--- a/templates/2.0/mapping.json
+++ b/templates/2.0/mapping.json
@@ -342,7 +342,7 @@
             "require_allow_list_signatures": {
                 "section": "cloud_verifier",
                 "option": "require_allow_list_signatures",
-                "default": "True"
+                "default": "False"
             },
             "durable_attestation_import" : {
                 "section": "cloud_verifier",

--- a/templates/2.1/mapping.json
+++ b/templates/2.1/mapping.json
@@ -372,7 +372,7 @@
             "require_allow_list_signatures": {
                 "section": "verifier",
                 "option": "require_allow_list_signatures",
-                "default": "True"
+                "default": "False"
             },
             "durable_attestation_import": {
                 "section": "verifier",

--- a/templates/2.2/mapping.json
+++ b/templates/2.2/mapping.json
@@ -7,6 +7,11 @@
                 "ima_ml_path": "default",
                 "measuredboot_ml_path": "default"
             }
+        },
+        "verifier": {
+            "add" : {
+                "require_allow_list_signatures": "False"
+            }
         }
     }
 }

--- a/templates/2.2/verifier.j2
+++ b/templates/2.2/verifier.j2
@@ -223,6 +223,9 @@ transparency_log_sign_algo = {{ verifier.transparency_log_sign_algo }}
 # will mean no signing should be done.
 signed_attributes = {{ verifier.signed_attributes }}
 
+# Require that allowlists are signed with a key passed via the tenant tool
+require_allow_list_signatures = {{ verifier.require_allow_list_signatures }}
+
 [revocations]
 
 # List of revocation notification methods to enable.


### PR DESCRIPTION
This PR adds the require_allow_list_signature config option to the verifier config file but sets it to 'False' on default. Also, when signatures are required, raise an error if a plain runtime policy is being used that doesn't have the 'payload' key in its map (The payload key in the signed policy contains the b64 encoded actual runtime policy).

Fixes: #1314
Resolves: #1464 