### PR TITLE
codestyle: Have mypy ignore import of PoolManager

### DIFF
--- a/keylime/requests_client.py
+++ b/keylime/requests_client.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional
 
 import requests
 from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter
-from requests.packages.urllib3.poolmanager import PoolManager  # pylint: disable=import-error
+from requests.packages.urllib3.poolmanager import PoolManager  # type: ignore  # pylint: disable=import-error
 
 
 class RequestsClient:


### PR DESCRIPTION
Tox reports the following error message:

mypy: commands[0]> mypy keylime/
keylime/requests_client.py:6: error: Library stubs not installed for "requests.packages.urllib3.poolmanager"  [import-untyped]
keylime/requests_client.py:6: note: Hint: "python3 -m pip install types-requests"
keylime/requests_client.py:6: note: (or run "mypy --install-types" to install all missing stub packages)
keylime/requests_client.py:6: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports

Resolve the issue by having mypy ignore the import.

Otherwise, none of the following could resolve the issue:
- Adding types-requests to requirements.txt followed by 'make check-rebuild'
- Adding 'python3 -m pip install types-requests' to tox.ini before 'mypy keylime/'