### PR TITLE
cert_utils: Ignore malformed certificate files

### DIFF
--- a/keylime/cert_utils.py
+++ b/keylime/cert_utils.py
@@ -80,7 +80,11 @@ def verify_cert(cert: Certificate, tpm_cert_store: str, cert_type: str = "") -> 
 
     try:
         for cert_file, pem_cert in trusted_certs.items():
-            signcert = x509_pem_cert(pem_cert)
+            try:
+                signcert = x509_pem_cert(pem_cert)
+            except Exception as err:
+                logger.warning("Ignoring certificate file %s due to error: %s", cert_file, str(err))
+                continue
             if cert.issuer != signcert.subject:
                 continue
 

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -32,9 +32,12 @@ def start_broker() -> None:
         raise Exception("install PyZMQ for 'zeromq' in 'enabled_revocation_notifications' option") from error
 
     def worker() -> None:
+        def sig_handler(*_: Any) -> None:
+            sys.exit(0)
+
         # do not receive signals form the parent process
         os.setpgrp()
-        signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+        signal.signal(signal.SIGTERM, sig_handler)
         dir_name = os.path.dirname(_SOCKET_PATH)
         if not os.path.exists(dir_name):
             os.makedirs(dir_name, 0o700)


### PR DESCRIPTION
Catch the exception when a malformed certificate file is read. Ignore it and print out a warning:

2023-11-03 12:00:51.919 - keylime.cert_utils - WARNING - \
  Ignoring certificate file /var/lib/keylime/tpm_cert_store/bundle.pem \
  due to error: Invalid base64-encoded string: number of data characters \
  (65) cannot be 1 more than a multiple of 4

Resolves: Issue #1081