### PR TITLE
Enable test functional/iak-idevid-register-with-certificates

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -66,6 +66,7 @@ adjust:
      - /functional/durable-attestion-sanity-on-localhost
      - /functional/ek-cert-use-ek_check_script
      - /functional/ek-cert-use-ek_handle-custom-ca_certs
+     - /functional/iak-idevid-register-with-certificates
      - /functional/install-rpm-with-ima-signature
      - /functional/keylime-non-default-ports
      - /functional/keylime_tenant-commands-on-localhost


### PR DESCRIPTION
The test is now merged.

The test recreates the IAK and IDevID keys out of band of the agent (using tpm2_tools), and sets up a CA to create certs for the keys. The agent attempts to register with the keys (checking the keys match the internal keys in the process) and fails when the CA has not been added as trusted, then succeeds when the CA is added.

[Testing repo PR](https://github.com/RedHat-SP-Security/keylime-tests/pull/514)