### PR TITLE
codestyle: Add type identifier to variable (pyright)

### DIFF
--- a/keylime/config.py
+++ b/keylime/config.py
@@ -226,7 +226,9 @@ def get_config(component: str) -> RawConfigParser:
                         raise Exception(f"Invalid component {component}")
 
                     for d in (x for x in CONFIG_SNIPPETS_DIRS[component] if os.path.exists(x)):
-                        snippets = sorted(filter(os.path.isfile, (os.path.join(d, f) for f in os.listdir(d) if f)))
+                        snippets: List[str] = sorted(
+                            filter(os.path.isfile, (os.path.join(d, f) for f in os.listdir(d) if f))
+                        )
                         applied_snippets = _config[component].read(snippets)
                         if applied_snippets:
                             base_logger.info("Applied configuration snippets from %s", d)


### PR DESCRIPTION
Add a type identifier to snippets to avoid the following pyright issue:

/home/stefanb/keylime/keylime/config.py
  /home/stefanb/keylime/keylime/config.py:230:68 - error: Argument of type \
      "list[int | str]" cannot be assigned to parameter "filenames" of type \
      "StrOrBytesPath | Iterable[StrOrBytesPath]" in function "read"
    Type "list[int | str]" cannot be assigned to type "StrOrBytesPath | Iterable[StrOrBytesPath]"
      "list[int | str]" is incompatible with "str"
      "list[int | str]" is incompatible with "bytes"
      "list[int | str]" is incompatible with protocol "PathLike[str]"
        "__fspath__" is not present
      "list[int | str]" is incompatible with protocol "PathLike[bytes]"
        "__fspath__" is not present
      "list[int | str]" is incompatible with "Iterable[StrOrBytesPath]"
    ... (reportGeneralTypeIssues)
1 error, 0 warnings, 0 informations