### PR TITLE
ca_impl_openssl: support CRL distribution point from config

### DIFF
--- a/keylime/ca_impl_openssl.py
+++ b/keylime/ca_impl_openssl.py
@@ -97,7 +97,7 @@ def mk_cacert(name: Optional[str] = None) -> Tuple[Certificate, RSAPrivateKey, R
             [
                 x509.DistributionPoint(
                     full_name=[
-                        x509.UniformResourceIdentifier("http://localhost/crl.pem"),
+                        x509.UniformResourceIdentifier(config.get("ca", "cert_crl_dist")),
                     ],
                     relative_name=None,
                     reasons=None,
@@ -161,7 +161,7 @@ def mk_signed_cert(
             [
                 x509.DistributionPoint(
                     full_name=[
-                        x509.UniformResourceIdentifier("http://localhost/crl.pem"),
+                        x509.UniformResourceIdentifier(config.get("ca", "cert_crl_dist")),
                     ],
                     relative_name=None,
                     reasons=None,

--- a/test/test_ca_impl_openssl.py
+++ b/test/test_ca_impl_openssl.py
@@ -2,8 +2,7 @@
 SPDX-License-Identifier: Apache-2.0
 Copyright 2017 Massachusetts Institute of Technology.
 """
-
-
+import os
 import sys
 import unittest
 from pathlib import Path
@@ -11,6 +10,7 @@ from pathlib import Path
 from cryptography import exceptions as crypto_exceptions
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from cryptography.x509 import CRLDistributionPoints
 
 from keylime import ca_impl_openssl
 
@@ -44,6 +44,33 @@ class OpenSSL_Test(unittest.TestCase):
         # Make sure serial number in cert is 4.
         self.assertIs(type(cert.serial_number), int)
         self.assertEqual(cert.serial_number, 4)
+
+    def test_openssl_crl_dist(self):
+        os.environ["KEYLIME_CA_CERT_CRL_DIST"] = "http://foobar.org"
+        _ = ca_impl_openssl.mk_cacert("my ca")
+        (ca_cert, ca_pk, _) = ca_impl_openssl.mk_cacert()
+        cert, _ = ca_impl_openssl.mk_signed_cert(ca_cert, ca_pk, "cert", 4)
+
+        pubkey = ca_cert.public_key()
+        assert isinstance(pubkey, RSAPublicKey)
+        assert cert.signature_hash_algorithm is not None
+        try:
+            pubkey.verify(
+                cert.signature,
+                cert.tbs_certificate_bytes,
+                padding.PKCS1v15(),
+                cert.signature_hash_algorithm,
+            )
+        except crypto_exceptions.InvalidSignature:
+            self.fail("Certificate signature validation failed.")
+
+        # Make sure serial number in cert is 4.
+        self.assertIs(type(cert.serial_number), int)
+        self.assertEqual(cert.serial_number, 4)
+        self.assertEqual(
+            cert.extensions.get_extension_for_class(CRLDistributionPoints).value[0].full_name[0].value,
+            os.environ["KEYLIME_CA_CERT_CRL_DIST"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Only "http://localhost/crl.pem" was used although the configuration is defining a setting for this
Signed-off-by: Karsten Ohme <karsten.ohme@ohmesoftware.de>