### PR TITLE
templates/2.1: Fix enable_iak_idevid in agent template

### DIFF
--- a/templates/2.1/agent.j2
+++ b/templates/2.1/agent.j2
@@ -179,7 +179,7 @@ ek_handle = "{{ agent.ek_handle }}"
 # iak_idevid_name_alg:        sha256, sm3_256, sha384, sha512
 # iak_idevid_template:        H-1, H-2, H-3, H-4, H-5
 # Leave template as "" in order to use asymmetric and name algorithm options
-enable_iak_idevid = "{{ agent.enable_iak_idevid }}"
+enable_iak_idevid = {{ agent.enable_iak_idevid }}
 iak_idevid_asymmetric_alg = "{{ agent.iak_idevid_asymmetric_alg }}"
 iak_idevid_name_alg = "{{ agent.iak_idevid_name_alg }}"
 iak_idevid_template = "{{ agent.iak_idevid_template }}"


### PR DESCRIPTION
The value in enable_iak_idevid in the agent template should not be surrounded by double quotes as it is a boolean value and not a string.