### PR TITLE
Detect template changes for IDevID - docs and template mappings

### DIFF
--- a/docs/user_guide/idevid_and_iak.rst
+++ b/docs/user_guide/idevid_and_iak.rst
@@ -38,9 +38,14 @@ For the agent to use its IDevID and IAK to register, the IAK and IDevID certific
 
 As with the registrar, the configuration options can either be set in the config file, ``agent.conf`` for the agent, or overridden using environment variables.
 
-Next, the functionality should be enabled by changing ``enable_iak_idevid`` to ``true``. Finally, the template used by the certificates needs to be specified. If the wrong template is chosen, the agent will fail to match the regenerated keys against the imported certificates and registration will fail.
+Next, the functionality should be enabled by changing ``enable_iak_idevid`` to ``true``. Finally, if using a standard template, the ``iak_idevid_template`` configuration option should be left with the default value ``detect``. This will cause the Keylime agent to detect what template was used from the imported certificates. With all this complete your agent should be ready to register using its IDevID and IAK.
 
-The template should be set using the ``iak_idevid_template`` configuration option. As an alternative, the ``iak_idevid_asymmetric_alg`` and ``iak_idevid_name_alg`` options are available to manually set the algorithms, but this is not recommended, and **these options are ignored** if ``iak_idevid_template`` has been set.
+.. note::
+    The following information can be used to manually set either the template or the individual algorithms and should not be required for the majority of users. The detect function mentioned above should be used instead.
+
+The template used by the certificates can also be manually specified. If the wrong template is chosen, the agent will fail to match the regenerated keys against the imported certificates and registration will fail.
+
+The template should be set using the ``iak_idevid_template`` configuration option. As an alternative, the ``iak_idevid_template`` option can be set to ``manual`` and the ``iak_idevid_asymmetric_alg`` and ``iak_idevid_name_alg`` options can be used to manually set the algorithms, but this is not recommended, and **these options are ignored** if ``iak_idevid_template`` is not set to ``manual``.
 
 Template definitions can be found in section 7.3.4 of [#tcg]_. If you don't know what template your IAK and IDevID use, the following table can be used to match your algorithms to a template:
 
@@ -54,8 +59,6 @@ H-4         ECC NIST P521    SHA512
 H-5         ECC SM2 P256     SM3_256
 ==========  ===============  ==========
 
-.. note::
-    This will be changed in an upcoming patch, where the templates will be detected from the certificates the agent loads.
 
 .. [#] IEEE Standard for Local and Metropolitan Area Networks - Secure Device Identity, https://standards.ieee.org/standard/802_1AR-2018.html  
 .. [#tcg] TPM 2.0 Keys for Device Identity and Attestation, https://trustedcomputinggroup.org/wp-content/uploads/TPM-2p0-Keys-for-Device-Identity-and-Attestation_v1_r12_pub10082021.pdf

--- a/templates/2.1/agent.j2
+++ b/templates/2.1/agent.j2
@@ -170,19 +170,20 @@ tpm_signing_alg = "{{ agent.tpm_signing_alg }}"
 ek_handle = "{{ agent.ek_handle }}"
 
 # Enable IDevID and IAK usage and set their algorithms.
-# Choosing a template will override the name and asymmetric algorithm choices.
+# By default the template will be detected automatically from the certificates. This will happen in iak_idevid_template is left empty or set as "default" or "detect".
+# Choosing a template will override the name and asymmetric algorithm choices. To use these choices, set iak_idevid_template to "manual"
 # Templates are specified in the TCG document found here, section 7.3.4: 
 # https://trustedcomputinggroup.org/wp-content/uploads/TPM-2p0-Keys-for-Device-Identity-and-Attestation_v1_r12_pub10082021.pdf
 #
 # Accepted values:
+# iak_idevid_template:        default, detect, H-1, H-2, H-3, H-4, H-5, manual
 # iak_idevid_asymmetric_alg:   rsa, ecc
 # iak_idevid_name_alg:        sha256, sm3_256, sha384, sha512
-# iak_idevid_template:        H-1, H-2, H-3, H-4, H-5
-# Leave template as "" in order to use asymmetric and name algorithm options
 enable_iak_idevid = {{ agent.enable_iak_idevid }}
+iak_idevid_template = "{{ agent.iak_idevid_template }}"
+# In order for these values to be used, set the iak_idevid_template option to manual
 iak_idevid_asymmetric_alg = "{{ agent.iak_idevid_asymmetric_alg }}"
 iak_idevid_name_alg = "{{ agent.iak_idevid_name_alg }}"
-iak_idevid_template = "{{ agent.iak_idevid_template }}"
 
 # The name of the file containing the X509 IAK certificate.
 # If set as "default", the "iak-cert.crt" value is used

--- a/templates/2.1/mapping.json
+++ b/templates/2.1/mapping.json
@@ -195,7 +195,7 @@
             "iak_idevid_template": {
                 "section": "agent",
                 "option": "iak_idevid_template",
-                "default": "H-1"
+                "default": "detect"
             },
             "iak_cert": {
                 "section": "agent",


### PR DESCRIPTION
These are documentation and template mapping changes that correspond to the changes in [rust-keylime PR 689](https://github.com/keylime/rust-keylime/pull/689). The rust PR adds the auto-detect for IDevID and IAK templates and changes the default value for idevid templates in the agent.conf.

Leaving this on draft until the rust-agent pr is looked at/approved, as that is a prerequisite. 