### PR TITLE
codestyle: Remove a 'type: ignore' comment (mypy)

### DIFF
--- a/keylime/common/migrations.py
+++ b/keylime/common/migrations.py
@@ -19,4 +19,4 @@ def apply(db_name: Optional[str]) -> None:
 
     alembic_args.extend(["upgrade", "head"])
 
-    alembic.config.main(argv=alembic_args)  # type: ignore
+    alembic.config.main(argv=alembic_args)


### PR DESCRIPTION
Remove the 'type: ignore' comment from migration.py to allow mypy to pass without errors.