### PR TITLE
Various fixes for example MB policy

### DIFF
--- a/keylime/mba/elchecking/__main__.py
+++ b/keylime/mba/elchecking/__main__.py
@@ -12,13 +12,12 @@ from . import policies
 # Invoke it with `python3 -m $packagename`, for some value of
 # `$packagename` that works with your `$PYTHONPATH`.
 
-
+mba.load_imports()
 parser = argparse.ArgumentParser()
 parser.add_argument("policy_name", choices=policies.get_policy_names())
 parser.add_argument("refstate_file", type=argparse.FileType("rt"))
 parser.add_argument("eventlog_file", type=argparse.FileType("rb"), default=sys.stdin)
 args = parser.parse_args()
-mba.load_imports()
 policy = policies.get_policy(args.policy_name)
 if policy is None:
     print(

--- a/keylime/mba/elchecking/example.py
+++ b/keylime/mba/elchecking/example.py
@@ -229,8 +229,14 @@ class Example(policies.Policy):
         )
         db_test = tests.OnceTest(
             tests.Or(
-                tests.KeySubset("a159c0a5-e494-a74a-87b5-ab155c2bf072", sigs_strip0x(refstate["db"])),
-                tests.KeySubset("a5c059a1-94e4-4aa7-87b5-ab155c2bf072", sigs_strip0x(refstate["db"])),
+                tests.KeySubsetMulti(
+                    ["a159c0a5-e494-a74a-87b5-ab155c2bf072", "2616c4c1-4c50-9240-aca9-41f936934328"],
+                    sigs_strip0x(refstate["db"]),
+                ),
+                tests.KeySubsetMulti(
+                    ["a5c059a1-94e4-4aa7-87b5-ab155c2bf072", "c1c41626-504c-4092-aca9-41f936934328"],
+                    sigs_strip0x(refstate["db"]),
+                ),
             )
         )
         vd_driver_config.set(

--- a/keylime/mba/elchecking/example.py
+++ b/keylime/mba/elchecking/example.py
@@ -387,6 +387,7 @@ class Example(policies.Policy):
             ),
         )
         dispatcher.set((5, "EV_EFI_ACTION"), tests.EvEfiActionTest(5))
+        dispatcher.set((1, "EV_EFI_ACTION"), tests.EvEfiActionTest(1))
         # Accept all UEFI_GPT_DATA. We only expect one entry for that.
         dispatcher.set((5, "EV_EFI_GPT_EVENT"), tests.OnceTest(tests.AcceptAll()))
         events_test = tests.FieldTest(

--- a/keylime/mba/elchecking/example.py
+++ b/keylime/mba/elchecking/example.py
@@ -184,6 +184,8 @@ class Example(policies.Policy):
         )
         # We only expect one EV_NO_ACTION event at the start.
         dispatcher.set((0, "EV_NO_ACTION"), tests.OnceTest(tests.AcceptAll()))
+        dispatcher.set((1, "EV_CPU_MICROCODE"), tests.OnceTest(tests.AcceptAll()))
+        dispatcher.set((1, "EV_EFI_HANDOFF_TABLES2"), tests.OnceTest(tests.AcceptAll()))
         dispatcher.set((0, "EV_S_CRTM_VERSION"), events_final.get("s_crtms"))
         dispatcher.set((0, "EV_EFI_PLATFORM_FIRMWARE_BLOB"), events_final.get("platform_firmware_blobs"))
         dispatcher.set((7, "EV_EFI_VARIABLE_DRIVER_CONFIG"), vd_driver_config)
@@ -291,6 +293,7 @@ class Example(policies.Policy):
                 )
             ),
         )
+        vd_authority.set("605dab50-e046-4300-abb6-3dd810dd8b23", "MokListRT", tests.OnceTest(tests.AcceptAll()))
 
         # A list of allowed digests for firmware from device driver appears
         # in PCR2, event type EV_EFI_BOOT_SERVICES_DRIVER. Here we will just

--- a/keylime/mba/elchecking/tests.py
+++ b/keylime/mba/elchecking/tests.py
@@ -670,6 +670,7 @@ class EvEfiActionTest(Test):
     """Test for valid EV_EFI_ACTION entry values"""
 
     _expected_strings = {
+        1: ["Entering ROM Based Setup"],
         4: ["Calling EFI Application from Boot Option", "Returning from EFI Application from Boot Option"],
         5: [
             "Exit Boot Services Invocation",

--- a/keylime/mba/elchecking/tests.py
+++ b/keylime/mba/elchecking/tests.py
@@ -551,6 +551,19 @@ class KeySubset(IterateTest):
         )
 
 
+class KeySubsetMulti(IterateTest):
+    def __init__(self, sig_types: typing.List[str], keys: typing.Iterable[typing.Mapping[str, str]]):
+        tests = [
+            And(
+                FieldTest("SignatureType", StringEqual(sig_type)),
+                FieldTest("Keys", IterateTest(SignatureSetMember(keys))),
+            )
+            for sig_type in sig_types
+        ]
+
+        super().__init__(Or(*tests))
+
+
 class FieldsMismatchError(Exception):
     """Represents a mismatch between expected and actual sets of field names."""
 


### PR DESCRIPTION
Bringing up some newer devices found some missing parts in the example policy.
This still misses EV_EFI_PLATFORM_FIRMWARE_BLOB2 handling, but that comes in a
seperate PR.

- mba/elchecking: load imports first
- mba/e/example: Allow db entries to be also hashes
- mba/e/example: ignore EV_CPU_MICROCODE, EV_EFI_HANDOFF_TABLES2 and MokListRT
- mba/e/elchecking: add workaround for non spec compliant firmware
