### PR TITLE
templates: Add version 2.2, with event log location options

### DIFF
--- a/templates/2.2/agent.j2
+++ b/templates/2.2/agent.j2
@@ -1,0 +1,237 @@
+# Keylime agent configuration
+# The Python agent is deprecated and will be removed with the next major release (7.0.0)!
+# Please migrate to the Rust based agent: https://github.com/keylime/rust-keylime/
+[agent]
+
+# The configuration file version number
+version = "{{ agent.version }}"
+
+# The agent's UUID.
+# If you set this to "generate", Keylime will create a random UUID.
+# If you set this to "hash_ek", Keylime will set the UUID to the result
+# of 'SHA256(public EK in PEM format)'.
+# If you set this to "environment", Keylime will use the value of the
+# environment variable "KEYLIME_AGENT_UUID" as UUID.
+# If you set this to "dmidecode", Keylime will use the UUID from
+# 'dmidecode -s system-uuid'.
+# If you set this to "hostname", Keylime will use the full qualified domain
+# name of current host as the agent id.
+uuid = "{{ agent.uuid }}"
+
+# The binding address and port for the agent server
+ip = "{{ agent.ip }}"
+port = {{ agent.port }}
+
+# Address and port where the verifier and tenant can connect to reach the agent.
+# These keys are optional.
+contact_ip = "{{ agent.contact_ip }}"
+contact_port = {{ agent.contact_port }}
+
+# The address and port of registrar server which agent communicate with
+registrar_ip = "{{ agent.registrar_ip }}"
+registrar_port = {{ agent.registrar_port }}
+
+# Enable mTLS communication between agent, verifier and tenant.
+# Details on why setting it to "False" is generally considered insecure can be found
+# on https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
+enable_agent_mtls = {{ agent.enable_agent_mtls }}
+
+# The 'tls_dir' option define the directory where the keys and certificates are
+# stored.
+#
+# If set as 'generate', automatically generate a CA, keys, and certificates for
+# the client and the server in the /var/lib/keylime/cv_ca directory, if not
+# present.
+#
+# The 'server_key', 'server_cert', and 'trusted_client_ca' options should all be
+# set with the 'default' keyword when 'generate' keyword is set for 'tls_dir'.
+#
+# If set as 'default', the 'var/lib/keylime/secure' directory is used, which
+# should contain the files indicated by the 'server_key', 'server_cert',
+# and 'trusted_client_ca' options.
+tls_dir = "{{ agent.tls_dir }}"
+
+# The name of the file containing the Keylime agent TLS server private key.
+# This private key is used to serve the Keylime agent REST API
+# A new private key is generated in case it is not found.
+# If set as 'default', the 'server-private.pem' value is used.
+server_key = "{{ agent.server_key }}"
+
+# Set the password used to decrypt the private key file.
+# This password will also be used to protect the generated private key used for
+# mTLS authentication
+# If left empty, the private key will not be encrypted.
+server_key_password = "{{ agent.server_key_password }}"
+
+# The name of the file containing the X509 certificate used as the Keylime agent
+# server TLS certificate.
+# This certificate must be self signed.
+server_cert = "{{ agent.server_cert }}"
+
+# A list of trusted client CA certificates
+trusted_client_ca = "{{ agent.trusted_client_ca }}"
+
+# The name of the file used to store the payload encryption key, derived from
+# the U and V parts.
+# This file is stored in the /var/lib/keylime/secure/ directory.
+enc_keyname = "{{ agent.enc_keyname }}"
+
+# The name of the file used to store the optional decrypted payload.
+# This file is istored in the /var/lib/keylime/secure/ directory.
+dec_payload_file = "{{ agent.dec_payload_file }}"
+
+# The size of the memory-backed tmpfs partition where Keylime stores keys and
+# the decrypted payload.
+# Use syntax that the 'mount' command would accept as a size parameter for tmpfs.
+# The default below sets it to 1 megabyte.
+secure_size =  "{{ agent.secure_size }}"
+
+# Use this option to set the TPM ownerpassword to something you want to use.
+# Set it to "generate" if you want Keylime to choose a random owner password
+# for you.
+tpm_ownerpassword = "{{ agent.tpm_ownerpassword }}"
+
+# Whether to allow the agent to automatically extract a zip file in
+# the delivered payload after it has been decrypted, or not. Defaults to "True".
+# After decryption, the archive will be unzipped to a directory in /var/lib/keylime/secure.
+# Note: the limits on the size of the tmpfs partition set above with the 'secure_size'
+# option will affect this.
+extract_payload_zip = {{ agent.extract_payload_zip }}
+
+# Whether to listen for revocation notifications from the verifier via ZeroMQ
+enable_revocation_notifications = {{ agent.enable_revocation_notifications }}
+
+# The IP to listen for revocation notifications via ZeroMQ
+revocation_notification_ip = "{{ agent.revocation_notification_ip }}"
+
+# The port to listen for revocation notifications via ZeroMQ
+revocation_notification_port = {{ agent.revocation_notification_port }}
+
+# The path to the certificate to verify revocation messages received from the
+# verifier.  The path is relative to /var/lib/keylime.
+# If set to "default", Keylime will use the file RevocationNotifier-cert.crt
+# from the unzipped contents provided by the tenant.
+revocation_cert = "{{ agent.revocation_cert }}"
+
+# A comma-separated list of Python scripts to run upon receiving a revocation
+# message. Keylime will verify the signature first, then call these Python
+# scripts with the json revocation message passed as argument.  The scripts must
+# be located in the directory set via 'revocation_actions_dir'
+#
+# Keylime will also get the list of revocation actions from the file
+# action_list in the unzipped payload content.
+revocation_actions = "{{ agent.revocation_actions }}"
+
+# A script to execute after unzipping the tenant payload.  This is like
+# cloud-init lite =)  Keylime will run it with a /bin/sh environment and
+# with a working directory of /var/lib/keylime/secure/unzipped.
+payload_script = "{{ agent.payload_script }}"
+
+# In case mTLS for the agent is disabled and the use of payloads is still
+# required, this option has to be set to "True" in order to allow the agent
+# to start. Details on why this configuration (mTLS disabled and payload enabled)
+# is generally considered insecure can be found on
+# https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
+enable_insecure_payload = {{ agent.enable_insecure_payload }}
+
+# Extend the delivered payload into a PCR of choice.
+# Specify a PCR number to turn it on.
+# Set to -1 or any negative or out of range PCR value to turn off.
+measure_payload_pcr = {{ agent.measure_payload_pcr }}
+
+# Wether or not to use an exponantial backoff algorithm for retries.
+exponential_backoff = {{ agent.exponential_backoff }}
+
+# Either how long to wait between failed attempts to communicate with the TPM
+# in seconds, or the base for the exponential backoff algorithm if enabled via
+# "exponential_backoff" option.
+# Floating point values are accepted.
+retry_interval = {{ agent.retry_interval }}
+
+# Integer number of retries to communicate with the TPM before giving up.
+max_retries = {{ agent.max_retries }}
+
+# List of hash algorithms used for PCRs
+# Accepted values: sha512, sha384, sha256, sha1
+tpm_hash_alg = "{{ agent.tpm_hash_alg }}"
+
+# List of encryption algorithms to use with the TPM
+# Accepted values: ecc, rsa
+tpm_encryption_alg = "{{ agent.tpm_encryption_alg }}"
+
+# List of signature algorithms to use
+# Accepted values: rsassa, rsapss, ecdsa, ecdaa, ecschnorr
+tpm_signing_alg = "{{ agent.tpm_signing_alg }}"
+
+# If an EK is already present on the TPM (e.g., with "tpm2_createek") and
+# you require Keylime to use this EK, change "generate" to the actual EK
+# handle (e.g. "0x81000000"). The Keylime agent will then not attempt to
+# create a new EK upon startup, and neither will it flush the EK upon exit.
+ek_handle = "{{ agent.ek_handle }}"
+
+# Enable IDevID and IAK usage and set their algorithms.
+# By default the template will be detected automatically from the certificates. This will happen in iak_idevid_template is left empty or set as "default" or "detect".
+# Choosing a template will override the name and asymmetric algorithm choices. To use these choices, set iak_idevid_template to "manual"
+# Templates are specified in the TCG document found here, section 7.3.4: 
+# https://trustedcomputinggroup.org/wp-content/uploads/TPM-2p0-Keys-for-Device-Identity-and-Attestation_v1_r12_pub10082021.pdf
+#
+# Accepted values:
+# iak_idevid_template:        default, detect, H-1, H-2, H-3, H-4, H-5, manual
+# iak_idevid_asymmetric_alg:   rsa, ecc
+# iak_idevid_name_alg:        sha256, sm3_256, sha384, sha512
+enable_iak_idevid = {{ agent.enable_iak_idevid }}
+iak_idevid_template = "{{ agent.iak_idevid_template }}"
+# In order for these values to be used, set the iak_idevid_template option to manual
+iak_idevid_asymmetric_alg = "{{ agent.iak_idevid_asymmetric_alg }}"
+iak_idevid_name_alg = "{{ agent.iak_idevid_name_alg }}"
+
+# The name of the file containing the X509 IAK certificate.
+# If set as "default", the "iak-cert.crt" value is used
+# If a relative path is set, it will be considered relative from the keylime_dir.
+# If an absolute path is set, it is used without change.
+#
+# To override iak_cert, set KEYLIME_AGENT_IAK_CERT environment variable.
+iak_cert = "{{ agent.iak_cert }}"
+
+# The name of the file containing the X509 IDevID certificate.
+# If set as "default", the "idevid-cert.crt" value is used
+# If a relative path is set, it will be considered relative from the keylime_dir.
+# If an absolute path is set, it is used without change.
+#
+# To override idevid_cert, set KEYLIME_AGENT_IDEVID_CERT environment variable.
+idevid_cert = "{{ agent.idevid_cert }}"
+
+# The user account to switch to to drop privileges when started as root
+# If left empty, the agent will keep running with high privileges.
+# The user and group specified here must allow the user to access the
+# WORK_DIR (typically /var/lib/keylime) and /dev/tpmrm0. Therefore,
+# suggested value for the run_as parameter is keylime:tss.
+# The following commands should be used to set ownership before running the
+# agent:
+# chown keylime /var/lib/keylime
+#
+# If tpmdata.yml already exists:
+# chown keylime /var/lib/keylime/tpmdata.yml
+#
+# If cv_ca directory exists:
+# chown keylime /var/lib/keylime/cv_ca
+# chown keylime /var/lib/keylime/cv_ca/cacert.crt
+run_as = "{{ agent.run_as }}"
+
+# Path from where the agent will read the IMA measurement log.
+#
+# If set as "default", Keylime will use the default path:
+# The default path is /sys/kernel/security/ima/ascii_runtime_measurements
+# If set as a relative path, it will be considered from the root path "/".
+# If set as an absolute path, it will use it without changes
+ima_ml_path = "{{ agent.ima_ml_path }}"
+
+# Path from where the agent will read the measured boot event log.
+#
+# If set as "default", Keylime will use the default path:
+# The default path is /sys/kernel/security/tpm0/binary_boot_measurements
+# If set as a relative path, it will be considered from the root path "/".
+# If set as an absolute path, it will use it without changes
+measuredboot_ml_path = "{{ agent.measuredboot_ml_path }}"
+
+

--- a/templates/2.2/ca.j2
+++ b/templates/2.2/ca.j2
@@ -1,0 +1,40 @@
+# Keylime CA configuration
+[ca]
+
+# The keystore password
+# This password is used to protect the generated CA private key.
+password = {{ ca.password }}
+
+# The configuration file version number
+version = {{ ca.version }}
+
+# CountryName argument (C) of the Issuer when generating certificates
+cert_country = {{ ca.cert_country }}
+
+# CommonName argument (CN) of the Issuer when generating certificates
+cert_ca_name = {{ ca.cert_ca_name }}
+
+# StateOrProvinceName argument (S) of the Issuer when generating certificates
+cert_state = {{ ca.cert_state }}
+
+# Locality argument (L) of the Issuer when generating certificates
+cert_locality = {{ ca.cert_locality }}
+
+# Organization argument (O) of the Issuer when generating certificates
+cert_organization = {{ ca.cert_organization }}
+
+# OrganizationalUnit argument (OU) of the Issuer when generating certificates
+cert_org_unit = {{ ca.cert_org_unit }}
+
+# CA certificate validity time in days
+cert_ca_lifetime = {{ ca.cert_ca_lifetime }}
+
+# Default generated certificate validity time in days
+cert_lifetime = {{ ca.cert_lifetime }}
+
+# Key length in bits
+cert_bits = {{ ca.cert_bits }}
+
+# Certification Revocation List (CRL) distribution address (URL)
+cert_crl_dist = {{ ca.cert_crl_dist }}
+

--- a/templates/2.2/logging.j2
+++ b/templates/2.2/logging.j2
@@ -1,0 +1,33 @@
+# Keylime logging configuration
+
+# The configuration file version number
+[logging]
+version = {{ logging.version }}
+
+[loggers]
+keys = {{ loggers.get('keys') }}
+
+[handlers]
+keys = {{ handlers.get('keys') }}
+
+[formatters]
+keys = {{ formatters.get('keys') }}
+
+[formatter_formatter]
+format = {{ formatter_formatter.format }}
+datefmt = {{ formatter_formatter.datefmt }}
+
+[logger_root]
+level = {{ logger_root.level }}
+handlers = {{ logger_root.handlers }}
+
+[handler_consoleHandler]
+class = {{ handler_consoleHandler.class }}
+level = {{ handler_consoleHandler.level }}
+formatter = {{ handler_consoleHandler.formatter }}
+args = {{ handler_consoleHandler.args }}
+
+[logger_keylime]
+level = {{ logger_keylime.level }}
+qualname = {{ logger_keylime.qualname }}
+handlers = {{ logger_keylime.handlers }}

--- a/templates/2.2/mapping.json
+++ b/templates/2.2/mapping.json
@@ -1,0 +1,12 @@
+{
+    "version": "2.2",
+    "type": "update",
+    "components": {
+        "agent": {
+            "add" : {
+                "ima_ml_path": "default",
+                "measuredboot_ml_path": "default"
+            }
+        }
+    }
+}

--- a/templates/2.2/registrar.j2
+++ b/templates/2.2/registrar.j2
@@ -1,0 +1,119 @@
+# Keylime registrar configuration
+[registrar]
+
+# The configuration file version number
+version = {{ registrar.version }}
+
+# The binding address and port for the registrar server
+ip = "{{ registrar.ip }}"
+port = {{ registrar.port }}
+tls_port = {{ registrar.tls_port }}
+
+# The 'tls_dir' option define the directory where the keys and certificates are
+# stored.
+#
+# If set as 'generate', automatically generate a CA, keys, and certificates for
+# the registrar server in the /var/lib/keylime/reg_ca directory, if not present.
+#
+# The 'server_key', 'server_cert', and 'trusted_client_ca' options should all be
+# set with the 'default' keyword when 'generate' keyword is set for 'tls_dir'.
+#
+# If set as 'default', share the files with the verifier by using the
+# 'var/lib/keylime/cv_ca' directory, which should contain the files indicated by
+# the 'server_key', 'server_cert', and 'trusted_client_ca' options.
+tls_dir = {{ registrar.tls_dir }}
+
+# The name of the file containing the Keylime registrar server private key.
+# The file should be stored in the directory set in the 'tls_dir' option.
+# This private key is used to serve the Keylime registrar REST API
+#
+# If set as 'default', the 'server-private.pem' value is used.
+server_key = {{ registrar.server_key }}
+
+# Set the password used to decrypt the private key file.
+# If 'tls_dir = generate', this password will also be used to protect the
+# generated server private key.
+# If left empty, the private key will not be encrypted.
+server_key_password = {{ registrar.server_key_password }}
+
+# The name of the file containing the Keylime registrar server certificate.
+# The file should be stored in the directory set in the 'tls_dir' option.
+#
+# If set as 'default', the 'server-cert.crt' value is used.
+server_cert = {{ registrar.server_cert }}
+
+# The list of trusted client CA certificates.
+# The files in the list should be stored in the directory set in the 'tls_dir'
+# option.
+#
+# If set as 'default', the value is set as '[cacert.crt]'
+trusted_client_ca = {{ registrar.trusted_client_ca }}
+
+# Database URL Configuration
+# See this document https://keylime.readthedocs.io/en/latest/installation.html#database-support
+# for instructions on using different database configurations.
+#
+# An example of database_url value for using sqlite:
+#   sqlite:////var/lib/keylime/reg_data.sqlite
+# An example of database_url value for using mysql:
+#   mysql+pymysql://keylime:keylime@keylime_db:[port]/registrar?charset=utf8
+#
+# If set as 'sqlite' keyword, will use the configuration set by the file located
+# at "/var/lib/keylime/reg_data.sqlite".
+database_url = {{ registrar.database_url }}
+
+# Limits for DB connection pool size in sqlalchemy
+# (https://docs.sqlalchemy.org/en/14/core/pooling.html#api-documentation-available-pool-implementations)
+database_pool_sz_ovfl = {{ registrar.database_pool_sz_ovfl }}
+
+# Whether to automatically update the DB schema using alembic
+auto_migrate_db = {{ registrar.auto_migrate_db }}
+
+# Durable Attestation is currently marked as an experimental feature
+# In order to enable Durable Attestation, an "adapter" for a Persistent data Store 
+# (time-series like database) needs to be specified. Some example adapters can be 
+# found under "da/examples" so, for instance 
+#      "durable_attestation_import = keylime.da.examples.redis.py"
+# could be used to interact with a Redis (Persistent data Store)
+durable_attestation_import = {{ registrar.durable_attestation_import }}
+
+# If an adapter for Durable Attestation was specified, then the URL for a Persistent Store
+# needs to be specified here. A second optional URL could be specified, for a 
+# Rekor Transparency Log. A third additional URL could be specified, pointing to a 
+# Time Stamp Authority (TSA), compatible with RFC3161. Additionally, one might need to 
+# specify a path containing certificates required by the stores or TSA. Continuing with 
+# the above example, the following values could be assigned to the parameters: 
+#      "persistent_store_url=redis://127.0.0.1:6379?db=10&password=/root/redis.auth&prefix=myda"
+#      "transparency_log_url=http://127.0.0.1:3000"
+#      "time_stamp_authority_url=http://127.0.0.1:2020"
+#      "time_stamp_authority_certs_path=~/mycerts/tsa_cert1.pem"
+persistent_store_url = {{ registrar.persistent_store_url }}
+transparency_log_url = {{ registrar.transparency_log_url }}
+time_stamp_authority_url = {{ registrar.time_stamp_authority_url }}
+time_stamp_authority_certs_path = {{ registrar.time_stamp_authority_certs_path }}
+
+# If Durable Attestation was enabled, which requires a Persistent Store URL 
+# to be specified, the two following parameters control the format and enconding
+# of the stored attestation artifacts (defaults "json" for format and "" for encoding)
+persistent_store_format = {{ registrar.persistent_store_format }}
+persistent_store_encoding = {{ registrar.persistent_store_encoding }}
+
+# If Durable Attestation was enabled with a Transparency Log URL was specified,
+# the digest algorithm for signatures is controlled by this parameter (default "sha256")
+transparency_log_sign_algo = {{ registrar.transparency_log_sign_algo }}
+
+# If Durable Attestation was enabled with a Transparency Log URL was specified,
+# a keylime administrator can specify some agent attributes (including attestation
+# artifacts, such as quotes and logs) to be signed by the registrar. The use of "all"
+# will result in the whole "package" (agent + artifacts) being signed and leaving it empty
+# will mean no signing should be done.
+signed_attributes = {{ registrar.signed_attributes }}
+
+# What TPM-based identity is allowed to be used to register agents.
+# The options "default" and "iak_idevid" will only allow registration with IAK and IDevID if python cryptography is version 38.0.0 or higher.
+# The following options are accepted:
+# "default": either an EK or IAK and IDevID may be used. In the case that cryptography version is <38.0.0 only EK will be used
+# "ek_cert_or_iak_idevid": this is equivalent to default
+# "ek_cert": only allow agents to use an EK to register
+# "iak_idevid": only allow agents with an IAK and IDevID to register
+tpm_identity = {{ registrar.tpm_identity }}

--- a/templates/2.2/tenant.j2
+++ b/templates/2.2/tenant.j2
@@ -1,0 +1,130 @@
+# Keylime tenant configuration
+[tenant]
+
+# The configuration file version number
+version = {{ tenant.version }}
+
+# The verifier IP address and port
+verifier_ip = {{ tenant.verifier_ip }}
+verifier_port = {{ tenant.verifier_port }}
+
+# The registrar IP address and port
+registrar_ip = {{ tenant.registrar_ip }}
+registrar_port = {{ tenant.registrar_port }}
+
+# The 'tls_dir' option define the directory where the keys and certificates are
+# stored.
+#
+# If set as 'default', share the files with the verifier by using the
+# 'var/lib/keylime/cv_ca', which should contain the files indicated by the
+# 'client_key', 'client_cert', and 'trusted_server_ca' options.
+tls_dir = {{ tenant.tls_dir }}
+
+# Enable mTLS communication between agent, verifier and tenant.
+# Details on why setting it to "False" is generally considered insecure can be found
+# on https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
+enable_agent_mtls = {{ tenant.enable_agent_mtls }}
+
+# The name of the file containing the Keylime tenant client private key.
+# The file should be stored in the directory set in the 'tls_dir' option.
+# This private key is used by the Keylime tenant to connect to the other
+# services using TLS.
+#
+# If set as 'default', the 'client-private.pem' value is used.
+client_key = {{ tenant.client_key }}
+
+# Set the password used to encrypt the private key file.
+# If client_key is set as 'default', should match the password set in the
+# 'client_key_password' option in the verifier configuration file
+client_key_password = {{ tenant.client_key_password }}
+
+# The name of the file containing the Keylime tenant client certificate.
+# The file should be stored in the directory set in the 'tls_dir' option.
+# This certificate is used by the Keylime tenant to connect to the other
+# services using TLS.
+#
+# If set as 'default', the 'client-cert.crt' value is used.
+client_cert = {{ tenant.client_cert }}
+
+# The list of trusted server CA certificates.
+# The files in the list should be stored in the directory set in the 'tls_dir'
+# option.
+#
+# If set as 'default', the value is set as '[cacert.crt]'
+trusted_server_ca = {{ tenant.trusted_server_ca }}
+
+# Directory containing the EK CA certificates.
+# The EK certificate provided by the agent will be validated against the CAs
+# located in this directory.
+tpm_cert_store = {{ tenant.tpm_cert_store }}
+
+# Maximum size of the payload in bytes. The value should match the 'secure_size'
+# option in the agent configuration
+max_payload_size = {{ tenant.max_payload_size }}
+
+# List of hash algorithms used for PCRs
+# Accepted values: sha512, sha384, sha256, sha1
+accept_tpm_hash_algs = {{ tenant.accept_tpm_hash_algs }}
+
+# List of encryption algorithms to use with the TPM
+# Accepted values: ecc, rsa
+accept_tpm_encryption_algs = {{ tenant.accept_tpm_encryption_algs }}
+
+# List of signature algorithms to use
+# Accepted values: rsassa, rsapss, ecdsa, ecdaa, ecschnorr
+accept_tpm_signing_algs = {{ tenant.accept_tpm_signing_algs }}
+
+# Wether or not to use an exponantial backoff algorithm for retries.
+exponential_backoff = {{ tenant.exponential_backoff }}
+
+# Either how long to wait between failed attempts to communicate with the TPM
+# in seconds, or the base for the exponential backoff algorithm if enabled via
+# "exponential_backoff" option.
+# Floating point values are accepted.
+retry_interval = {{ tenant.retry_interval }}
+
+# Integer number of retries to communicate with the TPM before giving up.
+max_retries = {{ tenant.max_retries }}
+
+# Request timeout in seconds.
+request_timeout = {{ tenant.request_timeout }}
+
+# Tell the tenant whether to require an EK certificate from the TPM.
+# If set to False the tenant will ignore EK certificates entirely.
+#
+# WARNING: SETTING THIS OPTION TO FALSE IS VERY DANGEROUS!!!
+#
+# If you disable this check, then you may not be talking to a real TPM.
+# All the security guarantees of Keylime rely upon the security of the EK
+# and the assumption that you are talking to a spec-compliant and honest TPM.
+
+# Some physical TPMs do not have EK certificates, so you may need to set
+# this to "False" for some deployments.  If you do set it to "False", you
+# MUST use the 'ek_check_script' option below to specify a script that will
+# check the provided EK against a allowlist for the environment that has
+# been collected in a trustworthy way.  For example, the cloud provider
+# might provide a signed list of EK public key hashes.  Then you could write
+# an ek_check_script that checks the signature of the allowlist and then
+# compares the hash of the given EK with the allowlist.
+require_ek_cert = {{ tenant.require_ek_cert }}
+
+# Optional script to execute to check the EK and/or EK certificate against a
+# allowlist or any other additional EK processing you want to do. Runs in
+# /var/lib/keylime. You call also specify an absolute path to the script.
+# Script should return 0 if the EK or EK certificate are valid.  Any other
+# return value will invalidate the tenant quote check and prevent
+# bootstrapping a key.
+#
+# The various keys are passed to the script via environment variables:
+# EK - contains a PEM encoded version of the public EK
+# EK_CERT - contains a DER encoded EK certificate if one is available.
+# PROVKEYS - contains a json document containing EK, EKcert, and AIK from the
+# provider.  EK and AIK are in PEM format.  The EKcert is in base64 encoded
+# DER format.
+#
+# Set to blank to disable this check.  See warning above if require_ek_cert
+# is "False".
+ek_check_script = {{ tenant.ek_check_script }}
+
+# Path to file containing the measured boot reference state
+mb_refstate = {{ tenant.mb_refstate }}

--- a/templates/2.2/verifier.j2
+++ b/templates/2.2/verifier.j2
@@ -1,0 +1,249 @@
+# Keylime verifier configuration
+[verifier]
+
+# The configuration file version number
+version = {{ verifier.version }}
+
+# Unique identifier for the each verifier instances.
+uuid = {{ verifier.uuid }}
+
+# The binding address and port for the verifier server
+ip = "{{ verifier.ip }}"
+port = {{ verifier.port }}
+
+# The address and port of registrar server that the verifier communicates with
+registrar_ip = {{ verifier.registrar_ip }}
+registrar_port = {{ verifier.registrar_port }}
+
+# Enable mTLS communication between agent, verifier and tenant.
+# Details on why setting it to "False" is generally considered insecure can be found
+# on https://github.com/keylime/keylime/security/advisories/GHSA-2m39-75g9-ff5r
+enable_agent_mtls = {{ verifier.enable_agent_mtls }}
+
+# The 'tls_dir' option define the directory where the keys and certificates are
+# stored.
+#
+# If set as 'generate', automatically generate a CA, keys, and certificates for
+# the client and the server in the /var/lib/keylime/cv_ca directory, if not
+# present.
+#
+# The 'server_key', 'server_cert', 'client_key', 'client_cert',
+# 'trusted_client_ca', and 'trusted_server_ca' options should all be set with
+# the 'default' keyword when 'generate' keyword is set for 'tls_dir'.
+#
+# If set as 'default', the 'var/lib/keylime/cv_ca' directory is used, which
+# should contain the files indicated by  the 'server_key', 'server_cert',
+# 'client_key', 'client_cert', 'trusted_client_ca', and 'trusted_server_ca'
+# options.
+tls_dir = {{ verifier.tls_dir }}
+
+# The name of the file containing the Keylime verifier server private key.
+# The file should be stored in the directory set in the 'tls_dir' option.
+# This private key is used to serve the Keylime verifier REST API
+#
+# If set as 'default', the 'server-private.pem' value is used.
+server_key = {{ verifier.server_key }}
+
+# Set the password used to decrypt the server private key file.
+# If 'tls_dir = generate', this password will also be used to protect the
+# generated server private key.
+# If left empty, the private key will not be encrypted.
+server_key_password = {{ verifier.server_key_password }}
+
+# The name of the file containing the Keylime verifier server certificate.
+# The file should be stored in the directory set in the 'tls_dir' option.
+#
+# If set as 'default', the 'server-cert.crt' value is used.
+server_cert = {{ verifier.server_cert }}
+
+# The list of trusted client CA certificates.
+# The files in the list should be stored in the directory set in the 'tls_dir'
+# option.
+#
+# If set as 'default', the value is set as '[cacert.crt]'
+trusted_client_ca = {{ verifier.trusted_client_ca }}
+
+# The name of the file containing the Keylime verifier client private key.
+# The file should be stored in the directory set in the 'tls_dir' option.
+# This private key is used by the Keylime verifier to connect to the other
+# services using TLS.
+#
+# If set as 'default', the 'client-private.pem' value is used.
+client_key = {{ verifier.client_key }}
+
+# Set the password used to decrypt the client private key file.
+# If 'tls_dir = generate', this password will also be used to protect the
+# generated client private key.
+# If left empty, the private key will not be encrypted.
+client_key_password = {{ verifier.client_key_password }}
+
+# The name of the file containing the Keylime verifier client certificate.
+# The file should be stored in the directory set in the 'tls_dir' option.
+# This certificate is used by the Keylime verifier to connect to the other
+# services using TLS.
+#
+# If set as 'default', the 'client-cert.crt' value is used.
+client_cert = {{ verifier.client_cert }}
+
+# The list of trusted server CA certificates.
+# The files in the list should be stored in the directory set in the 'tls_dir'
+# option.
+#
+# If set as 'default', the value is set as '[cacert.crt]'
+trusted_server_ca = {{ verifier.trusted_server_ca }}
+
+# Database URL Configuration
+# See this document https://keylime.readthedocs.io/en/latest/installation.html#database-support
+# for instructions on using different database configurations.
+#
+# An example of database_url value for using sqlite:
+#   sqlite:////var/lib/keylime/cv_data.sqlite
+# An example of database_url value for using mysql:
+#   mysql+pymysql://keylime:keylime@keylime_db:[port]/verifier?charset=utf8
+#
+# If set as 'sqlite' keyword, will use the configuration set by the file located
+# at "/var/lib/keylime/cv_data.sqlite".
+database_url = {{ verifier.database_url }}
+
+# Limits for DB connection pool size in sqlalchemy
+# (https://docs.sqlalchemy.org/en/14/core/pooling.html#api-documentation-available-pool-implementations)
+database_pool_sz_ovfl = {{ verifier.database_pool_sz_ovfl }}
+
+# Whether to automatically update the DB schema using alembic
+auto_migrate_db = {{ verifier.auto_migrate_db }}
+
+# The number of worker processes to use for the cloud verifier.
+# Set to "0" to create one worker per processor.
+num_workers = {{ verifier.num_workers }}
+
+# Wether or not to use an exponantial backoff algorithm for retries.
+exponential_backoff = {{ verifier.exponential_backoff }}
+
+# Either how long to wait between failed attempts to connect to a cloud agent
+# in seconds, or the base for the exponential backoff algorithm.
+# Floating point values accepted here.
+retry_interval = {{ verifier.retry_interval }}
+
+# Number of retries to connect to an agent before giving up. Must be an integer.
+max_retries = {{ verifier.max_retries }}
+
+# Time between integrity measurement checks, in seconds.  If set to "0", checks
+# will done as fast as possible.  Floating point values accepted here.
+quote_interval = {{ verifier.quote_interval }}
+
+# The verifier limits the size of upload payloads (allowlists) which defaults to
+# 100MB (104857600 bytes). This setting can be raised (or lowered) based on the
+# size of the actual payloads
+max_upload_size = {{ verifier.max_upload_size }}
+
+# Timeout in seconds for requests made to agents
+request_timeout = {{ verifier.request_timeout }}
+
+# The name of the boot attestation policy to use in comparing a measured boot event log
+# with a measured boot reference state.
+# A policy is a Python object that `isinstance` of `keylime.elchecking.policies.Policy`
+# and was registered by calling `keylime.elchecking.policies.register`.
+# The keylime agent extracts the measured boot event log.
+# The verifier client specifies the measured boot reference state to use;
+# this is specified independently for each agent.
+# Depending on the policy, the same reference state may be usable with multiple agents.
+# The `accept-all` policy ignores the reference state and approves every log.
+measured_boot_policy_name = {{ verifier.measured_boot_policy_name }}
+
+# This is a list of Python modules to dynamically load, for example to register
+# additional boot attestation policies.
+# Empty strings in the list are ignored.
+# A module here may be relative, in which case it is interpreted
+# relative to the keylime.elchecking package.
+# The default value for this config item is the empty list.
+measured_boot_imports = {{ verifier.measured_boot_imports }}
+
+# This is used to manage the number of times measure boot attestation
+# is done. In other words, it controls the number of times the call
+# to the measure boot policy engine is made to evaluate the boot log
+# against the policy specified.
+# Here are its possible values and number of bootlog evaluations.
+# once (default)  : Bootlog evaluation will be done for only one time.
+# always          : Bootlog evaluation will always be done (i.e. for unlimited times).
+measured_boot_evaluate = {{ verifier.measured_boot_evaluate }}
+
+# Severity labels for revocation events strictly ordered from least severity to
+# highest severtiy.
+severity_labels = {{ verifier.severity_labels }}
+
+# Severity policy that matches different event_ids to the severity label.
+# The rules are evaluated from the beginning of the list and the first match is
+# used. The event_id can also be a regex. Default policy assigns the highest
+# severity to all events.
+severity_policy = {{ verifier.severity_policy }}
+
+# If files are already opened when IMA tries to measure them this causes
+# a time of measure, time of use (ToMToU) error entry.
+# By default we ignore those entries and only print a warning.
+# Set to False to treat ToMToU entries as errors.
+ignore_tomtou_errors = {{ verifier.ignore_tomtou_errors }}
+
+# Durable Attestation is currently marked as an experimental feature
+# In order to enable Durable Attestation, an "adapter" for a Persistent data Store 
+# (time-series like database) needs to be specified. Some example adapters can be 
+# found under "da/examples" so, for instance 
+#      "durable_attestation_import = keylime.da.examples.redis.py"
+# could be used to interact with a Redis (Persistent data Store)
+durable_attestation_import = {{ verifier.durable_attestation_import }}
+
+# If an adapter for Durable Attestation was specified, then the URL for a Persistent Store
+# needs to be specified here. A second optional URL could be specified, for a 
+# Rekor Transparency Log. A third additional URL could be specified, pointing to a 
+# Time Stamp Authority (TSA), compatible with RFC3161. Additionally, one might need to 
+# specify a path containing certificates required by the stores or TSA. Continuing with 
+# the above example, the following values could be assigned to the parameters: 
+#      "persistent_store_url=redis://127.0.0.1:6379?db=10&password=/root/redis.auth&prefix=myda"
+#      "transparency_log_url=http://127.0.0.1:3000"
+#      "time_stamp_authority_url=http://127.0.0.1:2020"
+#      "time_stamp_authority_certs_path=~/mycerts/tsa_cert1.pem"
+persistent_store_url = {{ verifier.persistent_store_url }}
+transparency_log_url = {{ verifier.transparency_log_url }}
+time_stamp_authority_url = {{ verifier.time_stamp_authority_url }}
+time_stamp_authority_certs_path = {{ verifier.time_stamp_authority_certs_path }}
+
+# If Durable Attestation was enabled, which requires a Persistent Store URL 
+# to be specified, the two following parameters control the format and enconding
+# of the stored attestation artifacts (defaults "json" for format and "" for encoding)
+persistent_store_format = {{ verifier.persistent_store_format }}
+persistent_store_encoding = {{ verifier.persistent_store_encoding }}
+
+# If Durable Attestation was enabled with a Transparency Log URL was specified,
+# the digest algorithm for signatures is controlled by this parameter (default "sha256")
+transparency_log_sign_algo = {{ verifier.transparency_log_sign_algo }}
+
+# If Durable Attestation was enabled with a Transparency Log URL was specified,
+# a keylime administrator can specify some agent attributes (including attestation
+# artifacts, such as quotes and logs) to be signed by the verifier. The use of "all"
+# will result in the whole "package" (agent + artifacts) being signed and leaving it empty
+# will mean no signing should be done.
+signed_attributes = {{ verifier.signed_attributes }}
+
+[revocations]
+
+# List of revocation notification methods to enable.
+#
+# Available methods are:
+#
+# "agent": Deliver notification directly to the agent via the REST
+# protocol.
+#
+# "zeromq": Enable the ZeroMQ based revocation notification method;
+# zmq_ip and zmq_port options must be set. Currently this only works if you are
+# using keylime-CA.
+#
+# "webhook": Send notification via webhook. The endpoint URL must be
+# configured with 'webhook_url' option. This can be used to notify other
+# systems that do not have a Keylime agent running.
+enabled_revocation_notifications = {{ revocations.enabled_revocation_notifications }}
+
+# The binding address and port of the revocation notifier service via ZeroMQ.
+zmq_ip = {{ revocations.zmq_ip }}
+zmq_port = {{ revocations.zmq_port }}
+
+# Webhook url for revocation notifications.
+webhook_url = {{ revocations.webhook_url }}


### PR DESCRIPTION
Add the configuration templates version 2.2

This add the 'ima_ml_path' and 'measuredboot_ml_path' options to the configuration templates for the agent.