### PR TITLE
requirements: bump pyasn1-modules to 0.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ psutil>=5.4.2 # BSD
 lark>=1.0.0 # MIT
 # pyasn1 is used to read the EK cert, due to issue #944.
 pyasn1>=0.4.2 # BSD
-pyasn1-modules>=0.2.1 # BSD
+pyasn1-modules>=0.2.5 # BSD
 jinja2>=3.0.0 # BSD
 # Keylime requires also gpg (LGPLv2+).
 # Those bindings must match the local GPG version and therefore this package is not installed via PyPI.


### PR DESCRIPTION
Version 0.2.1 does not include rfc4108.
