### PR TITLE
templates: Fix typo on default measured boot log location

### DIFF
--- a/templates/2.2/agent.j2
+++ b/templates/2.2/agent.j2
@@ -229,7 +229,7 @@ ima_ml_path = "{{ agent.ima_ml_path }}"
 # Path from where the agent will read the measured boot event log.
 #
 # If set as "default", Keylime will use the default path:
-# The default path is /sys/kernel/security/tpm0/binary_boot_measurements
+# The default path is /sys/kernel/security/tpm0/binary_bios_measurements
 # If set as a relative path, it will be considered from the root path "/".
 # If set as an absolute path, it will use it without changes
 measuredboot_ml_path = "{{ agent.measuredboot_ml_path }}"


### PR DESCRIPTION
Fix typo on template comment about the default measured boot log location.

This is related with https://github.com/keylime/rust-keylime/pull/743