### PR TITLE
verifier, tenant: make payload for agent completely optional

### DIFF
--- a/docs/rest_apis.rst
+++ b/docs/rest_apis.rst
@@ -98,7 +98,7 @@ Cloud verifier (CV)
     :>json int code: HTTP status code
     :>json string status: Status as string
     :>json int operational_state: Current state of the agent in the CV. Defined in https://github.com/keylime/keylime/blob/master/keylime/common/states.py
-    :>json string v: V key for payload base64 encoded. Decoded length is 32 bytes
+    :>json string v: V key for payload base64 encoded or null. Decoded length is 32 bytes
     :>json string ip: Agents contact ip address for the CV
     :>json string port: Agents contact port for the CV
     :>json string tpm_policy: Static PCR policy and mask for TPM
@@ -164,7 +164,7 @@ Cloud verifier (CV)
 
 
 
-    :<json string v: V key for payload base64 encoded. Decoded length is 32 bytes.
+    :<json string v: (Optional) V key for payload base64 encoded. Decoded length is 32 bytes.
     :<json string cloudagent_ip: Agents contact ip address for the CV.
     :<json string cloudagent_port: Agents contact port for the CV.
     :<json string tpm_policy: Static PCR policy and mask for TPM. Is a string encoded dictionary that also includes a `mask` for which PCRs should be included in a quote.

--- a/docs/user_guide/runtime_ima.rst
+++ b/docs/user_guide/runtime_ima.rst
@@ -310,8 +310,7 @@ Now that we have our runtime policy available, we can send it to the verifier.
 Using the :code:`keylime_tenant` we can send the runtime policy as
 follows::
 
-  touch payload  # create empty payload for example purposes
-  keylime_tenant -c add --uuid <agent-uuid> -f payload --runtime-policy /path/to/policy.json
+  keylime_tenant -c add --uuid <agent-uuid> --runtime-policy /path/to/policy.json
 
 .. note::
   If your agent is already registered, you can use :code:`-c update`

--- a/docs/user_guide/user_selected_pcr_monitoring.rst
+++ b/docs/user_guide/user_selected_pcr_monitoring.rst
@@ -23,13 +23,9 @@ tool.
 
 You can add a node to using `keylime_tenant`::
 
-    # First create a payload to send to the agent (in our case this is empty)
-    touch payload
-
     # Now actually add the node
     keylime_tenant -c add \
     --uuid d432fbb3-d2f1-4a97-9ef7-75bd81c00000 \
-    -f payload \
     --tpm_policy '{"22":["0000000000000000000000000000000000000001","0000000000000000000000000000000000000000000000000000000000000001","000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001","ffffffffffffffffffffffffffffffffffffffff","ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"],"15":["0000000000000000000000000000000000000000","0000000000000000000000000000000000000000000000000000000000000000","000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"]}'
 
 rhboot shim-loader

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -82,7 +82,7 @@ def process_quote_response(
 
     # if no public key provided, then ensure we have cached it
     if received_public_key is None:
-        if agent.get("public_key", "") == "" or agent.get("b64_encrypted_V", "") == "":
+        if agent.get("public_key", "") == "" or (agent.get("v") and agent.get("b64_encrypted_V", "") == ""):
             logger.error("agent %s did not provide public key and no key or encrypted_v was cached at CV", agent_id)
             failure.add_event(
                 "no_pubkey",

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -517,7 +517,7 @@ class AgentsHandler(BaseHandler):
                 else:
                     json_body = json.loads(self.request.body)
                     agent_data = {
-                        "v": json_body["v"],
+                        "v": json_body.get("v", None),
                         "ip": json_body["cloudagent_ip"],
                         "port": int(json_body["cloudagent_port"]),
                         "operational_state": states.START,
@@ -1567,7 +1567,11 @@ async def process_agent(
         if main_agent_operational_state == states.GET_QUOTE and new_operational_state == states.PROVIDE_V:
             agent["num_retries"] = 0
             agent["operational_state"] = states.PROVIDE_V
-            await invoke_provide_v(agent)
+            # Only deploy V key if actually set
+            if agent.get("v"):
+                await invoke_provide_v(agent)
+            else:
+                await process_agent(agent, states.GET_QUOTE)
             return
 
         if (

--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -15,7 +15,7 @@ class JSONPickleType(PickleType):  # pylint: disable=abstract-method,too-many-an
 class VerfierMain(Base):
     __tablename__ = "verifiermain"
     agent_id = Column(String(80), primary_key=True)
-    v = Column(String(45))
+    v = Column(String(45), nullable=True)
     ip = Column(String(15))
     verifier_id = Column(String(80))
     verifier_ip = Column(String(15))


### PR DESCRIPTION
This now allows an agent to be added without using the payload feature.
Note that then also no U/V key is sent to the agent on successful attestation.

