### PR TITLE
PSS padding fix - salt length set according to wrong length

### DIFF
--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -79,7 +79,7 @@ class Tpm:
             if sig_alg in [tpm2_objects.TPM_ALG_RSASSA, tpm2_objects.TPM_ALG_RSAPSS]:
                 try:
                     (signature,) = struct.unpack_from(f"{sig_size}s", iak_sign, 6)
-                    tpm_util.verify(iak_pub, signature, digest, hashfunc, sig_alg, int(sig_size / 8))
+                    tpm_util.verify(iak_pub, signature, digest, hashfunc, sig_alg, hashfunc.digest_size)
                     logger.info("Agent %s AIK verified with IAK", uuid)
                     return True
                 except InvalidSignature:


### PR DESCRIPTION
The salt length for PSS should be the byte length of the digest getting signed. This has only been working when it was the same size as the signature.

For example, if the item is hashed into 32 bytes (sha256) and signed with that amount, the verification would pass as the salt would receive the correct length (256/8 = 32). However if the digest is 48 bytes, and the signature is 512 then it will fail (512/8 = 64) as a salt length of 64 is longer than 48.