### PR TITLE
mba: Support named measured boot policies

### DIFF
--- a/docs/user_guide/use_measured_boot.rst
+++ b/docs/user_guide/use_measured_boot.rst
@@ -35,90 +35,82 @@ and thus rebuild the contents of PCRs [0-9] (and potentially PCRs [11-14]).
 Implementation
 --------------
 
-Keylime can make use of this new capability in a very flexible manner. A
-"measured boot reference state" or `mb_refstate` for short can be specified by
-the `keylime` operator (i.e. the `tenant`). This operator-provided piece of
-information is used, in a fashion similar to the "IMA policy" (previously known
-as "allowlist"), by the `keylime_verifier`, to compare the contents of the
-information shipped from the `keylime_agent` (boot log in one case, IMA log on
-the other), against such reference state.
+Keylime can make use of this new capability in a very flexible manner. It can
+allow the keylime operator (i.e. tenant) to provide a measured boot policy for
+a keylime agent node and let the keylime verifier evaluate the policy against
+the boot event log of that node. In theory, the measured boot policy could
+contain both the reference state (i.e. reference data about the various boot events)
+of the node and the rule/policy to evaluate the boot event log against that
+reference state.
 
-Due to the fact that physical node-specific information can be encoded on the
-"measured boot log", it became necessary to specify (optionally) a second piece
-of information, a "measured boot policy" or `mb_policy` . This information is
-used to instruct the `keylime_verifier` on how to do the comparison (e.g.,
-using a regular expression, rather than a simple equality match). The policy
-name is specified in `keylime.conf`, under the `[cloud_verifier]` section of
-the file, with parameter named `measured_boot_policy_name`. The default value
-for it is `accept-all`, meaning "just don't try to match the contents, just
-replay the log and make sure the values of PCRs [0-9] and [11-14] match".
+Keylime, at present, allows the operator to provide the reference state
+(a.k.a. measured boot reference state) which is used by the policy engine 'elchecking'
+(part of the verifier) to evaluate the boot event log according
+to the rule/policy specified. The rule/policy to evaluate the boot event log
+against the measured boot reference state is specified in `keylime.conf`,
+under the `[cloud_verifier]` section of the file, with parameter named
+`measured_boot_policy_name`. The default value for it is `accept-all`,
+meaning "just don't try to match the contents, just replay
+the log and make sure the values of PCRs [0-9] and [11-14] match".
 
-Whenever a "measured boot reference state" is defined - via a new command-line
-option in `keylime_tenant` - `--mb_refstate`, the following actions will be
-taken.
+When the measured boot policy is provided by the operator while registering
+an agent node, the following actions will be taken.
 
-1) PCRs [0-9] and [11-14] will be included in the quote sent by `keylime_agent`
-
-2) The `keylime_agent` will also send the contents of
-`/sys/kernel/security/tpm0/binary_bios_measurements`
-
-3) The `keylime_verifier` will replay the boot log from step 2, ensuring the
-correct values for PCRs collected in step 1. Again, this is very similar to
-what it is done with "IMA logs" and PCR 10.
-
-4) The very same `keylime_verifier` will take the boot log, now deemed
-"attested" and compare it against the "measured boot reference state",
-according to the "measured boot policy", causing the attestation to fail if it
-does not conform.
+1. PCRs [0-9] and [11-14] will be included in the quote sent by `keylime_agent`
+2. The `keylime_agent` will also send the contents of`/sys/kernel/security/tpm0/binary_bios_measurements`
+3. The `keylime_verifier` will replay the boot log from step 2, ensuring the correct values for PCRs collected in step 1. Again, this is very similar to what it is done with "IMA logs" and PCR 10.
+4. The very same `keylime_verifier` will take the boot log, now deemed "attested" and evluate it against the measured boot policy, causing the attestation to fail if it does not conform.
 
 How to use 
 ---------- 
 
-The simplest way to use this new functionality is by
-providing an empty "measured boot reference state" and an `accept-all`
-"measured boot policy", which will cause the `keylime_verifier` to simply skip
-the aforementioned step 4.
+The operator can provide the measured boot policy / measured boot reference state
+by using the option '--mb-policy' with the command `keylime_tenant`.
+
+The simplest way to test this functionality is by providing an empty
+measured boot policy with the `accept-all` measured_boot_policy_name
+specified in `keylime.conf`, which will cause the `keylime_verifier`
+to simply skip the aforementioned step 4.
 
 An example follows::
 
-    echo "{}" > measured_boot_reference_state.txt
+    echo "{}" > mb_policy.txt
 
-    keylime_tenant -c add -t <AGENT IP> -v <VERIFIER IP> -u <AGENT UUID> --mb_refstate ./measured_boot_reference_state.txt
+    keylime_tenant -c add -t <AGENT IP> -v <VERIFIER IP> -u <AGENT UUID> --mb-policy ./mb_policy.txt
 
 Note: please keep in mind that the IMA-specific options can be combined with
 the above options in the example, resulting in a configuration where a
 `keylime_agent` sent a quote with PCRs [0-15] and both logs (boot and IMA)
 
 Evidently, to be fully used in a meaningful manner, keylime operators need to
-provide its own custom `mb_refstate` and `mb_policy`. While an user can write
-a policy that performs an "exact match" on a carefully constructed refstate, the
-key idea here is to create a pair of specification files which are at once meaningful
-(for the purposes of trusted computing attestation) and generic (enough to be
-applied to a set of nodes).
+provide their own measured boot policies and custom python module supporting
+custom values of measured_boot_policy_name. The python module needs to be specified
+with `measured_boot_imports` under the `[cloud_verifier]` section in `keylime.conf`.
 
-The most convenient way to crate an `mb_refstate` is starting from the contents
+The most convenient way to create a measured boot policy is starting from the contents
 of an UEFI boot log from a given node, and then tweak and customize it to make
 more generic. Keylime includes a tool (under `scripts` directory) -
-`generate_mb_refstate` - which will consume a boot log and output a JSON file
-containing an `mb_refstate`. An example follows::
+`create_mb_refstate` - which will consume a boot log and output a JSON file
+for measured boot policy. An example follows::
 
-   keylime/scripts/create_mb_refstate /sys/kernel/security/tpm0/binary_bios_measurements measured_boot_reference_state.json
+   create_mb_refstate /sys/kernel/security/tpm0/binary_bios_measurements measured_boot_reference_state.json
 
-   keylime_tenant -c add -t <AGENT IP> -v <VERIFIER IP> -u <AGENT UUID> --mb_refstate ./measured_boot_reference_state.json
+   keylime_tenant -c add -t <AGENT IP> -v <VERIFIER IP> -u <AGENT UUID> --mb-policy ./measured_boot_reference_state.json
 
-This reference state can be (as in the example above) consumed "as is", or it
+This measured boot reference state can be (as in the example above) consumed "as is", or it
 can be tweaked to be made more generic (or even more strict, if the keylime
 operator chooses so).
 
-The `mb_policy` is defined within a framework specified in `policies.py`, where
-some "trivial" policies such as `accept-all` and `reject-all` are pre-defined.
+Keylime facilitates a framework (a.k.a. elchecking policy engine) specified
+in `policies.py` under `keylime/mta/elchecking` directory, where some
+"trivial" policies such as `accept-all` and `reject-all` are pre-defined.
 The Domain-Specific Language (DSL) used by the framework are defined in
 `tests.py` and an illustrative use of it can be seen in the policy
-`example.py`, all under the `elchecking` directory. This example policy was
+`example.py`, all under the same directory. This example policy was
 crafted to be meaningful (i.e., with a relevant number of parameters tests) and
-yet applicable to a large set of nodes. It consumes a `mb_refstate` such as
+yet applicable to a large set of nodes. It consumes a measured boot policy such as
 the one generated by the aforementioned tool or the
-`example_reference_state.json`, located under the same directory. 
+`example_reference_state.json`, located under the same directory.
 
 Just to quickly exemplify what this policy does, it for instance tests if a
 node has `SecureBoot` enabled (`tests.FieldTest("Enabled",
@@ -130,5 +122,39 @@ tests are implemented.
 
 While an operator can attempt to write its own policy from scratch, it is
 recommended that one just copies `example.py` into `mypolicy.py`, change it as
-required and then just points to this new policy on `keylime.conf`
-(`measured_boot_policy_name`) for its own use.
+required and then just points to this policy for `measured_boot_policy_name` in `keylime.conf`
+for its own use.
+
+Named Measured Boot Policy
+----------------------------
+Keylime allows the operator to store measured boot policies with names and use
+the names to associate measured boot policies with various nodes. The policies are stored
+in a database maintained by the keylime verifier. The operator can also list, view, update
+and delete the policies stored.
+
+Examples to add, update, show, delete and list named measuredboot policies::
+
+   keylime_tenant -c addmbpolicy     -v <VERIFIER_IP>  --mb-policy-name <policy1_name> --mb-policy <policy1_file>
+
+   keylime_tenant -c updatembpolicy  -v <VERIFIER_IP>  --mb-policy-name <policy1_name> --mb-policy <policy1_file2>
+
+   keylime_tenant -c showmbpolicy    -v <VERIFIER_IP>  --mb-policy-name <policy1_name>
+
+   keylime_tenant -c deletembpolicy  -v <VERIFIER_IP>  --mb-policy-name <policy1_name>
+
+   keylime_tenant -c listmbpolicy    -v <VERIFIER_IP>
+
+Operator can provide the name of an stored measured boot policy to use the policy
+while registering a node as follows::
+
+  keylime_tenant -c add -t <AGENT IP> -v <VERIFIER IP> -u <AGENT UUID> --mb-policy-name  <policy1_name>
+
+If the poliy is not already stored, the following command to register the node will also
+store the policy into the database::
+
+  keylime_tenant -c add -t <AGENT IP> -v <VERIFIER IP> -u <AGENT UUID> --mb-policy-name <policy2_name> --mb-policy <policy2_file>
+
+The following command to register the node will store the UUID of the node as the name
+of the policy into the database::
+
+  keylime_tenant -c add -t <AGENT IP> -v <VERIFIER IP> -u <AGENT UUID> --mb-policy <policy3_file>

--- a/keylime/api_version.py
+++ b/keylime/api_version.py
@@ -6,9 +6,9 @@ from packaging import version
 
 VersionType = Union[int, float, str]
 
-CURRENT_VERSION: str = "2.2"
-VERSIONS: List[str] = ["1.0", "2.0", "2.1", "2.2"]
-LATEST_VERSIONS: Dict[str, str] = {"1": "1.0", "2": "2.2"}
+CURRENT_VERSION: str = "2.3"
+VERSIONS: List[str] = ["1.0", "2.0", "2.1", "2.2", "2.3"]
+LATEST_VERSIONS: Dict[str, str] = {"1": "1.0", "2": "2.3"}
 DEPRECATED_VERSIONS: List[str] = ["1.0"]
 
 

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -259,9 +259,9 @@ def prepare_get_quote(agent: Dict[str, Any]) -> Dict[str, Union[str, int]]:
 
 
 def process_get_status(agent: VerfierMain) -> Dict[str, Any]:
-    has_mb_refstate = 0
+    has_mb_policy = 0
     if agent.mb_policy.mb_policy is not None:
-        has_mb_refstate = 1
+        has_mb_policy = 1
 
     has_runtime_policy = 0
     if agent.ima_policy.generator and agent.ima_policy.generator > ima.RUNTIME_POLICY_GENERATOR.EmptyAllowList:
@@ -274,7 +274,7 @@ def process_get_status(agent: VerfierMain) -> Dict[str, Any]:
         "port": agent.port,
         "tpm_policy": agent.tpm_policy,
         "meta_data": agent.meta_data,
-        "has_mb_refstate": has_mb_refstate,
+        "has_mb_refstate": has_mb_policy,
         "has_runtime_policy": has_runtime_policy,
         "accept_tpm_hash_algs": agent.accept_tpm_hash_algs,
         "accept_tpm_encryption_algs": agent.accept_tpm_encryption_algs,

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -38,6 +38,7 @@ from keylime.db.keylime_db import DBEngineManager, SessionManager
 from keylime.db.verifier_db import VerfierMain, VerifierAllowlist, VerifierMbpolicy
 from keylime.failure import MAX_SEVERITY_LABEL, Component, Event, Failure, set_severity_config
 from keylime.ima import ima
+from keylime.mba import mba
 
 logger = keylime_logging.init_logging("verifier")
 
@@ -683,20 +684,74 @@ class AgentsHandler(BaseHandler):
                             raise
 
                     # Handle measured boot policy
-                    mb_policy = json_body["mb_refstate"]
-                    mb_policy_stored = None
-                    try:
-                        mb_policy_db_format: Dict[str, Any] = {}
-                        mb_policy_db_format["name"] = agent_id
-                        mb_policy_db_format["mb_policy"] = mb_policy
-                        mb_policy_stored = VerifierMbpolicy(**mb_policy_db_format)
-                        session.add(mb_policy_stored)
-                        session.commit()
-                    except SQLAlchemyError as e:
-                        logger.error("SQLAlchemy Error while updating mb_policy for agent ID %s: %s", agent_id, e)
-                        raise
+                    # - No name, mb_policy   : store mb_policy using agent UUID as name
+                    # - Name, no mb_policy   : fetch existing mb_policy from DB
+                    # - Name, mb_policy      : store mb_policy using name
 
-                    # Write the agent to the database, attaching associated stored policy
+                    mb_policy_name = json_body["mb_policy_name"]
+                    mb_policy = json_body["mb_policy"]
+                    mb_policy_stored = None
+
+                    if mb_policy_name:
+                        try:
+                            mb_policy_stored = (
+                                session.query(VerifierMbpolicy).filter_by(name=mb_policy_name).one_or_none()
+                            )
+                        except SQLAlchemyError as e:
+                            logger.error("SQLAlchemy Error for agent ID %s: %s", agent_id, e)
+                            raise
+
+                        # Prevent overwriting existing mb_policy with name provided in request
+                        if mb_policy and mb_policy_stored:
+                            web_util.echo_json_response(
+                                self,
+                                409,
+                                f"mb_policy with name {mb_policy_name} already exists. Please use a different name or delete the mb_policy from the verifier.",
+                            )
+                            logger.warning("mb_policy with name %s already exists", mb_policy_name)
+                            return
+
+                        # Return error if the mb_policy is neither provided nor stored.
+                        if not mb_policy and not mb_policy_stored:
+                            web_util.echo_json_response(
+                                self, 404, f"Could not find mb_policy with name {mb_policy_name}!"
+                            )
+                            logger.warning("Could not find mb_policy with name %s", mb_policy_name)
+                            return
+
+                    else:
+                        # Use the UUID of the agent
+                        mb_policy_name = agent_id
+                        try:
+                            mb_policy_stored = (
+                                session.query(VerifierMbpolicy).filter_by(name=mb_policy_name).one_or_none()
+                            )
+                        except SQLAlchemyError as e:
+                            logger.error("SQLAlchemy Error for agent ID %s: %s", agent_id, e)
+                            raise
+
+                        # Prevent overwriting existing mb_policy
+                        if mb_policy and mb_policy_stored:
+                            web_util.echo_json_response(
+                                self,
+                                409,
+                                f"mb_policy with name {mb_policy_name} already exists. You can delete the mb_policy from the verifier.",
+                            )
+                            logger.warning("mb_policy with name %s already exists", mb_policy_name)
+                            return
+
+                    # Store the policy into database if not stored
+                    if mb_policy_stored is None:
+                        try:
+                            mb_policy_db_format = mba.mb_policy_db_contents(mb_policy_name, mb_policy)
+                            mb_policy_stored = VerifierMbpolicy(**mb_policy_db_format)
+                            session.add(mb_policy_stored)
+                            session.commit()
+                        except SQLAlchemyError as e:
+                            logger.error("SQLAlchemy Error while updating mb_policy for agent ID %s: %s", agent_id, e)
+                            raise
+
+                    # Write the agent to the database, attaching associated stored ima_policy and mb_policy
                     try:
                         assert runtime_policy_stored
                         assert mb_policy_stored
@@ -1120,6 +1175,224 @@ class VerifyIdentityHandler(BaseHandler):
         else:
             web_util.echo_json_response(self, 404, "agent id not found")
             logger.info("GET returning 404, agaent not found")
+
+    def data_received(self, chunk: Any) -> None:
+        raise NotImplementedError()
+
+
+class MbpolicyHandler(BaseHandler):
+    def head(self) -> None:
+        web_util.echo_json_response(self, 400, "Mbpolicy handler: HEAD Not Implemented")
+
+    def __validate_input(self, method: str) -> Tuple[bool, Optional[str]]:
+        """Validate the input"""
+
+        if self.request.uri is None:
+            web_util.echo_json_response(self, 400, "Invalid URL")
+            return False, None
+        rest_params = web_util.get_restful_params(self.request.uri)
+        if rest_params is None or "mbpolicies" not in rest_params:
+            web_util.echo_json_response(self, 400, "Invalid URL")
+            return False, None
+
+        if not web_util.validate_api_version(self, cast(str, rest_params["api_version"]), logger):
+            return False, None
+
+        mb_policy_name = rest_params["mbpolicies"]
+        if mb_policy_name is None and method != "GET":
+            web_util.echo_json_response(self, 400, "Invalid URL")
+            logger.warning("%s returning 400 response: %s", method, self.request.path)
+            return False, None
+
+        return True, mb_policy_name
+
+    def get(self) -> None:
+        """Get a mb_policy or list of names of mbpolicies
+
+        GET /mbpolicies/[name]
+        name is required to get a mb_policy but not for getting the names of the mbpolicies.
+        """
+
+        params_valid, mb_policy_name = self.__validate_input("GET")
+        if not params_valid:
+            return
+
+        session = get_session()
+        if mb_policy_name is None:
+            try:
+                names_mbpolicies = session.query(VerifierMbpolicy.name).all()
+            except SQLAlchemyError as e:
+                logger.error("SQLAlchemy Error: %s", e)
+                web_util.echo_json_response(self, 500, "Failed to get names of mbpolicies")
+                raise
+
+            names_response = []
+            for name in names_mbpolicies:
+                names_response.append(name[0])
+            web_util.echo_json_response(self, 200, "Success", {"mbpolicy names": names_response})
+
+        else:
+            try:
+                mbpolicy = session.query(VerifierMbpolicy).filter_by(name=mb_policy_name).one()
+            except NoResultFound:
+                web_util.echo_json_response(self, 404, f"Measured boot policy {mb_policy_name} not found")
+                return
+            except SQLAlchemyError as e:
+                logger.error("SQLAlchemy Error: %s", e)
+                web_util.echo_json_response(self, 500, "Failed to get mb_policy")
+                raise
+
+            response = {}
+            response["name"] = getattr(mbpolicy, "name", None)
+            response["mb_policy"] = getattr(mbpolicy, "mb_policy", None)
+            web_util.echo_json_response(self, 200, "Success", response)
+
+    def delete(self) -> None:
+        """Delete a mb_policy
+
+        DELETE /mbpolicies/{name}
+        """
+
+        params_valid, mb_policy_name = self.__validate_input("DELETE")
+        if not params_valid or mb_policy_name is None:
+            return
+
+        session = get_session()
+        try:
+            mbpolicy = session.query(VerifierMbpolicy).filter_by(name=mb_policy_name).one()
+        except NoResultFound:
+            web_util.echo_json_response(self, 404, f"Measured boot policy {mb_policy_name} not found")
+            return
+        except SQLAlchemyError as e:
+            logger.error("SQLAlchemy Error: %s", e)
+            web_util.echo_json_response(self, 500, "Failed to get mb_policy")
+            raise
+
+        try:
+            agent = session.query(VerfierMain).filter_by(mb_policy_id=mbpolicy.id).one_or_none()
+        except SQLAlchemyError as e:
+            logger.error("SQLAlchemy Error: %s", e)
+            raise
+        if agent is not None:
+            web_util.echo_json_response(
+                self,
+                409,
+                f"Can't delete mb_policy as it's currently in use by agent {agent.agent_id}",
+            )
+            return
+
+        try:
+            session.query(VerifierMbpolicy).filter_by(name=mb_policy_name).delete()
+            session.commit()
+        except SQLAlchemyError as e:
+            logger.error("SQLAlchemy Error: %s", e)
+            session.close()
+            web_util.echo_json_response(self, 500, f"Database error: {e}")
+            raise
+
+        # NOTE(kaifeng) 204 Can not have response body, but current helper
+        # doesn't support this case.
+        self.set_status(204)
+        self.set_header("Content-Type", "application/json")
+        self.finish()
+        logger.info("DELETE returning 204 response for mb_policy: %s", mb_policy_name)
+
+    def __get_mb_policy_db_format(self, mb_policy_name: str) -> Dict[str, Any]:
+        """Get the measured boot policy from the request and return it in Db format"""
+
+        content_length = len(self.request.body)
+        if content_length == 0:
+            web_util.echo_json_response(self, 400, "Expected non zero content length")
+            logger.warning("POST returning 400 response. Expected non zero content length.")
+            return {}
+
+        json_body = json.loads(self.request.body)
+        mb_policy = json_body.get("mb_policy")
+        mb_policy_db_format = mba.mb_policy_db_contents(mb_policy_name, mb_policy)
+
+        return mb_policy_db_format
+
+    def post(self) -> None:
+        """Create a mb_policy
+
+        POST /mbpolicies/{name}
+        body: ...
+        """
+
+        params_valid, mb_policy_name = self.__validate_input("POST")
+        if not params_valid or mb_policy_name is None:
+            return
+
+        mb_policy_db_format = self.__get_mb_policy_db_format(mb_policy_name)
+        if not mb_policy_db_format:
+            return
+
+        session = get_session()
+        # don't allow overwritting
+        try:
+            mbpolicy_count = session.query(VerifierMbpolicy).filter_by(name=mb_policy_name).count()
+            if mbpolicy_count > 0:
+                web_util.echo_json_response(
+                    self, 409, f"Measured boot policy with name {mb_policy_name} already exists"
+                )
+                logger.warning("Measured boot policy with name %s already exists", mb_policy_name)
+                return
+        except SQLAlchemyError as e:
+            logger.error("SQLAlchemy Error: %s", e)
+            raise
+
+        try:
+            # Add the data
+            session.add(VerifierMbpolicy(**mb_policy_db_format))
+            session.commit()
+        except SQLAlchemyError as e:
+            logger.error("SQLAlchemy Error: %s", e)
+            raise
+
+        web_util.echo_json_response(self, 201)
+        logger.info("POST returning 201")
+
+    def put(self) -> None:
+        """Update an mb_policy
+
+        PUT /mbpolicies/{name}
+        body: ...
+        """
+
+        params_valid, mb_policy_name = self.__validate_input("PUT")
+        if not params_valid or mb_policy_name is None:
+            return
+
+        mb_policy_db_format = self.__get_mb_policy_db_format(mb_policy_name)
+        if not mb_policy_db_format:
+            return
+
+        session = get_session()
+        # don't allow creating a new policy
+        try:
+            mbpolicy_count = session.query(VerifierMbpolicy).filter_by(name=mb_policy_name).count()
+            if mbpolicy_count != 1:
+                web_util.echo_json_response(
+                    self, 409, f"Measured boot policy with name {mb_policy_name} does not already exist"
+                )
+                logger.warning("Measured boot policy with name %s does not already exist", mb_policy_name)
+                return
+        except SQLAlchemyError as e:
+            logger.error("SQLAlchemy Error: %s", e)
+            raise
+
+        try:
+            # Update the named mb_policy
+            session.query(VerifierMbpolicy).filter_by(name=mb_policy_name).update(
+                mb_policy_db_format  # pyright: ignore
+            )
+            session.commit()
+        except SQLAlchemyError as e:
+            logger.error("SQLAlchemy Error: %s", e)
+            raise
+
+        web_util.echo_json_response(self, 201)
+        logger.info("PUT returning 201")
 
     def data_received(self, chunk: Any) -> None:
         raise NotImplementedError()
@@ -1744,6 +2017,7 @@ def main() -> None:
             (r"/v?[0-9]+(?:\.[0-9]+)?/verify/identity", VerifyIdentityHandler),
             (r"/v?[0-9]+(?:\.[0-9]+)?/agents/.*", AgentsHandler),
             (r"/v?[0-9]+(?:\.[0-9]+)?/allowlists/.*", AllowlistHandler),
+            (r"/v?[0-9]+(?:\.[0-9]+)?/mbpolicies/.*", MbpolicyHandler),
             (r"/versions?", VersionHandler),
             (r".*", MainHandler),
         ]

--- a/keylime/mba/mba.py
+++ b/keylime/mba/mba.py
@@ -106,7 +106,7 @@ def bootlog_parse(bootlog_b64: Optional[str], hash_alg: str) -> Tuple[MBPCRDict,
 
 
 # ##########
-# read a policy definition (aka "refstate") from a file.
+# read a policy definition (aka "mb_policy") from a file.
 # ##########
 
 
@@ -133,15 +133,15 @@ def policy_load(policy_path: Optional[str] = None) -> str:
 # ##########
 
 
-def policy_is_valid(mb_refstate: Optional[str]) -> bool:
+def policy_is_valid(mb_policy: Optional[str]) -> bool:
     """
-    MBA API front-end for checking the validity of a MBA policy (aka refstate).
-    :param mb_refstate: a string describing the policy
+    MBA API front-end for checking the validity of a MBA policy (aka mb_policy).
+    :param mb_policy: a string describing the policy
     :returns: true if the string is valid policy
     """
     try:
         m = _find_implementation("policy_is_valid")
-        return m.policy_is_valid(mb_refstate)  # type: ignore[no-any-return]
+        return m.policy_is_valid(mb_policy)  # type: ignore[no-any-return]
     except Exception as e:
         raise ValueError from e
 
@@ -159,7 +159,7 @@ def bootlog_evaluate(
 ) -> Failure:
     """
     MBA API front-end for evaluating a measured boot event log against a policy.
-    :param policy_data: policy definition (aka "refstate") (as a string).
+    :param policy_data: policy definition (aka "mb_policy") (as a string).
     :param measurement_data: parsed measured boot event log as produced by `bootlog_parse`
     :param pcrsInQuote: a set of PCRs provided by the quote.
     :param agent_id: the UUID of the keylime agent sending this data.
@@ -185,3 +185,18 @@ def _find_implementation(functionname: str) -> Any:
         if hasattr(m, functionname) and isfunction(getattr(m, functionname)):
             return m
     raise ValueError(f"No implementation for function {functionname} found among measured boot imports")
+
+
+# ###########
+# MB policy to store into the database
+# ###########
+
+
+def mb_policy_db_contents(mb_policy_name: str, mb_policy: Optional[str]) -> Dict[str, Any]:
+    """Assembles a mb_policy dictionary to be written into the database"""
+    mb_policy_db_format: Dict[str, Any] = {}
+
+    mb_policy_db_format["name"] = mb_policy_name
+    mb_policy_db_format["mb_policy"] = mb_policy
+
+    return mb_policy_db_format

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -218,7 +218,7 @@ class Tpm:
         runtime_policy: Optional[RuntimePolicyType],
         ima_keyrings: Optional[ImaKeyrings],
         mb_measurement_list: Optional[str],
-        mb_refstate: Optional[str],
+        mb_policy: Optional[str],
         hash_alg: Hash,
         count: int,
     ) -> Failure:
@@ -301,7 +301,7 @@ class Tpm:
         # Handle measured boot PCRs only if the parsing worked
         if not mb_failure:
             for pcr_num in set(config.MEASUREDBOOT_PCRS) & pcr_nums:
-                if mba.policy_is_valid(mb_refstate):
+                if mba.policy_is_valid(mb_policy):
                     if not mb_measurement_list:
                         logger.error(
                             "Measured Boot PCR %d in policy, but no measurement list provided by agent %s",
@@ -392,7 +392,7 @@ class Tpm:
             logger.error("PCRs specified in policy not in quote (from agent %s): %s", agent_id, missing)
             failure.add_event("missing_pcrs", {"context": "PCRs are missing in quote", "data": list(missing)}, True)
 
-        if not mb_failure and mba.policy_is_valid(mb_refstate):
+        if not mb_failure and mba.policy_is_valid(mb_policy):
             mb_evaluate = config.get("verifier", "measured_boot_evaluate", fallback="once")
 
             # Value of measured_boot_evaluate can be only 'once' or 'always'
@@ -404,7 +404,7 @@ class Tpm:
 
             if mb_evaluate == "always":
                 mb_policy_failure = mba.bootlog_evaluate(
-                    mb_refstate,
+                    mb_policy,
                     mb_measurement_data,
                     pcrs_in_quote,
                     agentAttestState.get_agent_id(),
@@ -413,7 +413,7 @@ class Tpm:
 
             elif mb_evaluate == "once" and count == 0:
                 mb_policy_failure = mba.bootlog_evaluate(
-                    mb_refstate,
+                    mb_policy,
                     mb_measurement_data,
                     pcrs_in_quote,
                     agentAttestState.get_agent_id(),
@@ -435,7 +435,7 @@ class Tpm:
         hash_alg: Hash = Hash.SHA256,
         ima_keyrings: Optional[ImaKeyrings] = None,
         mb_measurement_list: Optional[str] = None,
-        mb_refstate: Optional[str] = None,
+        mb_policy: Optional[str] = None,
         compressed: bool = False,
         count: int = -1,
         skip_pcr_check: bool = False,
@@ -488,7 +488,7 @@ class Tpm:
                 runtime_policy,
                 ima_keyrings,
                 mb_measurement_list,
-                mb_refstate,
+                mb_policy,
                 hash_alg,
                 count,
             )

--- a/test/test_api_version.py
+++ b/test/test_api_version.py
@@ -13,7 +13,7 @@ class APIVersion_Test(unittest.TestCase):
 
     def test_current_version(self):
         """Test current_version."""
-        self.assertEqual(api_version.current_version(), "2.2", "Current version is 2.2")
+        self.assertEqual(api_version.current_version(), "2.3", "Current version is 2.3")
 
     def test_latest_minor_version(self):
         """Test laster_minor_version."""


### PR DESCRIPTION
Similar to named runtime policies, it allows the operator to add, show, delete, update and use measured boot policies with names. It also allows to list the measured boot policies.