### PR TITLE
Change Docker and Action Tags to Digests

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,11 +27,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@dd3a744dd3a5cabbfbce0f98a816f38424f30f0f # v2
       with:
         config-file: ./.github/codeql-config.yml
         languages: ${{ matrix.language }}
@@ -43,7 +43,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@dd3a744dd3a5cabbfbce0f98a816f38424f30f0f # v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -57,4 +57,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@dd3a744dd3a5cabbfbce0f98a816f38424f30f0f # v2

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USER }}
@@ -30,7 +30,7 @@ jobs:
 
       - name: Generate docker metadata for keylime_base
         id: meta_base
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
         with:
           images: |
             ${{ env.IMAGE_BASE }}/keylime_base
@@ -41,7 +41,7 @@ jobs:
 
       - name: Generate docker metadata for keylime_verifier
         id: meta_verifier
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
         with:
           images: |
             ${{ env.IMAGE_BASE }}/keylime_verifier
@@ -52,7 +52,7 @@ jobs:
 
       - name: Generate docker metadata for keylime_registrar
         id: meta_registrar
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
         with:
           images: |
             ${{ env.IMAGE_BASE }}/keylime_registrar
@@ -63,7 +63,7 @@ jobs:
 
       - name: Generate docker metadata for keylime_tenant
         id: meta_tenant
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
         with:
           images: |
             ${{ env.IMAGE_BASE }}/keylime_tenant
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build and push base
         id: build_base
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           file: docker/release/base/Dockerfile
@@ -88,7 +88,7 @@ jobs:
 
       - name: Build and push registrar
         id: build_registrar
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           file: docker/release/registrar/Dockerfile
@@ -98,7 +98,7 @@ jobs:
 
       - name: Build and push verifier
         id: build_verifier
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           file: docker/release/verifier/Dockerfile
@@ -108,7 +108,7 @@ jobs:
 
       - name: Build and push tenant
         id: build_tenant
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           file: docker/release/tenant/Dockerfile

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,7 +6,7 @@ jobs:
   greeting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/first-interaction@v1
+    - uses: actions/first-interaction@fb2402657b4a28582200150d0a145671d0e50597 # v1
       continue-on-error: true
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
         with:
           python-version: "3.10"
 
@@ -33,7 +33,7 @@ jobs:
           .
 
       - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/submit-HEAD-coverage.yaml
+++ b/.github/workflows/submit-HEAD-coverage.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: Submit code coverage from merged PR
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: Install testing-farm script
       run: pip3 -v install tft-cli
     - name: Run tests on Testing Farm
@@ -25,17 +25,17 @@ jobs:
     - name: List downloaded files
       run: ls coverage*
     - name: Upload coverage.unittests.xml report to Codecov with GitHub Action
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2
       with:
         files: coverage.unittests.xml
         flags: unittests
     - name: Upload coverage.testsuite.xml report to Codecov with GitHub Action
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2
       with:
         files: coverage.testsuite.xml
         flags: testsuite
     - name: Upload coverage.packit.xml report to Codecov with GitHub Action
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2
       with:
         files: coverage.packit.xml
         flags: packit-e2e

--- a/.github/workflows/submit-PR-coverage.yaml
+++ b/.github/workflows/submit-PR-coverage.yaml
@@ -11,7 +11,7 @@ jobs:
       run:
         working-directory: scripts
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: Wait for Packit tests to finish and download coverage.xml file
       run: ./download_packit_coverage.sh
       env:
@@ -20,17 +20,17 @@ jobs:
     - name: List downloaded files
       run: ls coverage*
     - name: Upload coverage.unittests.xml report to Codecov with GitHub Action
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2
       with:
         files: scripts/coverage.unittests.xml
         flags: unittests
     - name: Upload coverage.testsuite.xml report to Codecov with GitHub Action
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2
       with:
         files: scripts/coverage.testsuite.xml
         flags: testsuite
     - name: Upload coverage.packit.xml report to Codecov with GitHub Action
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2
       with:
         files: scripts/coverage.packit.xml
         flags: packit-e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
   style-checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.0
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+    - uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
+    - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0
   tpm-tests:
     runs-on: ubuntu-latest
     container:
@@ -24,7 +24,7 @@ jobs:
         KEYLIME_TEST: True
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Run tests
       run: .ci/test_wrapper.sh
   lint:
@@ -36,7 +36,7 @@ jobs:
         KEYLIME_TEST: True
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Install build dependencies
       run: sudo dnf -y install swig
     - name: Install Python dependencies

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -5,7 +5,7 @@
 # It is not recommended for use beyond testing scenarios.
 ##############################################################################
 
-FROM quay.io/fedora/fedora:37-x86_64
+FROM quay.io/fedora/fedora:37-x86_64@sha256:eab075950eeef382b80b6c2ffb693381e6a7c507d3337949197c37ad244842e9
 MAINTAINER Luke Hinds <lhinds@redhat.com>
 LABEL version="1.1.0" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
 

--- a/docker/release/base/Dockerfile.in
+++ b/docker/release/base/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM fedora:37 AS keylime_base
+FROM index.docker.io/library/fedora:37@sha256:de153a3928b8901ad05d8d3314a1f7680570979bd2c04c4562b817daa8358a33 AS keylime_base
 LABEL version="_version_" description="Keylime Base - Only used as an base image for derived packages"
 MAINTAINER Keylime Team <main@keylime.groups.io>
 


### PR DESCRIPTION
Currently the Keylime's dockerfiles and action workflows are using tags over digests.

Tags are risky. Pinning to digests for Actions and Dockerfiles ensures you are using a specific, verified version of a dependency, otherwise its possible someone could replace the code for an existing tag, which could lead to certain attacks being triggered by the workflow runs.

Check out [GitHubs documentation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [the following](https://candrews.integralblue.com/2023/09/always-use-docker-image-digests/) for Dockerfiles

I will make two follow up PR's. One to introduce Dependabot to keep the actions updated. The 2nd will be for Frizbee-action, an OSS tool that will automatically flip tags for any new actions added.

If you like we can add 'pip' as an ecosystem for dependabot to keep the Python deps updated.