### PR TITLE
Add Frizbee Action

### DIFF
--- a/.github/frizbee.yml
+++ b/.github/frizbee.yml
@@ -1,0 +1,21 @@
+name: Frizbee Pinned Actions and Container Images Check
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run every day at midnight
+  workflow_dispatch:
+
+jobs:
+  frizbee_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: stacklok/frizbee-action@v0.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.FRIZBEE_TOKEN }}
+        with:
+          actions: .github/workflows
+          dockerfiles: '["./docker"]' # You can specify multiple files or directories
+          open_pr: true
+          fail_on_unpinned: true


### PR DESCRIPTION
This adds the Frizbee action that will automatically flip tags to digests on any Dockerfiles, workflows.

Note this action requires a token scoped with only (limited scopes), see
[here](https://github.com/stacklok/frizbee-action?tab=readme-ov-file#create-a-token) for details