### PR TITLE
revocation_notifier: Take into account CA certificates added via configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,9 @@ jobs:
     - name: Install build dependencies
       run: sudo dnf -y install swig
     - name: Install Python dependencies
-      run: sudo dnf -y install python3.6 tox python3-pip
+      run: sudo dnf -y install python3.10 tox python3-pip
     - name: Run lints
-      run: tox -vv -e 'pylint'
+      run: tox -vv -e 'pylint,pylint310'
     - name: Run mypy
       run: tox -vv -e 'mypy'
     - name: Run pyright

--- a/keylime/requests_client.py
+++ b/keylime/requests_client.py
@@ -1,3 +1,4 @@
+import re
 import ssl
 from typing import Any, Dict, Optional
 
@@ -15,6 +16,10 @@ class RequestsClient:
         ignore_hostname: bool = True,
         **kwargs: Any,
     ) -> None:
+        # Remove eventual "http?://" from the base url
+        if base_url.startswith("http"):
+            base_url = re.sub(r"https?://", "", base_url)
+
         if tls_enabled:
             self.base_url = f"https://{base_url}"
         else:

--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -41,8 +41,8 @@ adjust:
 
   discover:
     how: fmf
-    url: https://github.com/RedHat-SP-Security/keylime-tests
-    ref: main
+    url: https://github.com/ansasaki/keylime-tests
+    ref: tls_on_webhook
     test:
      - /setup/configure_tpm_emulator
      - /setup/install_upstream_keylime

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.18.0
-envlist = py3,py36,pylint,pylint36
+envlist = py3,py310,pylint,pylint39
 skipsdist = True
 ignore_basepython_conflict=true
 
@@ -27,8 +27,8 @@ commands =
     mypy keylime/
 
 
-[testenv:pylint36]
-basepython = python3.6
+[testenv:pylint310]
+basepython = python3.10
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
Previously, the revocation notifier would use only the system installed CA certificates, ignoring those added via `trusted_ca_certificates` configuration. Also, if the webhook didn't offer a certificate, the revocation notifier would ignore the missing certificate and continue the communication in plaintext, even when TLS is enabled via configuration. This can be dangerous if sensitive data is sent to the webhook.

This change makes the revocation notification to use the configured TLS options.