### PR TITLE
Enhancement 110: add tool to handle keylime policies 

### DIFF
--- a/keylime/cert_utils.py
+++ b/keylime/cert_utils.py
@@ -34,6 +34,25 @@ OID_HWTYPE_TPM = "2.23.133.1.2"
 logger = keylime_logging.init_logging("cert_utils")
 
 
+def is_x509_cert(cert_data: bytes) -> bool:
+    """
+    Determine wheter the data passed is a valid x509 cert.
+
+    :param cert_data: bytes to check
+    :return: bool, indicating whether the provided input is a valid cert
+    """
+    try:
+        x509_pem_cert(cert_data.decode("UTF-8"))
+        return True
+    except Exception:
+        try:
+            x509_der_cert(cert_data)
+            return True
+        except Exception:
+            return False
+        return False
+
+
 def x509_der_cert(der_cert_data: bytes) -> Certificate:
     """Load an x509 certificate provided in DER format
     :param der_cert_data: the DER bytes of the certificate

--- a/keylime/cmd/keylime_policy.py
+++ b/keylime/cmd/keylime_policy.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+"""
+Utility to assist with runtime policies.
+
+SPDX-License-Identifier: Apache-2.0
+Copyright 2024 Red Hat, Inc.
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+try:
+    import argcomplete
+except ModuleNotFoundError:
+    argcomplete = None
+
+
+from keylime.policy import create_runtime_policy
+
+logger = logging.getLogger("keylime_policy")
+
+
+def main() -> None:
+    """keylime_policy entry point."""
+    if os.geteuid() != 0:
+        logger.critical("Please, run this program as root")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(add_help=False)
+
+    main_parser = argparse.ArgumentParser()
+
+    action_subparsers = main_parser.add_subparsers(title="actions")
+
+    create_parser = action_subparsers.add_parser("create", help="create policy", parents=[parser])
+    create_subparser = create_parser.add_subparsers(title="create")
+    create_subparser.required = True
+
+    create_runtime_policy.get_arg_parser(create_subparser, parser)
+
+    if argcomplete:
+        # This should happen before parse_args()
+        argcomplete.autocomplete(main_parser)
+
+    args = main_parser.parse_args()
+    if "func" not in args:
+        main_parser.print_help()
+        main_parser.exit()
+
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/keylime/common/algorithms.py
+++ b/keylime/common/algorithms.py
@@ -71,24 +71,22 @@ class Hash(str, enum.Enum):
         return self.value
 
 
-class Encrypt:
+class Encrypt(str, enum.Enum):
     RSA = "rsa"
     ECC = "ecc"
-    supported_algorithms = (RSA, ECC)
 
     @staticmethod
     def is_recognized(algorithm: str) -> bool:
-        return algorithm in Encrypt.supported_algorithms
+        return algorithm in list(Encrypt)
 
 
-class Sign:
+class Sign(str, enum.Enum):
     RSASSA = "rsassa"
     RSAPSS = "rsapss"
     ECDSA = "ecdsa"
     ECDAA = "ecdaa"
     ECSCHNORR = "ecschnorr"
-    supported_algorithms = (RSASSA, RSAPSS, ECDSA, ECDAA, ECSCHNORR)
 
     @staticmethod
     def is_recognized(algorithm: str) -> bool:
-        return algorithm in Sign.supported_algorithms
+        return algorithm in list(Sign)

--- a/keylime/common/algorithms.py
+++ b/keylime/common/algorithms.py
@@ -45,6 +45,28 @@ class Hash(str, enum.Enum):
     def get_ff_hash(self) -> bytes:
         return b"\xff" * (self.get_size() // 8)
 
+    def hexdigest_len(self) -> int:
+        return len(self.__hashfn(b"").hexdigest())
+
+    def file_digest(self, filepath: str) -> str:
+        """
+        Calculate the digest of the specified file.
+
+        :param filepath: the path of the file to calculate the digest
+        :return: str, the hex digest of the specified file
+        """
+        _BUFFER_SIZE = 65535
+        alg = "sm3" if self.value == "sm3_256" else self.value
+        hasher = hashlib.new(alg)
+        with open(filepath, "rb") as f:
+            while True:
+                data = f.read(_BUFFER_SIZE)
+                if not data:
+                    break
+                hasher.update(data)
+
+        return hasher.hexdigest()
+
     def __str__(self) -> str:
         return self.value
 

--- a/keylime/ima/ima.py
+++ b/keylime/ima/ima.py
@@ -552,3 +552,8 @@ def validate_runtime_policy(runtime_policy: RuntimePolicyType) -> None:
     except Exception as error:
         msg = str(error).split("\n", 1)[0]
         raise ImaValidationError(message=f"{msg}", code=400) from error
+
+
+def empty_policy() -> RuntimePolicyType:
+    """Return an empty runtime policy."""
+    return copy.deepcopy(EMPTY_RUNTIME_POLICY)

--- a/keylime/models/registrar/registrar_agent.py
+++ b/keylime/models/registrar/registrar_agent.py
@@ -6,7 +6,7 @@ from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 from keylime import cert_utils, config, crypto, keylime_logging
-from keylime.models.base import *
+from keylime.models.base import Boolean, Certificate, Dictionary, Integer, OneOf, PersistableModel, String, da_manager
 from keylime.tpm import tpm2_objects
 from keylime.tpm.tpm_main import Tpm
 
@@ -254,13 +254,13 @@ class RegistrarAgent(PersistableModel):
 
     def _prepare_status_flags(self):
         if "ek_tpm" in self.changes or "aik_tpm" in self.changes:
-            self.active = False
+            self.active = False  # pylint: disable=attribute-defined-outside-init
 
     def _prepare_regcount(self):
         reg_fields = ("ek_tpm", "ekcert", "aik_tpm", "iak_tpm", "iak_cert", "idevid_tpm", "idevid_cert")
 
-        if self.regcount is None:
-            self.regcount = 0
+        if self.regcount is None:  # pylint: disable=access-member-before-definition
+            self.regcount = 0  # pylint: disable=attribute-defined-outside-init
 
         if any(field in reg_fields for field in self.changes) and self.changes_valid:
             self.regcount += 1

--- a/keylime/policy/create_runtime_policy.py
+++ b/keylime/policy/create_runtime_policy.py
@@ -1,0 +1,844 @@
+"""
+Module to assist with creating runtime policies.
+
+SPDX-License-Identifier: Apache-2.0
+Copyright 2024 Red Hat, Inc.
+"""
+
+import argparse
+import binascii
+import datetime
+import json
+import logging
+import os
+import pathlib
+from importlib import util
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TextIO, Tuple, cast
+
+import psutil
+
+from keylime import cert_utils
+from keylime.common import algorithms, validators
+from keylime.ima import file_signatures, ima
+from keylime.ima.types import RuntimePolicyType
+from keylime.policy import initrd
+from keylime.policy.utils import merge_lists, merge_maplists
+
+_has_rpm = util.find_spec("rpm") is not None
+
+rpm_repo: Any
+if _has_rpm:
+    from keylime.policy import rpm_repo
+
+
+if TYPE_CHECKING:
+    # FIXME: how to make mypy and pylint happy here?
+    _SubparserType = argparse._SubParsersAction[argparse.ArgumentParser]  # pylint: disable=protected-access
+else:
+    _SubparserType = Any
+
+logger = logging.getLogger("policy.create_runtime_policy")
+
+IMA_MEASUREMENT_LIST = "/sys/kernel/security/ima/ascii_runtime_measurements"
+IGNORED_KEYRINGS: List[str] = []
+FALLBACK_HASH_ALGO = algorithms.Hash.SHA256
+
+
+BASE_EXCLUDE_DIRS: List[str] = [
+    "/sys",
+    "/run",
+    "/proc",
+    "/lost+found",
+    "/dev",
+    "/media",
+    "/snap",
+    "/mnt",
+    "/var",
+    "/tmp",
+]
+
+
+def exclude_dirs_based_on_rootfs(dirs_to_exclude: List[str]) -> List[str]:
+    """
+    Build a list of directories to exclude, as they don't match the root filesystem.
+
+    :param dirs_to_exclude: list of directories to exclude
+    :return: a list of strings, that contains directories we need to exclude
+    """
+    rootfs = None
+    to_exclude = []
+    # First we identify the root filesystem
+    disk_part = psutil.disk_partitions(all=True)
+    for pp in disk_part:
+        if pp.mountpoint == "/":
+            rootfs = pp.fstype
+            break
+
+    # Now we select mountpoints to exclude
+    for pp in disk_part:
+        if pp.fstype != rootfs:
+            to_exclude.append(pp.mountpoint)
+            logger.debug(
+                "exclude_dirs_based_on_rootfs(): excluding %s (fstype %s); rootfs: %s",
+                pp.mountpoint,
+                pp.fstype,
+                rootfs,
+            )
+
+    trimmed_dirs = []
+    # Finally, let's trim this list down based on the existing
+    # dirs_to_exclude.
+    for dir_e in to_exclude:
+        matched = False
+        for cur in dirs_to_exclude:
+            if dir_e.startswith(cur):
+                matched = True
+                logger.debug("exclude_dirs_based_on_rootfs(): %s already covered by %s; skipping", dir_e, cur)
+                continue
+        if not matched:
+            trimmed_dirs.append(dir_e)
+    logger.debug("exclude_dirs_based_on_rootfs(): excluded dirs: %s", trimmed_dirs)
+    return trimmed_dirs
+
+
+def _calculate_digest(
+    prefix: str, fpath: str, alg: str, remove_prefix: bool, only_owned_by_root: bool
+) -> Tuple[bool, str, str]:
+    """
+    Filter the specified file to decide if we should calculate its digest.
+
+    This method should skip non-files (e.g. sockets) and directories,
+    as well as files not owned by root (uid 0).
+
+    The return is a tuple with 3 values:
+    1) a boolean indicating the success of the operation
+       to calculate its checksum, as well as
+    2) the file path path (with the prefix removed, if required), and
+    3) its associated digest.
+
+    :param prefix: str indicating the path prefix, the "root" directory for the file
+    :param fpath: str inficating the path for the file
+    :param alg: int, digest algorithm
+    :param remove_prefix: boolean that indicates whether the displayed file should have its prefix removed
+    :param only_owned_by_root: boolean to indicate whether it should calculate the digest only if the file is owned by root
+    :return: Tuple of boolean, str and str, indicating whether this method calculated the digest, the file name and its digest, respectively
+    """
+    if not os.path.isfile(fpath) or os.path.isdir(fpath):
+        return False, "", ""
+
+    if only_owned_by_root:
+        # Skipping files not not owned by root (uid 0).
+        st = os.stat(fpath, follow_symlinks=False)
+
+        if st.st_uid != 0:
+            return False, "", ""
+
+    # Let's take care of removing the prefix, if requested.
+    fkey = fpath
+    if remove_prefix:
+        fkey = fkey[len(str(prefix)) :]
+
+    # IMA replaces spaces with underscores in the log, so we do
+    # that here as well, for them to match.
+    fkey = fkey.replace(" ", "_")
+
+    return True, fkey, algorithms.Hash(alg).file_digest(fpath)
+
+
+def path_digests(
+    *fdirpath: str,
+    alg: str = algorithms.Hash.SHA256,
+    dirs_to_exclude: Optional[List[str]] = None,
+    digests: Optional[Dict[str, List[str]]] = None,
+    remove_prefix: bool = False,
+    only_owned_by_root: bool = False,
+    match_rootfs: bool = False,
+) -> Dict[str, List[str]]:
+    """
+    Calculate the digest of every file under the specified directory.
+
+    :param *fdirpath: the directory that contains the files to calculate their digests
+    :param alg: the algorithm to use for the digests. The default is SHA-256
+    :param dirs_to_exclude: a list of directories that should be excluded from the checksum calculation
+    :param digests: the map of files and their set of digests that will be filled by this method
+    :param remove_prefix: a flag to indicate whether the files should have their prefixes removed when added to the resulting map
+    :param only_owned_by_root: a flag to indicate it should calculate the digests only for files owned by root. Default is False
+    :param match_rootfs: a flag to indicate we want files to match the filesystem of the root fs
+    :return: a mapping of a file (str) with a set of checksums (str)
+    """
+    if digests is None:
+        digests = {}
+
+    # Let's first check if the root is not marked to be excluded.
+    if match_rootfs or dirs_to_exclude:
+        if dirs_to_exclude is None:
+            dirs_to_exclude = []
+
+        if match_rootfs:
+            dirs_to_exclude.extend(exclude_dirs_based_on_rootfs(dirs_to_exclude))
+
+        for to_exclude in dirs_to_exclude:
+            if str(*fdirpath).startswith(to_exclude):
+                # Okay, nothing to do here, since the root
+                # is marked to be excluded.
+                return digests
+
+    subdirs = []
+    for f in os.scandir(str(*fdirpath)):
+        if f.is_dir():
+            exclude = False
+            if dirs_to_exclude:
+                for to_exclude in dirs_to_exclude:
+                    if f.path.startswith(to_exclude):
+                        exclude = True
+                        break
+            if not exclude:
+                subdirs.append(pathlib.Path(f.path).resolve().as_posix())
+        if f.is_file():
+            ok, fkey, fdigest = _calculate_digest(
+                str(*fdirpath), pathlib.Path(f.path).as_posix(), alg, remove_prefix, only_owned_by_root
+            )
+            if ok:
+                if fkey not in digests:
+                    digests[fkey] = []
+                digests[fkey].append(fdigest)
+
+    for d in subdirs:
+        for fname in pathlib.Path(d).glob("**/*"):
+            dst_file = fname.as_posix()
+            ok, fkey, fdigest = _calculate_digest(str(*fdirpath), dst_file, alg, remove_prefix, only_owned_by_root)
+            if ok:
+                if fkey not in digests:
+                    digests[fkey] = []
+                digests[fkey].append(fdigest)
+
+    return digests
+
+
+def print_digests_legacy_format(digests: Dict[str, List[str]], outfile: TextIO) -> None:
+    """
+    Print the digest dict using the legacy allowlist format.
+
+    Helper to print the digests dictionary in the format
+    used by the old allowlist, which is basically the output
+    of the sha256sum utility, i.e. <digest>  <file>
+
+    :param digests: a dictionary that maps a file with a set of checksums
+    :return: None
+    """
+    # Print the boot_aggregate first, if available
+    boot_agg_fname = "boot_aggregate"
+    if boot_agg_fname in digests:
+        for digest in digests[boot_agg_fname]:
+            print(f"{digest}  {boot_agg_fname}", file=outfile)
+
+    for fname, fdigests in digests.items():
+        if fname == boot_agg_fname:
+            continue
+        for digest in fdigests:
+            print(f"{digest}  {fname}", file=outfile)
+
+
+def process_ima_sig_ima_ng_line(line: str) -> Tuple[str, str, str, bool]:
+    """
+    Process a single line "ima", "ima-ng" and "ima-sig" IMA log .
+
+    :param line: str that has the line to be processed
+    :return: a tuple containing 3 strings and a bool. The strings are, in
+             order: 1) the hash algorithm used, 2) the checksum, 3) either
+             the file path or signature, depending on the template, and 4)
+             a boolean indicating whether the method succeeded
+    """
+    ret = ("", "", "", False)
+    if not line:
+        return ret
+
+    pieces = line.split(" ")
+    if len(pieces) < 5:
+        errmsg = f"Skipping line that was split into {len(pieces)} pieces, expected at least 5: {line}"
+        logger.debug(errmsg)
+        return ret
+    if pieces[2] not in ("ima-sig", "ima-ng", "ima"):
+        errmsg = f"skipping line that uses a template ({pieces[2]}) not in ('ima-sig', 'ima-ng', 'ima'): {line}"
+        logger.debug(errmsg)
+        return ret
+
+    # 10 83f995337082103cbdabf65245b03ba2ec8478dd ima-sig sha256:a3525d7a8b5b6bd86867a9d29799429f06fe764818d9caef633f619243734794 /usr/lib/systemd/system-generators/ostree-system-generator 030204d33204490066306402305eccb7e34bbe38a90aa822c58680e27202a592ab229d3713d021bb72842eeaf32fbcb668a3f4c30bba948a17dab82b30023055c9c4fbfc4e13d9d515de662fea2fa4cd136690d1a8289158b33b9fe3d619684b8bfb7f271fec9e3de9b82298ae4488
+    # 10 8d814e778e1fca7c551276523ac44455da1dc420 ima-ng sha256:0bc72531a41dbecb38557df75af4bc194e441e71dc677c659a1b179ac9b3e6ba boot_aggregate
+    # 10 0d429a9b12737a69b446d4adb05c1e633db73eb8 ima b00b5e664e582fad1bcd29b4cb07e628c4c98022 /bin/ls
+
+    csum_hash = pieces[3].split(":")
+
+    alg = ""
+    csum = ""
+    # Old "ima" template.
+    if len(csum_hash) == 2:
+        alg = csum_hash[0]
+        csum = csum_hash[1]
+    else:
+        csum = csum_hash[0]
+        # Lets attempt to detect the alg by len.
+        for dig_alg in list(algorithms.Hash):
+            if len(csum) == algorithms.Hash(dig_alg).hexdigest_len():
+                alg = dig_alg
+                break
+        if not alg:
+            errmsg = f"skipping line that using old 'ima' template because it was not possible to identify the hash alg: {line}"
+            logger.debug(errmsg)
+            return ret
+
+    path = pieces[4].rstrip("\n")
+    return alg, csum, path, True
+
+
+def boot_aggregate_parse(line: str) -> Tuple[str, str]:
+    """
+    Parse the boot aggregate from the provided line.
+
+    :param line: str with the line to be parsed
+    :return: tuple with two values, the algorithm used and the digest of the
+             boot aggregate
+    """
+    def_alg = FALLBACK_HASH_ALGO
+    def_agg = "0" * algorithms.Hash(def_alg).hexdigest_len()
+
+    alg, digest, fpath, ok = process_ima_sig_ima_ng_line(line)
+    if not ok or fpath != "boot_aggregate":
+        return def_alg, def_agg
+    return alg, digest
+
+
+def boot_aggregate_from_file(
+    ascii_runtime_file: str = IMA_MEASUREMENT_LIST,
+) -> Tuple[str, str]:
+    """
+    Return the boot aggregate indicated in the specified file.
+
+    :param ascii_runtime_file: a string indicating the file where we should read the boot aggregate from. The default is /sys/kernel/security/ima/ascii_runtime_measurements.
+    :return: str, the boot aggregate
+    """
+    with open(ascii_runtime_file, "r", encoding="UTF-8") as f:
+        agg = f.readline().strip("\n")
+        if agg.endswith(" boot_aggregate"):
+            alg, digest, _, ok = process_ima_sig_ima_ng_line(agg)
+            if ok:
+                return alg, digest
+
+    def_alg = FALLBACK_HASH_ALGO
+    def_agg = "0" * algorithms.Hash(def_alg).hexdigest_len()
+    return def_alg, def_agg
+
+
+def list_initrds(basedir: str = "/boot") -> List[str]:
+    """
+    Return a list of initrds found in the indicated base dir.
+
+    :param basedir: str, the directory where to find the initrds. Default is /boot
+    :return: a list of filenames starting with "initr"
+    """
+    initrds = []
+    for f in os.scandir(basedir):
+        if f.is_file() and pathlib.Path(f.path).name.startswith("initr"):
+            initrds.append(pathlib.Path(f.path).as_posix())
+    return initrds
+
+
+def process_flat_allowlist(allowlist_file: str, hashes_map: Dict[str, List[str]]) -> Tuple[Dict[str, List[str]], bool]:
+    """Process a flat allowlist file."""
+    ret = True
+    try:
+        with open(allowlist_file, "r", encoding="UTF-8") as fobj:
+            while True:
+                line = fobj.readline()
+                if not line:
+                    break
+                line = line.strip()
+                if len(line) == 0:
+                    continue
+                pieces = line.split(None, 1)
+                if not len(pieces) == 2:
+                    logmsg = f"Skipping line that was split into {len(pieces)} parts, expected 2: {line}"
+                    logger.info(logmsg)
+                    continue
+
+                (checksum_hash, path) = pieces
+
+                # IMA replaces spaces with underscores in the log, so we do
+                # that here as well, for them to match.
+                path = path.replace(" ", "_")
+                hashes_map.setdefault(path, []).append(checksum_hash)
+    except (PermissionError, FileNotFoundError) as ex:
+        errmsg = f"An error occurred while accessing the allowlist: {ex}"
+        logger.error(errmsg)
+        ret = False
+    return hashes_map, ret
+
+
+def get_arg_parser(create_parser: _SubparserType, parent_parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Perform the setup of the command-line arguments for this module."""
+    runtime_p = create_parser.add_parser("runtime", help="create runtime policies", parents=[parent_parser])
+    fs_group = runtime_p.add_argument_group("runtime policy from filesystem")
+
+    if _has_rpm:
+        repo_group = runtime_p.add_argument_group("runtime policy from repositories")
+        repo_group.add_argument(
+            "--local-rpm-repo", dest="local_rpm_repo", type=pathlib.Path, help="Local RPM repo directory"
+        )
+        repo_group.add_argument(
+            "--remote-rpm-repo",
+            dest="remote_rpm_repo",
+            help="Remote RPM repo URL",
+        )
+
+    fs_group.add_argument(
+        "--algo",
+        dest="algo",
+        choices=list(algorithms.Hash),
+        required=False,
+        help="checksum algorithm to be used. If not specified, it will attempt to use the same algorithm the boot aggregate uses or fallback to sha256, otherwise",
+        default="",
+    )
+    fs_group.add_argument(
+        "--ramdisk-dir",
+        dest="ramdisk_dir",
+        required=False,
+        help="path to where the initrds are located, e.g.: /boot",
+        default="",
+    )
+    fs_group.add_argument(
+        "--rootfs",
+        dest="rootfs",
+        required=False,
+        help="path to the root filesystem, e.g.: /",
+        default="",
+    )
+    fs_group.add_argument(
+        "-s",
+        "--skip-path",
+        dest="skip_path",
+        required=False,
+        help="comma-separated list of directories; files found there will not have their checksums calculated",
+        default="",
+    )
+
+    runtime_p.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        required=False,
+        help="output file (defaults to stdout)",
+        default="/dev/stdout",
+    )
+    runtime_p.add_argument(
+        "-p",
+        "--base-policy",
+        dest="base_policy",
+        required=False,
+        help="Merge new data into the given JSON runtime policy",
+        default="",
+    )
+    runtime_p.add_argument(
+        "-k",
+        "--keyrings",
+        dest="get_keyrings",
+        required=False,
+        help="Create keyrings policy entries",
+        action="store_true",
+        default=False,
+    )
+    runtime_p.add_argument(
+        "-b",
+        "--ima-buf",
+        dest="get_ima_buf",
+        required=False,
+        help="Process ima-buf entries other than those related to keyrings",
+        action="store_true",
+        default=False,
+    )
+    runtime_p.add_argument(
+        "-a",
+        "--allowlist",
+        dest="allowlist",
+        required=False,
+        help="Read checksums from the given plain-text allowlist",
+        default="",
+    )
+    runtime_p.add_argument(
+        "-e",
+        "--exclude-list",
+        dest="exclude_list_file",
+        required=False,
+        help="An IMA exclude list file whose contents will be added to the policy",
+        default="",
+    )
+    runtime_p.add_argument(
+        "--use-ima-measurement-list",
+        action="store_true",
+        dest="use_measurement_list",
+        help=f"Read checksums from the IMA measurement list. Default is {IMA_MEASUREMENT_LIST}, but another list can be specified with the -m/--ima-measurement-list option",
+        default=False,
+    )
+    runtime_p.add_argument(
+        "-m",
+        "--ima-measurement-list",
+        dest="ima_measurement_list",
+        required=False,
+        help="Use given IMA measurement list for hash, keyring, and critical "
+        f"data extraction rather than {IMA_MEASUREMENT_LIST}; use /dev/null for "
+        "an empty list",
+        default=IMA_MEASUREMENT_LIST,
+    )
+    runtime_p.add_argument(
+        "-i",
+        "--ignored-keyrings",
+        dest="ignored_keyrings",
+        action="append",
+        required=False,
+        help="Ignores the given keyring; this option may be passed multiple times",
+        default=IGNORED_KEYRINGS,
+    )
+    runtime_p.add_argument(
+        "-A",
+        "--add-ima-signature-verification-key",
+        action="append",
+        dest="ima_signature_keys",
+        default=[],
+        help="Add the given IMA signature verification key to the Keylime-internal 'tenant_keyring'; "
+        "the key should be an x509 certificate in DER or PEM format but may also be a public or "
+        "private key file; this option may be passed multiple times",
+    )
+
+    runtime_p.add_argument(
+        "--show-legacy-allowlist",
+        dest="legacy_allowlist",
+        help="Instead of the actual policy, display only the digests in the legacy allowlist format",
+        action="store_true",
+        default=False,
+    )
+
+    runtime_p.set_defaults(func=create_runtime_policy)
+
+    return runtime_p
+
+
+def merge_base_policy(policy: RuntimePolicyType, base_policy_file: str) -> Optional[RuntimePolicyType]:
+    """Merge a base policy to another."""
+    try:
+        with open(base_policy_file, "r", encoding="UTF-8") as fobj:
+            basepol = fobj.read()
+        base_policy: RuntimePolicyType = json.loads(basepol)
+
+        try:
+            ima.validate_runtime_policy(base_policy)
+        except ima.ImaValidationError as ex:
+            errmsg = f"Base policy is not a valid runtime policy: {ex}"
+            logger.error(errmsg)
+            return None
+
+        # Cherry-pick from base policy what is supported and merge into policy
+        policy["digests"] = merge_maplists(policy["digests"], base_policy.get("digests", {}))
+        policy["excludes"] = merge_lists(policy["excludes"], base_policy.get("excludes", []))
+        policy["keyrings"] = merge_maplists(policy["keyrings"], base_policy.get("keyrings", {}))
+        policy["ima-buf"] = merge_maplists(policy["ima-buf"], base_policy.get("ima-buf", {}))
+
+        ignored_keyrings = base_policy.get("ima", {}).get("ignored_keyrings", [])
+        policy["ima"]["ignored_keyrings"] = merge_lists(policy["ima"]["ignored_keyrings"], ignored_keyrings)
+
+        policy["verification-keys"] = base_policy.get("verification-keys", "")
+    except (PermissionError, FileNotFoundError) as ex:
+        errmsg = f"An error occurred while loading the policy: {ex}"
+        logger.error(errmsg)
+        return None
+    except json.decoder.JSONDecodeError as ex:
+        errmsg = f"An error occurred while converting the policy to a JSON object: {ex}"
+        logger.error(errmsg)
+        return None
+
+    return policy
+
+
+def get_hashes_from_measurement_list(
+    ima_measurement_list_file: str, hashes_map: Dict[str, List[str]]
+) -> Tuple[Dict[str, List[str]], bool]:
+    """Get the hashes from the IMA measurement list file."""
+    ret = True
+    try:
+        with open(ima_measurement_list_file, "r", encoding="UTF-8") as fobj:
+            while True:
+                line = fobj.readline()
+                if not line:
+                    break
+                pieces = line.split(" ")
+                if len(pieces) < 5:
+                    errmsg = f"Skipping line that was split into {len(pieces)} pieces, expected at least 5: {line}"
+                    logger.info(errmsg)
+                    continue
+                if pieces[2] not in ("ima-sig", "ima-ng"):
+                    continue
+                checksum_hash = pieces[3].split(":")[1]
+                path = pieces[4].rstrip("\n")
+                hashes_map.setdefault(path, []).append(checksum_hash)
+    except (PermissionError, FileNotFoundError) as ex:
+        errmsg = f"An error occurred: {ex}"
+        logger.error(errmsg)
+        ret = False
+    return hashes_map, ret
+
+
+def process_exclude_list_line(line: str) -> Tuple[str, bool]:
+    """Validate an exclude list line."""
+    if not line:
+        return "", False
+
+    _, validator_msg = validators.valid_exclude_list([line])
+    if validator_msg:
+        errmsg = f"Bad IMA exclude list rule '{line}': {validator_msg}"
+        logger.warning(errmsg)
+        return "", False
+
+    return line, True
+
+
+def process_exclude_list_file(exclude_list_file: str, excludes: List[str]) -> Tuple[List[str], bool]:
+    """Add the contents of the IMA exclude list file to the given list."""
+    ret = True
+    try:
+        with open(exclude_list_file, "r", encoding="UTF-8") as fobj:
+            while True:
+                line = fobj.readline()
+                if not line:
+                    break
+
+                line, ok = process_exclude_list_line(line.strip())
+                if not ok:
+                    return [], False
+
+                excludes.append(line)
+    except (PermissionError, FileNotFoundError) as ex:
+        errmsg = f"An error occurred: {ex}"
+        logger.error(errmsg)
+        ret = False
+    return excludes, ret
+
+
+def get_rootfs_digests(
+    rootfs: str, skip_path: Optional[str], hashes_map: Dict[str, List[str]], algo: str
+) -> Dict[str, List[str]]:
+    """Calculate digests for files under a directory."""
+    dirs_to_exclude = []
+    if skip_path:
+        dirs_to_exclude = skip_path.split(",")
+    dirs_to_exclude.extend(BASE_EXCLUDE_DIRS)
+    hashes_map = path_digests(
+        rootfs,
+        dirs_to_exclude=dirs_to_exclude,
+        digests=hashes_map,
+        alg=algo,
+        only_owned_by_root=True,
+        match_rootfs=True,
+    )
+    return hashes_map
+
+
+def get_initrds_digests(initrd_dir: str, hashes_map: Dict[str, List[str]], algo: str) -> Dict[str, List[str]]:
+    """Calculate digests for files from initrds from the given directory."""
+    for initrd_file in list_initrds(initrd_dir):
+        initrd_data = initrd.InitrdReader(initrd_file)
+        hashes_map = path_digests(initrd_data.contents(), remove_prefix=True, digests=hashes_map, alg=algo)
+    return hashes_map
+
+
+def process_ima_buf_in_measurement_list(
+    ima_measurement_list_file: str,
+    ignored_keyrings: List[str],
+    get_keyrings: bool,
+    keyrings_map: Dict[str, List[str]],
+    get_ima_buf: bool,
+    ima_buf_map: Dict[str, List[str]],
+) -> Tuple[Dict[str, List[str]], Dict[str, List[str]], bool]:
+    """
+    Process ima-buf entries.
+
+    Process ima-buf entries and get the keyrings map from key-related entries
+    and ima_buf map from the rest.
+    """
+    ret = True
+    try:
+        with open(ima_measurement_list_file, "r", encoding="UTF-8") as fobj:
+            while True:
+                line = fobj.readline()
+                if not line:
+                    break
+                pieces = line.split(" ")
+                if len(pieces) != 6:
+                    errmsg = f"Skipping line that was split into {len(pieces)} pieces, expected 6: {line}"
+                    logger.info(errmsg)
+                    continue
+                if pieces[2] not in ("ima-buf"):
+                    continue
+                checksum_hash = pieces[3].split(":")[1]
+                path = pieces[4]
+
+                bindata = None
+                try:
+                    bindata = binascii.unhexlify(pieces[5].strip())
+                except binascii.Error:
+                    pass
+
+                # check whether buf's bindata contains a key; if so, we will only
+                # append it to 'keyrings', never to 'ima-buf'
+                if bindata and cert_utils.is_x509_cert(bindata):
+                    if path in ignored_keyrings or not get_keyrings:
+                        continue
+
+                    keyrings_map.setdefault(path, []).append(checksum_hash)
+                    continue
+
+                if get_ima_buf:
+                    ima_buf_map.setdefault(path, []).append(checksum_hash)
+    except (PermissionError, FileNotFoundError) as ex:
+        errmsg = f"An error occurred: {ex}"
+        logger.error(errmsg)
+        ret = False
+    return keyrings_map, ima_buf_map, ret
+
+
+def process_signature_verification_keys(verification_keys: List[str], policy: RuntimePolicyType) -> RuntimePolicyType:
+    """Add the given keys (x509 certificates) to keyring."""
+    if not verification_keys:
+        return policy
+
+    verification_key_list = None
+    if policy.get("verification-keys"):
+        keyring = file_signatures.ImaKeyring().from_string(policy["verification-keys"])
+        if not keyring:
+            logger.error("Could not create IMA Keyring from JSON")
+    else:
+        keyring = file_signatures.ImaKeyring()
+
+    if keyring:
+        for key in verification_keys:
+            try:
+                pubkey, keyidv2 = file_signatures.get_pubkey_from_file(key)
+                if not pubkey:
+                    errmsg = f"File '{key}' is not a file with a key"
+                    logger.error(errmsg)
+                else:
+                    keyring.add_pubkey(pubkey, keyidv2)
+            except ValueError as e:
+                errmsg = f"File '{key}' does not have a supported key: {e}"
+                logger.error(errmsg)
+
+        verification_key_list = keyring.to_string()
+
+    if verification_key_list:
+        policy["verification-keys"] = verification_key_list
+
+    return policy
+
+
+def create_runtime_policy(args: argparse.Namespace) -> Optional[RuntimePolicyType]:
+    """Create a runtime policy from the input arguments."""
+    if args.algo and not (args.ramdisk_dir or args.rootfs):
+        logger.warning(
+            "You need to specify at least one of --ramdisk-dir or --rootfs to use a custom checksum algorithm"
+        )
+
+    algo = args.algo
+    if args.algo == "":
+        # Need to find the algo from the boot_aggregate.
+        algo, _ = boot_aggregate_from_file(args.ima_measurement_list)
+
+    policy = ima.empty_policy()
+
+    # Set hash algo.
+    policy["ima"]["log_hash_alg"] = algo
+
+    if args.base_policy:
+        merged_policy = merge_base_policy(policy, cast(str, args.base_policy))
+        if not merged_policy:
+            logger.error("Unable to merge base policy")
+            return None
+        policy = merged_policy
+
+    if args.allowlist:
+        policy["digests"], ok = process_flat_allowlist(args.allowlist, policy["digests"])
+        if not ok:
+            return None
+
+    if _has_rpm and rpm_repo:
+        if args.local_rpm_repo:
+            # FIXME: pass the IMA sigs as well.
+            policy["digests"], _imasigs, ok = rpm_repo.analyze_local_repo(
+                args.local_rpm_repo, digests=policy["digests"]
+            )
+            if not ok:
+                return None
+        if args.remote_rpm_repo:
+            # FIXME: pass the IMA sigs as well.
+            policy["digests"], _imasigs, ok = rpm_repo.analyze_remote_repo(
+                args.remote_rpm_repo, digests=policy["digests"]
+            )
+            if not ok:
+                return None
+
+    if args.use_measurement_list:
+        logger.debug("Measurement list is %s", args.ima_measurement_list)
+        policy["digests"], ok = get_hashes_from_measurement_list(args.ima_measurement_list, policy["digests"])
+        if not ok:
+            return None
+    if args.ramdisk_dir:
+        policy["digests"] = get_initrds_digests(args.ramdisk_dir, policy["digests"], algo)
+    if args.rootfs:
+        policy["digests"] = get_rootfs_digests(args.rootfs, args.skip_path, policy["digests"], algo)
+
+    if args.exclude_list_file:
+        policy["excludes"], ok = process_exclude_list_file(args.exclude_list_file, policy["excludes"])
+        if not ok:
+            return None
+
+    policy["ima"]["ignored_keyrings"].extend(args.ignored_keyrings)
+    if args.get_keyrings or args.get_ima_buf:
+        policy["keyrings"], policy["ima-buf"], ok = process_ima_buf_in_measurement_list(
+            args.ima_measurement_list,
+            policy["ima"]["ignored_keyrings"],
+            args.get_keyrings,
+            policy["keyrings"],
+            args.get_ima_buf,
+            policy["ima-buf"],
+        )
+        if not ok:
+            return None
+
+    policy = process_signature_verification_keys(args.ima_signature_keys, policy)
+
+    # Ensure we only have unique values in lists
+    for key in ["digests", "ima-buf", "keyrings"]:
+        policy[key] = {k: sorted(list(set(v))) for k, v in policy[key].items()}  # type: ignore
+
+    policy["excludes"] = sorted(list(set(policy["excludes"])))
+    policy["ima"]["ignored_keyrings"] = sorted(list(set(policy["ima"]["ignored_keyrings"])))
+
+    policy["meta"]["generator"] = ima.RUNTIME_POLICY_GENERATOR.LegacyAllowList
+    policy["meta"]["timestamp"] = str(datetime.datetime.now())
+
+    try:
+        ima.validate_runtime_policy(policy)
+    except ima.ImaValidationError as ex:
+        errmsg = f"Base policy is not a valid runtime policy: {ex}"
+        logger.error(errmsg)
+        return None
+
+    try:
+        with open(args.output, "w", encoding="UTF-8") as fobj:
+            if args.legacy_allowlist:
+                print_digests_legacy_format(policy["digests"], fobj)
+            else:
+                jsonpolicy = json.dumps(policy)
+                fobj.write(jsonpolicy)
+    except (PermissionError, FileNotFoundError) as ex:
+        errmsg = f"An error occurred while writing the policy: %{ex}"
+        logger.error(errmsg)
+        return None
+
+    return policy

--- a/keylime/policy/initrd.py
+++ b/keylime/policy/initrd.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+
+"""
+Module to help with extracting initrds.
+
+SPDX-License-Identifier: Apache-2.0
+Copyright 2024 Red Hat, Inc.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from importlib import util
+from typing import IO, Dict
+
+from keylime.policy.utils import Compression, Magic, read_bytes_from_open_file
+
+_HAS_LIBARCHIVE = util.find_spec("libarchive") is not None
+if _HAS_LIBARCHIVE:
+    import libarchive  # pylint: disable=import-error
+else:
+    libarchive = None
+
+logger = logging.getLogger("policy.initrd")
+
+
+class InitrdReader:
+    """A helper class for reading the contents of an initrd. This is based on dracut's skipcpio."""
+
+    _initrd_file: str = ""
+    _contents_dir: str = ""
+    _flist: Dict[str, str] = {}
+
+    # New ASCII format. CRC format is identical, except that
+    # the magic field is 070702 instead of 070701.
+    # struct cpio_newc_header {
+    #     char    c_magic[6];
+    #     char    c_ino[8];
+    #     char    c_mode[8];
+    #     char    c_uid[8];
+    #     char    c_gid[8];
+    #     char    c_nlink[8];
+    #     char    c_mtime[8];
+    #     char    c_filesize[8];
+    #     char    c_devmajor[8];
+    #     char    c_devminor[8];
+    #     char    c_rdevmajor[8];
+    #     char    c_rdevminor[8];
+    #     char    c_namesize[8];
+    #     char    c_check[8];
+    # }__attribute__((packed));
+
+    # CPIO fields are 8 bytes long, except for the magic, which is 6.
+    CPIO_MAGIC_LEN: int = 6
+    CPIO_FIELD_LEN: int = 8
+    CPIO_ALIGNMENT: int = 4
+    CPIO_END: bytes = b"TRAILER!!!"
+    CPIO_END_LEN: int = 10
+    CPIO_NAMESIZE_OFFSET: int = 94  # 6 (magic) + 11 fields (x8)
+    CPIO_FILESIZE_OFFSET: int = 54  # 6 (magic) + 6 fields (x8)
+    CPIO_HEADER_LEN: int = 110  # 6 (magic) + 13 fields (x8)
+    CPIO_HEADER_AND_TRAILING_LEN: int = CPIO_HEADER_LEN + CPIO_END_LEN
+
+    @staticmethod
+    def align_up(pos: int, alignment: int) -> int:
+        """Align pos to the specified byte alignment."""
+        return (pos + alignment - 1) & (~(alignment - 1))
+
+    @staticmethod
+    def extract_at_offset_fallback(infile: IO[bytes], offset: int) -> None:
+        """
+        Fall back for extracting an initrd at given offset.
+
+        This method will extract an initrd by calling system programs
+        to do the decompression and extraction, and will be used if
+        libarchive is not available. Note that the data will be extracted
+        at the current directory.
+
+        :param infile: the (open) file we will be using to extract the data from
+        :param offset: the offset in the provided file where the data to be extract starts
+        :return: None
+        """
+        logger.debug("extract_at_offset_fallback(): file %s, offset %s", infile.name, offset)
+
+        decompression: Dict[str, str] = {
+            Compression.LZO: "lzop -d -c",
+            Compression.BZIP2: "bzcat --",
+            Compression.CPIO: "cat --",
+            Compression.GZIP: "zcat --",
+            Compression.ZSTD: "zstd -d -c",
+            Compression.LZ4: "lz4 -d -c",
+            Compression.XZ: "xzcat --",
+        }
+
+        # cat will be used for the decompression, and may be one of
+        # the following programs: lzop, bzcat, zcat, zstd, lz4, xzcat
+        # or even cat itself, if no compression is used.
+        cat: str = decompression[Compression.XZ]
+        comp_type = Compression.detect_from_open_file(infile, offset)
+        if comp_type and comp_type in decompression:
+            cat = decompression[comp_type]
+
+        logger.debug("extract_at_offset_fallback(): identified format %s", cat)
+
+        # We need 2 programs to do this, the one identified in the previous
+        # step, to do the decompression, stored in the cat variable, plus
+        # cpio itself. Let's check if we have them avialable before moving
+        # ahead.
+
+        cat_args = cat.split(" ")
+        orig_cat_bin = cat_args[0]
+        cat_bin = shutil.which(orig_cat_bin)
+        if cat_bin is None:
+            errmsg = f"Unable to move forward; '{orig_cat_bin}' not available in the path"
+            logger.error(errmsg)
+            raise Exception(errmsg)
+        cat_args[0] = cat_bin
+
+        cpio_bin = shutil.which("cpio")
+        if cpio_bin is None:
+            errmsg = "Unable to move forward; 'cpio' not available in the path"
+            logger.error(errmsg)
+            raise Exception(errmsg)
+        cpio_args = f"{cpio_bin} --quiet -i".split(" ")
+
+        # Ok, we have the required programs, so now we need to run cat,
+        # to possibly decompress the data, then use its output and input
+        # to cpio.
+        infile.seek(offset)
+        data = infile.read()
+
+        with subprocess.Popen(
+            cat_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ) as cat_proc:
+            decompressed, stderr = cat_proc.communicate(input=data)
+            if cat_proc.returncode != 0:
+                errmsg = f"Unable to process file '{infile.name}' at offset {offset} with '{orig_cat_bin}': {stderr.decode('UTF-8')}"
+                logger.error(errmsg)
+                raise Exception(errmsg)
+            with subprocess.Popen(cpio_args, stdin=subprocess.PIPE) as cpio_proc:
+                _, stderr = cpio_proc.communicate(input=decompressed)
+                if cpio_proc.returncode != 0:
+                    errmsg = f"Unable to process cpio archive from file '{infile.name}' at offset {offset}: {stderr.decode('UTF-8')}"
+                    logger.error(errmsg)
+                    raise Exception(errmsg)
+
+    @staticmethod
+    def extract_at_offset_libarchive(infile: IO[bytes], offset: int) -> None:
+        """
+        libarchive-based initrd extractor.
+
+        This method will extract an initrd using the libarchive module.
+        Note that the data will be extracted at the current directory.
+
+        :param infile: the (open) file we will be using to extract the data from
+        :param offset: the offset in the provided file where the data to be extract starts
+        :return: None
+        """
+        logger.debug("extract_at_offset_libarchive(): file %s, offset %s", infile.name, offset)
+
+        if not _HAS_LIBARCHIVE or not libarchive:
+            raise Exception("libarchive is not available")
+
+        infile.seek(offset)
+        data = infile.read()
+
+        try:
+            libarchive.extract_memory(data)
+        except Exception as exc:
+            errmsg = f"Unable to extract data from '{infile.name}' at offset {offset} with libarchive: {exc}"
+            logger.error(errmsg)
+            raise Exception(errmsg) from None
+
+    @staticmethod
+    def extract_at_offset(infile: IO[bytes], offset: int, dstdir: str) -> None:
+        """
+        Extract an initrd file from given offset to a given directory.
+
+        This method extracts the contents of an initrd indicated by the the
+        file and offset provided. It will either use libarchive, if available,
+        or fall back to doing the extraction by using system commands.
+
+        :param infile: the (open) file to use for getting the data
+        :param offset: the offset in the provided file where the data start
+        :param dstdir: the directory to extract the data at
+        :return: None
+        """
+        prevdir = os.getcwd()
+
+        extract_method = InitrdReader.extract_at_offset_fallback
+        if _HAS_LIBARCHIVE:
+            extract_method = InitrdReader.extract_at_offset_libarchive
+
+        try:
+            os.chdir(dstdir)
+            extract_method(infile, offset)
+        finally:
+            os.chdir(prevdir)
+
+    @staticmethod
+    def is_eof(f: IO[bytes]) -> bool:
+        """Check for EOF (enf of file)."""
+        s = f.read(1)
+        if s != b"":  # Restore position.
+            f.seek(-1, os.SEEK_CUR)
+
+        return s == b""
+
+    @staticmethod
+    def skip_cpio(infile: IO[bytes]) -> int:
+        """
+        Find the offset where the "main" initrd starts.
+
+        :param infile: an open file handle for the initrd
+        :return: int, the offset where the data of interest starts
+        """
+        pos = 0
+        previous = 0
+        parsing = False
+        buffer_size: int = 2048  # Buffer arbitrarily long.
+        cpio_formats = (Magic.CPIO_NEW_ASCII, Magic.CPIO_CRC)
+
+        buffer = read_bytes_from_open_file(infile, pos, buffer_size)
+        # Reset file offset.
+        infile.seek(0)
+
+        # Now let's check if it's a cpio archive.
+        magic = buffer[: InitrdReader.CPIO_MAGIC_LEN]
+        if magic not in cpio_formats:
+            return pos
+
+        while True:
+            filename_len = int(
+                "0x"
+                + buffer[
+                    InitrdReader.CPIO_NAMESIZE_OFFSET : InitrdReader.CPIO_NAMESIZE_OFFSET + InitrdReader.CPIO_FIELD_LEN
+                ].decode("UTF-8"),
+                0,
+            )
+            filesize = int(
+                "0x"
+                + buffer[
+                    InitrdReader.CPIO_FILESIZE_OFFSET : InitrdReader.CPIO_FILESIZE_OFFSET + InitrdReader.CPIO_FIELD_LEN
+                ].decode("UTF-8"),
+                0,
+            )
+
+            filename = buffer[InitrdReader.CPIO_HEADER_LEN : pos + InitrdReader.CPIO_HEADER_LEN + filename_len]
+            if not parsing:
+                # Mark as the beginning of the archive.
+                previous = pos
+                parsing = True
+
+            pos = InitrdReader.align_up(pos + InitrdReader.CPIO_HEADER_LEN + filename_len, InitrdReader.CPIO_ALIGNMENT)
+            pos = InitrdReader.align_up(pos + filesize, InitrdReader.CPIO_ALIGNMENT)
+
+            if filename_len == (InitrdReader.CPIO_END_LEN + 1) and filename == InitrdReader.CPIO_END:
+                infile.seek(pos)
+                parsing = False
+                break
+
+            infile.seek(pos)
+            buffer = read_bytes_from_open_file(infile, pos, InitrdReader.CPIO_HEADER_AND_TRAILING_LEN)
+
+            magic = buffer[: InitrdReader.CPIO_MAGIC_LEN]
+            if magic not in cpio_formats:
+                logger.warning("Corrupt CPIO archive (magic: %s)", magic.decode("UTF-8"))
+                return pos
+
+            if InitrdReader.is_eof(infile):
+                break
+
+        if InitrdReader.is_eof(infile):
+            # CPIO_END not found.
+            return pos
+
+        # Skip zeros.
+        while True:
+            i = 0
+            buffer = read_bytes_from_open_file(infile, pos, buffer_size)
+            for i, value in enumerate(buffer):
+                if value != 0:
+                    break
+
+            if buffer[i] != 0:
+                pos += i
+                infile.seek(pos)
+                break
+
+            pos += len(buffer)
+
+            if InitrdReader.is_eof(infile):
+                # Rewinding, as we got to the end of the archive.
+                pos = previous
+                break
+
+        return pos
+
+    def _extract(self) -> None:
+        """Extract an initrd."""
+        with open(self._initrd_file, "rb") as infile:
+            InitrdReader.extract_at_offset(infile, self.skip_cpio(infile), self._contents_dir)
+
+    def set_initrd(self, initrdfile: str) -> None:
+        """
+        Define the initrd to be used.
+
+        Specify an initrd file, that will be extracted. Its contents
+        can be found at the path indicated by the method contents().
+
+        :param initrdfile: a string with the path of an initrd
+        :return: None
+        """
+        if not os.path.isfile(initrdfile):
+            errmsg = f"Specified initrd file '{initrdfile}' does not seem to exist; please double check"
+            logger.error(errmsg)
+            raise Exception(errmsg)
+
+        self._initrd_file = os.path.realpath(initrdfile)
+        if self._contents_dir and os.path.isdir(self._contents_dir):
+            shutil.rmtree(self._contents_dir)
+        self._contents_dir = tempfile.mkdtemp(prefix="keylime-initrd-")
+        self._extract()
+
+    def contents(self) -> str:
+        """
+        Return the path where the extracted initrd is available.
+
+        :return: str
+        """
+        return self._contents_dir
+
+    def __init__(self, initrdfile: str) -> None:
+        """
+        Initialize the class with the specified initrd.
+
+        :param initrdfile: the path of the initrd we want to extract
+        :return: None
+        """
+        self.set_initrd(initrdfile)
+
+    def __del__(self) -> None:
+        """
+        Destructor.
+
+        Takes care of removing the temp directory created to contain
+        the initrd contents after it has been extracted from the cpio
+        archive.
+
+        :return: None
+        """
+        if self._contents_dir and os.path.isdir(self._contents_dir):
+            logger.debug("Removing temporary directory %s", self._contents_dir)
+            shutil.rmtree(self._contents_dir)

--- a/keylime/policy/rpm_repo.py
+++ b/keylime/policy/rpm_repo.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+
+"""Analyze local and remote RPM repositories."""
+
+import gzip
+import logging
+import multiprocessing
+import os
+import pathlib
+import shutil
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from contextlib import contextmanager
+from typing import Dict, Generator, List, Optional, Tuple
+
+import rpm  # pylint: disable=import-error
+
+from keylime.common import algorithms
+from keylime.policy.utils import Compression, merge_maplists
+from keylime.signing import verify_signature_from_file
+from keylime.types import PathLike_str
+
+logger = logging.getLogger("policy.rpm_repo")
+
+
+def _parse_rpm_header(hdr: rpm.hdr) -> Tuple[Dict[str, List[str]], Dict[str, List[bytes]]]:
+    # First, the file digests.
+    _MD5_DIGEST_LEN = 32  # In the past, rpm used MD5 for the digests.
+    _SHA256_DIGEST_LEN = algorithms.Hash("sha256").hexdigest_len()
+    empty_hashes = ("0" * _MD5_DIGEST_LEN, "0" * _SHA256_DIGEST_LEN)
+    digests = {f.name: [f.digest] for f in rpm.files(hdr) if f.digest not in empty_hashes}
+
+    # Now, the IMA signatures, if any.
+    ima_sig = {f.name: [f.imasig] for f in rpm.files(hdr) if f.imasig}
+    return digests, ima_sig
+
+
+def analyze_rpm_pkg(pkg: PathLike_str) -> Tuple[Dict[str, List[str]], Dict[str, List[bytes]]]:
+    """
+    Analyze a single RPM package.
+
+    :param pkg: the path to a single package
+    :return: two dicts; the first one containts the digests of the files and the
+             second one contains the ima signatures, if any
+    """
+    ts = rpm.TransactionSet()
+    ts.setVSFlags(rpm.RPMVSF_MASK_NOSIGNATURES | rpm.RPMVSF_MASK_NODIGESTS)
+
+    with open(pkg, "rb") as f:
+        hdr = ts.hdrFromFdno(f)
+
+    # Symbolic links in IMA are resolved before the measured,
+    # registering the final linked name in the logs
+    return _parse_rpm_header(hdr)
+
+
+def analyze_rpm_pkg_url(url: str) -> Tuple[Dict[str, List[str]], Dict[str, List[bytes]]]:
+    """Analyze a single RPM package from its URL."""
+    # To fetch the header we can emulate rpmReadPackageFile, but this
+    # seems to require multiple reads.  This simplified algorithm read
+    # first a sizeable blob, adjusted from the median of some repo
+    # analysis, and if the hdrFromFdno fails, try to expand it
+    # iteratively.
+
+    # Estimation of a RPM header size.
+    _RPM_HEADER_SIZE = 24 * 1024
+
+    # Hide errors while fetching partial headers.
+    with open(os.devnull, "wb") as devnull:
+        rpm.setLogFile(devnull)
+
+        logmsg = f"Fetching header for {url}"
+        logger.debug(logmsg)
+
+        blob = b""
+        chunk_size = _RPM_HEADER_SIZE
+        while True:
+            with tempfile.TemporaryFile() as f:
+                range_ = f"{len(blob)}-{len(blob) + chunk_size - 1}"
+                req = urllib.request.Request(url, headers={"Range": f"bytes={range_}"})
+                try:
+                    with urllib.request.urlopen(req) as resp:
+                        blob += resp.read()
+                except urllib.error.HTTPError as exc:
+                    errmsg = f"Error trying to open {url}: {exc}"
+                    logger.warning(errmsg)
+                    return {}, {}
+
+                f.write(blob)
+                f.seek(0)
+
+                ts = rpm.TransactionSet()
+                ts.setVSFlags(rpm.RPMVSF_MASK_NOSIGNATURES | rpm.RPMVSF_MASK_NODIGESTS)
+                try:
+                    hdr = ts.hdrFromFdno(f)
+                    break
+                except Exception:
+                    chunk_size = max(1024, int(chunk_size / 2))
+
+    # Symbolic links in IMA are resolved before the measured,
+    # registering the final linked name in the logs
+    return _parse_rpm_header(hdr)
+
+
+def analyze_local_repo(
+    *repodir: str,
+    digests: Optional[Dict[str, List[str]]] = None,
+    imasigs: Optional[Dict[str, List[bytes]]] = None,
+    jobs: Optional[int] = None,
+) -> Tuple[Dict[str, List[str]], Dict[str, List[bytes]], bool]:
+    """
+    Analyze a local repository.
+
+    :param *repodir: str, the directory of the repository, where "repodata" is
+           located
+    :param digests: dict of str and a list of strings, to store the files and
+                     their associated digests
+    :param imasigs: dict of str and a list of bytes, to store the files and
+                       their associated IMA signatures
+    :param jobs: integer, the number of jobs to use when processing the rpms
+    :return: tuple with the dict of digests, the dict of IMA signatures and a
+             boolean indicating the success of this method
+    """
+    # Validate repodir.
+    if not str(*repodir):
+        logger.error("Please specify a repository")
+        return {}, {}, False
+
+    repo = pathlib.Path(*repodir)
+    if not repo.exists():
+        errmsg = f"{repo.absolute()} does not seem to exist"
+        logger.error(errmsg)
+        return {}, {}, False
+
+    repodata_dir = repo.joinpath("repodata")
+    if not repodata_dir.exists():
+        errmsg = f"{repodata_dir.absolute()} does not seem to exist"
+        logger.error(errmsg)
+        return {}, {}, False
+
+    repomd_xml = repodata_dir.joinpath("repomd.xml")
+    if not repomd_xml.exists():
+        errmsg = f"{repomd_xml} cannot be found"
+        logger.error(errmsg)
+        return {}, {}, False
+
+    repomd_asc = repodata_dir.joinpath("repomd.xml.asc")
+    if repomd_asc.exists():
+        repomd_key = repodata_dir.joinpath("repomd.xml.key")
+        if not repomd_key.exists():
+            errmsg = f"Error. Key file {repomd_key} missing"
+            logger.error(errmsg)
+            return {}, {}, False
+
+        try:
+            verify_signature_from_file(repomd_key, repomd_xml, repomd_asc, "Repository metadata")
+        except Exception:
+            logger.error("Error. Invalid signature. Untrusted repository")
+            return {}, {}, False
+    else:
+        logger.warning("Warning. Unsigned repository. Continuing the RPM scanning")
+
+    jobs = jobs if jobs else multiprocessing.cpu_count()
+
+    if not digests:
+        digests = {}
+    if not imasigs:
+        imasigs = {}
+
+    # Analyze all the RPMs in parallel
+    with multiprocessing.Pool(jobs) as pool:
+        for rpm_digests, rpm_imasigs in pool.map(analyze_rpm_pkg, repo.glob("**/*.rpm")):
+            digests = merge_maplists(digests, rpm_digests)
+            imasigs = merge_maplists(imasigs, rpm_imasigs)
+
+    return digests, imasigs, True
+
+
+@contextmanager
+def get_from_url(url: str) -> Generator[str, None, None]:
+    """Download the contents of an URL."""
+    try:
+        with urllib.request.urlopen(url) as resp:
+            tfile = None
+            try:
+                tfile = tempfile.NamedTemporaryFile(prefix="keylime-policy-rpm-repo", delete=False)
+                fname = tfile.name
+                shutil.copyfileobj(resp, tfile)
+                tfile.close()
+                yield fname
+            finally:
+                if tfile:
+                    os.remove(tfile.name)
+    except (urllib.error.HTTPError, ValueError) as exc:
+        logger.debug("HTTP error with URL '%s': %s", url, exc)
+        yield ""
+
+
+def get_filelists_ext_from_repomd(repo: str, repomd_xml: str) -> Optional[str]:
+    """Parse the filelist_ext file from a given repomd.xml file."""
+    root = _parse_xml_file(repomd_xml).getroot()
+    location = root.find(
+        "./{http://linux.duke.edu/metadata/repo}data[@type='filelists-ext']/{http://linux.duke.edu/metadata/repo}location"
+    )
+    return urllib.parse.urljoin(repo, location.attrib["href"]) if location is not None else None
+
+
+def get_rpm_urls_from_repomd(repo: str, repomd_xml: str) -> List[str]:
+    """Parse the RPM URLs from a given repomd.xml file."""
+    root = _parse_xml_file(repomd_xml).getroot()
+    location = root.find(
+        "./{http://linux.duke.edu/metadata/repo}data[@type='primary']/{http://linux.duke.edu/metadata/repo}location"
+    )
+    if location is None:
+        logger.error("Error. Primary location tag not found")
+        return []
+
+    logger.debug("Generating package list from repo ...")
+    primary_xml_url = urllib.parse.urljoin(repo, location.attrib["href"])
+    with get_from_url(primary_xml_url) as primary_xml:
+        if not primary_xml:
+            logger.error("Error. Primary XML file cannot be downloaded")
+            return []
+
+        root = _parse_xml_file(primary_xml)
+
+        locations = root.findall(
+            "./{http://linux.duke.edu/metadata/common}package[@type='rpm']"
+            "/{http://linux.duke.edu/metadata/common}location"
+        )
+
+        return [urllib.parse.urljoin(repo, ll.attrib["href"]) for ll in locations]
+
+
+def _parse_xml_file(filepath: str) -> ET.ElementTree:
+    # We support only gzip compression, currently.
+    ctype = Compression.detect_from_file(filepath)
+    if ctype:
+        if ctype != Compression.GZIP:
+            errmsg = (
+                f"Compression type '{ctype}' NOT supported yet; The only compression format currently supported is gzip"
+            )
+            logger.debug(errmsg)
+            raise Exception(errmsg)
+        # Gzip.
+        with gzip.open(filepath) as to_parse:
+            return ET.parse(to_parse)
+
+    # Let us assume no compression here.
+    with open(filepath, encoding="UTF-8") as to_parse:
+        return ET.parse(to_parse)
+
+
+def _analyze_remote_repo(
+    repo: str, digests: Optional[Dict[str, List[str]]], imasigs: Optional[Dict[str, List[bytes]]], jobs: Optional[int]
+) -> Tuple[Dict[str, List[str]], Dict[str, List[bytes]], bool]:
+    # Make the repo ends with "/", so we can be considered as a base URL
+    repo = repo if (repo).endswith("/") else f"{repo}/"
+
+    if not digests:
+        digests = {}
+    if not imasigs:
+        imasigs = {}
+
+    repomd_xml_url = urllib.parse.urljoin(repo, "repodata/repomd.xml")
+    with get_from_url(repomd_xml_url) as repomd_xml:
+        if not repomd_xml:
+            errmsg = f"{repomd_xml_url} cannot be found"
+            logger.error(errmsg)
+            return {}, {}, False
+
+        repomd_asc_url = urllib.parse.urljoin(repo, "repodata/repomd.xml.asc")
+        print("ASC", repomd_asc_url)
+        with get_from_url(repomd_asc_url) as repomd_asc:
+            if repomd_asc:
+                repomd_key_url = urllib.parse.urljoin(repo, "repodata/repomd.xml.key")
+                with get_from_url(repomd_key_url) as repomd_key:
+                    if not repomd_key:
+                        errmsg = f"Error. Key file {repomd_key_url} missing"
+                        logger.error(errmsg)
+                        return {}, {}, False
+                    try:
+                        verify_signature_from_file(repomd_key, repomd_xml, repomd_asc, "Repository metadata")
+                    except Exception:
+                        logger.error("Error. Invalid signature. Untrusted repository")
+                        return {}, {}, False
+            else:
+                logger.warning("Warning. Unsigned repository. Continuing the RPM scanning")
+
+        # Check if this repo contains the filelists-ext.xml metadata
+        filelists_ext_xml_url = get_filelists_ext_from_repomd(repo, repomd_xml)
+        if filelists_ext_xml_url:
+            with get_from_url(filelists_ext_xml_url) as filelists_ext_xml:
+                if not filelists_ext_xml:
+                    errmsg = f"{filelists_ext_xml_url} cannot be found"
+                    logger.error(errmsg)
+                    return {}, {}, False
+
+                root = _parse_xml_file(filelists_ext_xml)
+                files = root.findall(".//{http://linux.duke.edu/metadata/filelists-ext}file[@hash]")
+                for f in files:
+                    if not f.text:
+                        continue
+                    v = digests.get(f.text, [])
+                    v.append(f.attrib["hash"])
+                    digests[f.text] = v
+
+                return digests, imasigs, True
+
+        # If not, use the slow method
+        logger.warning("Warning. filelist-ext.xml not present in the repo")
+        rpms = get_rpm_urls_from_repomd(repo, repomd_xml)
+
+    # The default job selection is a bit weird.  The issue is that
+    # seems that librpm can be not always thread safe, so we can use a
+    # single thread (asyncio) or multiple process.  To avoid change
+    # all the stack, I go for synchronous functions but with many
+    # process.  In the future we can move all to asyncio.
+    jobs = jobs if jobs else (multiprocessing.cpu_count() * 8)
+
+    # Analyze all the RPMs in parallel
+    with multiprocessing.Pool(jobs) as pool:
+        for rpm_digests, rpm_imasigs in pool.map(analyze_rpm_pkg_url, rpms):
+            digests = merge_maplists(digests, rpm_digests)
+            imasigs = merge_maplists(imasigs, rpm_imasigs)
+
+    return digests, imasigs, True
+
+
+def analyze_remote_repo(
+    *repourl: str,
+    digests: Optional[Dict[str, List[str]]] = None,
+    imasigs: Optional[Dict[str, List[bytes]]] = None,
+    jobs: Optional[int] = None,
+) -> Tuple[Dict[str, List[str]], Dict[str, List[bytes]], bool]:
+    """Analyze a remote repository."""
+    try:
+        return _analyze_remote_repo(str(*repourl), digests, imasigs, jobs)
+    except Exception as exc:
+        logger.error(exc)
+        return {}, {}, False

--- a/keylime/policy/utils.py
+++ b/keylime/policy/utils.py
@@ -1,0 +1,124 @@
+"""
+Module to assist with creating runtime policies.
+
+SPDX-License-Identifier: Apache-2.0
+Copyright 2024 Red Hat, Inc.
+"""
+
+import enum
+from typing import IO, Any, Dict, List, Optional
+
+
+def merge_lists(list1: List[Any], list2: List[Any]) -> List[Any]:
+    """Merge two lists removing repeated entries."""
+    list1.extend(list2)
+    return sorted(list(set(list1)))
+
+
+def merge_maplists(map1: Dict[Any, List[Any]], map2: Dict[Any, List[Any]]) -> Dict[Any, List[Any]]:
+    """Merge two maps of lists, removing repeated entries in the lists."""
+    for key, value in map2.items():
+        if key not in map1:
+            map1[key] = value
+            continue
+        map1[key] = merge_lists(map1[key], map2[key])
+    return map1
+
+
+def read_bytes_from_open_file(infile: IO[bytes], offset: int, count: int) -> bytes:
+    """
+    Read a specified amount of bytes from the input file, from a given offset.
+
+    :param infile: the (open) file to read the files from
+    :param offset: the offset to use with the provided file to read the bytes from
+    :param count: the amount of bytes to read from
+    :return: the requested bytes
+    """
+    infile.seek(offset)
+    return infile.read(count)
+
+
+def read_bytes_from_file(fpath: str, offset: int, count: int) -> bytes:
+    """
+    Read a specified amount of bytes from the input file, from a given offset.
+
+    :param fpath: the path for the file to read the bytes from
+    :param offset: the offset to use with the provided file to read the bytes from
+    :param count: the amount of bytes to read from
+    :return: the requested bytes
+    """
+    with open(fpath, "rb") as infile:
+        return read_bytes_from_open_file(infile, offset, count)
+
+
+class Magic(bytes, enum.Enum):
+    """Magic bytes for identifying file types."""
+
+    CPIO_NEW_ASCII = b"070701"
+    CPIO_CRC = b"070702"
+    LZO = b"\x89\x4c\x5a\x4f\x00\x0d"
+    BZIP2 = b"BZh"
+    GZIP = b"\x1f\x8b"
+    ZSTD = b"\x28\xB5\x2F\xFD"
+    LZ4 = b"\x04\x22\x4d\x18"
+    XZ = b"\xFD\x37\x7A\x58\x5A\x00"
+
+
+class Compression(str, enum.Enum):
+    """Compression formats."""
+
+    BZIP2 = "bzip2"
+    GZIP = "gzip"
+    ZSTD = "zstd"
+    XZ = "xz"
+    LZO = "lzo"
+    LZ4 = "lz4"
+    ZCK = "zchunk"
+    CPIO = "cpio"
+
+    @staticmethod
+    def detect(magic: bytes) -> Optional[str]:
+        """Detect compression format from given magic bytes."""
+        # Magic bytes for identifying file types.
+        MAGIC_CPIO_NEW_ASCII: bytes = b"070701"
+        MAGIC_CPIO_CRC: bytes = b"070702"
+        MAGIC_LZO: bytes = b"\x89\x4c\x5a\x4f\x00\x0d"
+        MAGIC_BZIP2: bytes = b"BZh"
+        MAGIC_GZIP: bytes = b"\x1f\x8b"
+        MAGIC_ZSTD: bytes = b"\x28\xB5\x2F\xFD"
+        MAGIC_LZ4: bytes = b"\x04\x22\x4d\x18"
+        MAGIC_XZ: bytes = b"\xFD\x37\x7A\x58\x5A\x00"
+        MAGIC_ZCK_V1: bytes = b"\x00ZCK1"
+        MAGIC_ZCK_DET_V1: bytes = b"\x00ZHR1"
+
+        formats = {
+            MAGIC_CPIO_NEW_ASCII: Compression.CPIO,
+            MAGIC_CPIO_CRC: Compression.CPIO,
+            MAGIC_LZO: Compression.LZO,
+            MAGIC_BZIP2: Compression.BZIP2,
+            MAGIC_GZIP: Compression.GZIP,
+            MAGIC_ZSTD: Compression.ZSTD,
+            MAGIC_LZ4: Compression.LZ4,
+            MAGIC_XZ: Compression.XZ,
+            MAGIC_ZCK_V1: Compression.ZCK,
+            MAGIC_ZCK_DET_V1: Compression.ZCK,
+        }
+
+        for m, ctype in formats.items():
+            if magic.startswith(m):
+                return ctype
+
+        return None
+
+    @staticmethod
+    def detect_from_open_file(infile: IO[bytes], offset: int = 0) -> Optional[str]:
+        """Detect compression format from given file and offset."""
+        _MAGIC_LEN = 6
+        magic = read_bytes_from_open_file(infile, offset, _MAGIC_LEN)
+        return Compression.detect(magic)
+
+    @staticmethod
+    def detect_from_file(fpath: str, offset: int = 0) -> Optional[str]:
+        """Detect compression format from given file path and offset."""
+        with open(fpath, "rb") as infile:
+            return Compression.detect_from_open_file(infile, offset)

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,4 +55,5 @@ console_scripts =
         keylime_convert_runtime_policy = keylime.cmd.convert_runtime_policy:main
         keylime_sign_runtime_policy = keylime.cmd.sign_runtime_policy:main
         keylime_upgrade_config = keylime.cmd.convert_config:main
-	keylime_create_policy = keylime.cmd.create_policy:main
+        keylime_create_policy = keylime.cmd.create_policy:main
+        keylime_policy = keylime.cmd.keylime_policy:main

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,6 @@
 dbus-python
+# modules required for pylint
+setuptools
 # packages required for mypy
 sqlalchemy-stubs
 typed-ast

--- a/test/data/create-runtime-policy/setup-initrd-tests
+++ b/test/data/create-runtime-policy/setup-initrd-tests
@@ -1,0 +1,161 @@
+#!/bin/bash
+set -euo pipefail
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Red Hat, Inc.
+
+BASEDIR=${1:-}
+if [ -z "${BASEDIR}" ] || [ ! -d "${BASEDIR}" ]; then
+    echo "Please specify a valid directory to use for setting up the dummy initrds" >&2
+    exit 1
+fi
+
+TREE="${BASEDIR}"/tree
+CPIO="${BASEDIR}"/main.cpio
+EARLY_CPIO="${BASEDIR}"/early
+OUTDIR="${BASEDIR}"/initrd
+INITRD_PREFIX="${OUTDIR}"/initramfs-keylime
+DUMMY_ROOTFS="${BASEDIR}"/dummy-rootfs
+
+build_fedora_like_early_tree() {
+    [ -n "${TREE}" ] \
+        || die "Please indicate the dummy initrd tree in the TREE variable"
+
+    # Let's first create a dummy tree to serve as our "initrd".
+    [ -d "${TREE}" ] && rm -rf "${TREE}"
+    mkdir -p "${TREE}"
+
+    printf '1\n' > "${TREE}"/early_cpio
+}
+
+build_debian_like_early_tree() {
+    [ -n "${TREE}" ] \
+        || die "Please indicate the dummy initrd tree in the TREE variable"
+
+    # Let's first create a dummy tree to serve as our "initrd".
+    [ -d "${TREE}" ] && rm -rf "${TREE}"
+    mkdir -p "${TREE}"
+
+    mkdir -p "${TREE}"/kernel/x86/microcode
+    printf 'foobar\n' > "${TREE}"/kernel/x86/microcode/GenuineFooBar.bin
+}
+
+
+build_dummy_tree() {
+    [ -n "${TREE}" ] \
+        || die "Please indicate the dummy initrd tree in the TREE variable"
+
+    # Let's first create a dummy tree to serve as our "initrd".
+    [ -d "${TREE}" ] && rm -rf "${TREE}"
+    mkdir -p "${TREE}"
+
+    # Now let's populate it.
+    mkdir -p "${TREE}"/{dev,var/tmp,usr/{bin,sbin,lib,lib64}}
+
+    ln -s usr/bin "${TREE}"/bin
+    ln -s usr/sbin "${TREE}"/sbin
+    ln -s usr/lib "${TREE}"/lib
+    ln -s usr/lib64 "${TREE}"/lib64
+
+    # Add also a couple of dummy scripts.
+    # foo: sha256:18eb0ba043d6fc5b06b6f785b4a411fa0d6d695c4a08d2497e8b07c4043048f7
+    printf '#!/bin/sh\necho foo\n' > "${TREE}"/usr/bin/foo
+    # bar: sha256:dd2ccf6ebfabbca501864a3ec5aebecfadd69d717ea9d9ddd509b49471d039db
+    printf '#!/bin/sh\necho bar\n' > "${TREE}"/usr/sbin/bar
+    # foobar.so: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    printf '' > "${TREE}"/usr/lib/foobar.so
+    # foobar.so: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    printf '' > "${TREE}"/usr/lib64/foobar64.so
+
+    printf '' > "${TREE}/dev/foo bar"
+    # Add a named pipe/FIFO as well.
+    mknod "${TREE}"/usr/fifo p
+}
+
+make_early_cpio() {
+    for distro in fedora debian; do
+        cpio_f="build_${distro}_like_early_tree"
+
+        "${cpio_f}"
+        (
+            cd "${TREE}" && find . -print0 | sort -z \
+                | cpio --null --quiet -o -H newc \
+                > "${EARLY_CPIO}-${distro}.cpio"
+        )
+    done
+}
+
+make_cpio() {
+    build_dummy_tree
+    # Let's build the CPIO file here too.
+    (
+        cd "${TREE}" && find . -print0 | sort -z \
+            | cpio --null --quiet -o -H newc > "${CPIO}"
+    )
+    build_debian_like_early_tree
+}
+
+build_dummy_rootfs() {
+    mkdir -p "${DUMMY_ROOTFS}"/{dev,var/tmp,usr/{bin,sbin,lib,lib64},tmp,root,home/foobar}
+    # All dummy files with sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    printf '' > "${DUMMY_ROOTFS}"/dev/foobar-sdaX
+    printf '' > "${DUMMY_ROOTFS}"/var/tmp/foobar
+    printf '' > "${DUMMY_ROOTFS}"/usr/bin/foobar-bin
+    printf '' > "${DUMMY_ROOTFS}"/usr/sbin/foobar-sbin
+    printf '' > "${DUMMY_ROOTFS}"/usr/lib/foobar.so
+    printf '' > "${DUMMY_ROOTFS}"/usr/lib64/foobar64.so
+    printf '' > "${DUMMY_ROOTFS}"/usr/lib64/foobar-temp
+    printf '' > "${DUMMY_ROOTFS}"/root/foobar-root
+    printf '' > "${DUMMY_ROOTFS}"/home/foobar/non-root
+
+    if [ "${EUID}" -eq 0 ]; then
+        # Running as root, let's make sure at least home
+        # is not owned by root.
+        chown 0:0 -R "${DUMMY_ROOTFS}"/
+        chown 1000:1000 -R "${DUMMY_ROOTFS}"/home/
+    fi
+}
+
+build_dummy_rootfs
+make_early_cpio
+make_cpio
+
+# Now let's compress our CPIO.
+[ -d "${OUTDIR}" ] && rm -rf "${OUTDIR}"
+mkdir -p "${OUTDIR}"
+
+# Let's get info on the compression available.
+c_missing=
+compression=
+for c in cat gzip zstd bzip2 xz lzma lz4 lzop; do
+    if ! command -v "${c}" >/dev/null 2>/dev/null; then
+        c_missing="${c_missing} ${c}"
+        continue
+    fi
+    compression="${compression} ${c}"
+done
+
+if [ -n "${c_missing}" ]; then
+    echo "WARN: not testing with the following compression because it was not found in the path:${c_missing}" >&2
+fi
+
+for distro in debian fedora; do
+    for compress in ${compression}; do
+        if ! command -v "${compress}" >/dev/null 2>/dev/null; then
+            echo "WARN: not compressing with '${compress}' because it was not found in the PATH" >&2
+            continue
+        fi
+
+        cmd="${compress} -c"
+        [ "${compress}"  = "cat" ] && cmd="${compress}"
+
+        # Version concatenated with the early_cpio.
+        dst="${INITRD_PREFIX}-early-${distro}-${compress}".img
+        cp "${EARLY_CPIO}-${distro}".cpio "${dst}"
+        ${cmd} < "${CPIO}" >> "${dst}"
+
+        # Without the early_cpio.
+        dst="${INITRD_PREFIX}-${distro}-${compress}".img
+        ${cmd} < "${CPIO}" >> "${dst}"
+    done
+done

--- a/test/data/create-runtime-policy/setup-rpm-tests
+++ b/test/data/create-runtime-policy/setup-rpm-tests
@@ -1,0 +1,331 @@
+#!/bin/bash
+set -euo pipefail
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Red Hat, Inc.
+
+die() {
+    echo "${0} ERROR: ${1}" >&2
+    exit "${2:-1}"
+}
+
+BASEDIR=${1:-}
+if [ -z "${BASEDIR}" ] || [ ! -d "${BASEDIR}" ]; then
+    die "Please specify a valid directory to use for setting up the dummy rpms"
+fi
+
+BASEDIR="$(realpath "${BASEDIR}")"
+
+# rpmbuild
+RPMBUILD="${BASEDIR}"/rpmbuild
+SPECDIR="${RPMBUILD}"/SPECS
+SRCDIR="${RPMBUILD}"/SOURCES
+BUILDDIR="${RPMBUILD}"/BUILD
+BUILDROOTDIR="${RPMBUILD}"/BUILDROOT
+RPMSDIR="${RPMBUILD}"/RPMS
+SRPMSDIR="${RPMBUILD}"/SRPMS
+SPECFILE="${BASEDIR}"/dummy-template.spec
+EMPTY_SPECFILE="${BASEDIR}"/dummy-empty-template.spec
+
+MACROS_RC="${BASEDIR}"/rpmbuild-macros
+MACROS_RC_SIG="${BASEDIR}"/rpmbuild-macros-sig
+# gpg
+GPGDIR_RSA="${BASEDIR}"/gnupg/rsa
+GPGDIR_ECC="${BASEDIR}"/gnupg/ecc
+GPGRSA="gpg --homedir ${GPGDIR_RSA} --batch --yes"
+GPGECC="gpg --homedir ${GPGDIR_ECC} --batch --yes"
+
+# IMA signing keys.
+IMA_KEYSDIR="${BASEDIR}"/ima-keys
+IMA_KEYS_CFG="${IMA_KEYSDIR}"/config
+IMA_PRIV_KEY="${IMA_KEYSDIR}"/privkey.pem
+IMA_PUB_KEY="${IMA_KEYSDIR}"/pubkey.pem
+IMA_KEYS_CERT_DER="${IMA_KEYSDIR}"/x509.der
+
+# test repositories
+RPM_REPO_UNSIGNED="${BASEDIR}"/repo/unsigned
+RPM_REPO_SIGNED_ECC="${BASEDIR}"/repo/signed-ecc
+RPM_REPO_SIGNED_RSA="${BASEDIR}"/repo/signed-rsa
+RPM_REPO_SIGNED_MISMATCH="${BASEDIR}"/repo/signed-mismatch
+RPM_REPO_SIGNED_NO_REPOMD="${BASEDIR}"/repo/no-repomd
+RPM_REPO_SIGNED_NO_KEY="${BASEDIR}"/repo/signed-no-key
+RPM_REPO_FILELIST_EXT_MISMATCH="${BASEDIR}"/repo/filelist-ext-mismatch
+RPM_REPO_UNSUPPORTED_COMPRESSION="${BASEDIR}"/repo/unsupported-compression
+
+sanity_check() {
+    # We need the following programs available for this to work.
+    _progs="gpg rpmbuild rpmsign createrepo_c openssl"
+    for _p in ${_progs}; do
+        command -v "${_p}" >/dev/null || die "'${_p}' NOT available" 77
+    done
+}
+
+create_ima_keys() {
+    mkdir -p "${IMA_KEYSDIR}"
+
+    cat << EOF > "${IMA_KEYS_CFG}"
+[ req ]
+default_bits = 3072
+default_md = sha256
+distinguished_name = req_distinguished_name
+prompt = no
+string_mask = utf8only
+x509_extensions = myexts
+
+[ req_distinguished_name ]
+O = Keylime Test Suite
+CN = Executable Signing Key
+emailAddress = keylime@example.com
+
+[ myexts ]
+basicConstraints=critical,CA:FALSE
+keyUsage=digitalSignature
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid
+EOF
+
+    openssl req -x509 -new -nodes -utf8 -days 90 -batch -x509 \
+        -config "${IMA_KEYS_CFG}" -outform DER \
+        -out "${IMA_KEYS_CERT_DER}" -keyout "${IMA_PRIV_KEY}"
+    openssl rsa -pubout -in "${IMA_PRIV_KEY}" -out "${IMA_PUB_KEY}"
+}
+
+create_gpg_rsa_key() {
+    mkdir -p "${GPGDIR_RSA}"
+    chmod 700 "${GPGDIR_RSA}"
+
+    ${GPGRSA} --gen-key <<EOF
+%no-protection
+Key-Type: RSA
+Key-Length: 3072
+Subkey-Type: RSA
+Subkey-Length: 3072
+Name-Real: Keylime Test Suite
+Name-Email: keylime@example.com
+Expire-Date: 0
+EOF
+}
+
+create_gpg_ecc_key() {
+    mkdir -p "${GPGDIR_ECC}"
+    chmod 700 "${GPGDIR_ECC}"
+
+    ${GPGECC} --gen-key <<EOF
+%no-protection
+Key-Type:  ECDSA
+Key-Curve: nistp256
+Subkey-Type: ECDH
+Subkey-Curve: nistp256
+Name-Real: Keylime Test Suite
+Name-Email: keylime@example.com
+Expire-Date: 0
+EOF
+}
+
+create_keys() {
+    [ -d "${GPGDIR_RSA}" ] || create_gpg_rsa_key
+    [ -d "${GPGDIR_ECC}" ] || create_gpg_ecc_key
+    [ -d "${IMA_KEYSDIR}" ] || create_ima_keys
+}
+
+save_spec_template() {
+    _dst="${1}"
+cat << EOF > "${_dst}"
+%global source_date_epoch_from_changelog 0
+Name: DUMMY-%{dummy_name}
+Version: %{dummy_version}
+Release: %{dummy_release}
+Summary: Dummy package for testing purposes
+Provides: %{dummy_name}
+BuildArch: noarch
+License: CC0
+%description
+Dummy package for testing purposes, not intended to be installed.
+%install
+mkdir -p %{buildroot}%{_bindir}
+printf 'foo' > %{buildroot}%{_bindir}/dummy-foobar
+mkdir -p %{buildroot}%{_sysconfdir}
+printf 'bar' > %{buildroot}%{_sysconfdir}/dummy-foobar.conf
+%files
+%{_bindir}/dummy-foobar
+%{_sysconfdir}/dummy-foobar.conf
+EOF
+}
+
+save_empty_spec_template() {
+    _dst="${1}"
+cat << EOF > "${_dst}"
+%global source_date_epoch_from_changelog 0
+Name: DUMMY-%{dummy_name}
+Version: %{dummy_version}
+Release: %{dummy_release}
+Summary: Dummy package for testing purposes
+Provides: %{dummy_name}
+BuildArch: noarch
+License: CC0
+%description
+Dummy package for testing purposes, not intended to be installed.
+%files
+EOF
+}
+
+create_rpmbuild_macros() {
+    _dst="${1}"
+cat << EOF > "${_dst}"
+%_sourcedir ${SRCDIR}
+%_rpmdir ${RPMSDIR}
+%_srcrpmdir ${SRPMSDIR}
+%_specdir ${SPECDIR}
+%_builddir ${BUILDDIR}
+EOF
+}
+
+create_rpmbuild_macros_sig() {
+    _dst="${1}"
+    create_rpmbuild_macros "${_dst}"
+
+    cat << EOF >> "${_dst}"
+%_signature ${GPGRSA}
+%_gpg_path ${GPGDIR_RSA}
+%_gpg_name keylime@example.com
+%_gpgbin /usr/bin/gpg2
+%__gpg_sign_cmd %{__gpg} ${GPGRSA} --force-v3-sigs --verbose --no-armor --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}'
+%_file_signing_key ${IMA_PRIV_KEY}
+EOF
+}
+
+create_rpm() {
+    _name="${1}"
+    _version="${2}"
+    _rel="${3}"
+    _spec="${4}"
+    _signed=${5:-}
+
+    _macros="${MACROS_RC}"
+    [ -n "${_signed}" ] && _macros="${MACROS_RC_SIG}"
+
+    rpmbuild --define "dummy_name ${_name}" \
+             --define "dummy_version ${_version}" \
+             --define "dummy_release ${_rel}" \
+             --load="${_macros}" \
+             -bb "${_spec}"
+
+    # Make sure rpm was created at the right place.
+    # From the following commit, it seems rpmbuild will not honor
+    # the custom settings defined via the macros and will build
+    # into ~/rpmbuild regardless.
+    # https://github.com/rpm-software-management/rpm/commit/96467dce18f264b278e17ffe1859c88d9b5aa4b6
+    _pkgname="DUMMY-${_name}-${_version}-${_rel}.noarch.rpm"
+
+    _expected_pkg="${RPMSDIR}/noarch/${_pkgname}"
+    [ -e "${_expected_pkg}" ] && return 0
+
+    # OK, the package was not built where it should. Let us see if
+    # it was built in ~/rpmbuild instead, and if that is the case,
+    # copy it to the expected location.
+    _bad_location_pkg="${HOME}/rpmbuild/RPMS/noarch/${_pkgname}"
+    if [ -e "${_bad_location_pkg}" ]; then
+        echo "WARNING: the package ${_pkgname} was built into ~/rpmbuild despite rpmbuild being instructed to build it at a different location. Probably a fallout from https://github.com/rpm-software-management/rpm/commit/96467dce" >&2
+        install -D -m644 "${_bad_location_pkg}" "${_expected_pkg}"
+        return 0
+    fi
+
+    # Should not be here.
+    return 1
+}
+
+prepare_rpms() {
+    save_spec_template "${SPECFILE}"
+    save_empty_spec_template "${EMPTY_SPECFILE}"
+
+    # Create the required rpmbuild directories.
+    mkdir -p "${SPECDIR}" "${SRCDIR}" "${BUILDDIR}" \
+             "${BUILDROOTDIR}" "${RPMSDIR}" "${SRPMSDIR}"
+
+    # And the directories for the repositories.
+    for _repodir in "${RPM_REPO_UNSIGNED}" \
+                    "${RPM_REPO_SIGNED_RSA}" \
+                    "${RPM_REPO_SIGNED_ECC}" \
+                    "${RPM_REPO_SIGNED_MISMATCH}"; do
+        [ -d "${_repodir}" ] && rm -rf "${_repodir}"
+        mkdir -p "${_repodir}"
+    done
+
+    # Now let us build the RPMs.
+    create_rpmbuild_macros "${MACROS_RC}"
+    create_rpmbuild_macros_sig "${MACROS_RC_SIG}"
+    _version=42.0.0
+    _rel=el42
+    for _pn in foo bar; do
+        create_rpm "${_pn}" "${_version}" "${_rel}" "${SPECFILE}"
+    done
+
+    # Create an empty rpm as well.
+    create_rpm "empty" "${_version}" "${_rel}" "${EMPTY_SPECFILE}"
+
+    # And copy them to the "unsigned" repo.
+    find "${RPMSDIR}" -type f -name '*.rpm' -exec cp {} "${RPM_REPO_UNSIGNED}"/ \;
+    pushd "${RPM_REPO_UNSIGNED}" >/dev/null
+        createrepo_c --general-compress-type=gz .
+    popd >/dev/null
+
+    # Now we can copy the content over to the signed versions.
+    for _repodir in "${RPM_REPO_SIGNED_RSA}" \
+                    "${RPM_REPO_SIGNED_ECC}"; do
+        cp -a "${RPM_REPO_UNSIGNED}"/* "${_repodir}"/
+    done
+
+    # For ${RPM_REPO_SIGNED_RSA}", let us also pass --filelist-ext
+    # to createrepo_c.
+    pushd "${RPM_REPO_SIGNED_RSA}" >/dev/null
+        createrepo_c --general-compress-type=gz --filelists-ext .
+    popd >/dev/null
+
+    # Sign the repo metadata for the signed repos with both an RSA
+    # and an ECC gpg key..
+    ${GPGRSA} --detach-sign \
+              --armor "${RPM_REPO_SIGNED_RSA}"/repodata/repomd.xml
+    ${GPGRSA} --output "${RPM_REPO_SIGNED_RSA}"/repodata/repomd.xml.key \
+              --armor --export keylime@example.com
+
+    ${GPGECC} --detach-sign \
+              --armor "${RPM_REPO_SIGNED_ECC}"/repodata/repomd.xml
+    ${GPGECC} --output "${RPM_REPO_SIGNED_ECC}"/repodata/repomd.xml.key \
+              --armor --export keylime@example.com
+
+    # For the mismatched one, let's use the asc file from the RSA repo
+    # and the key from the ECC one.
+    cp "${RPM_REPO_SIGNED_RSA}"/* -a "${RPM_REPO_SIGNED_MISMATCH}"/
+    cp -f "${RPM_REPO_SIGNED_ECC}"/repodata/repomd.xml.key \
+        "${RPM_REPO_SIGNED_MISMATCH}"/repodata/repomd.xml.key
+
+    # A repo without the repomd.xml file.
+    mkdir -p "${RPM_REPO_SIGNED_NO_REPOMD}"/repodata/
+
+    # Now a signed repo without the key.
+    mkdir -p "${RPM_REPO_SIGNED_NO_KEY}"
+    cp "${RPM_REPO_SIGNED_RSA}"/* -a "${RPM_REPO_SIGNED_NO_KEY}"/
+    rm -f "${RPM_REPO_SIGNED_NO_KEY}"/repodata/repomd.xml.key
+
+    # And a repo without the filelists-ext file, although it indicates
+    # it has one.
+    mkdir -p "${RPM_REPO_FILELIST_EXT_MISMATCH}"
+    cp "${RPM_REPO_SIGNED_RSA}"/* -a "${RPM_REPO_FILELIST_EXT_MISMATCH}"/
+    rm -f "${RPM_REPO_FILELIST_EXT_MISMATCH}"/repodata/*-filelists-ext.xml*
+
+    # Add a repo using non-supported compression for the files.
+    # We currently support only gzip.
+    mkdir -p "${RPM_REPO_UNSUPPORTED_COMPRESSION}"
+    find "${RPMSDIR}" -type f -name '*.rpm' -exec cp {} "${RPM_REPO_UNSUPPORTED_COMPRESSION}"/ \;
+    pushd "${RPM_REPO_UNSUPPORTED_COMPRESSION}" >/dev/null
+        createrepo_c --general-compress-type=xz .
+    popd >/dev/null
+
+    # Now let us add IMA signatures to the rpms in RPM_REPO_SIGNED_RSA.
+    find "${RPM_REPO_SIGNED_RSA}" -type f -name '*.rpm' -exec \
+        rpmsign --load="${MACROS_RC_SIG}" --addsign --signfiles {} \;
+}
+
+sanity_check
+create_keys
+prepare_rpms

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -191,15 +191,20 @@ echo "==========================================================================
 echo $'\t\t\tRunning Unit Tests'
 echo "=================================================================================="
 # Run separate unit tests
+# Newer versions of pytest exit with status 5 to indicate no tests were
+# collected to run: https://github.com/pytest-dev/pytest/pull/817
+PYTEST_NO_TESTS_RAN=5
 python3 -m unittest discover -s keylime/ima -p '*_test.py' -v
-if [ $? -ne 0 ]; then
-    echo "Error: Unit tests failed"
+_ret=$?
+if [ ${_ret} -ne 0 ] && [ ${_ret} -ne ${PYTEST_NO_TESTS_RAN} ]; then
+    echo "Error(keylime/ima): Unit tests failed"
     exit 1
 fi
 
 python3 -m unittest discover -s keylime/tpm -p '*_test.py' -v
-if [ $? -ne 0 ]; then
-    echo "Error: Unit tests failed"
+_ret=$?
+if [ ${_ret} -ne 0 ] && [ ${_ret} -ne ${PYTEST_NO_TESTS_RAN} ]; then
+    echo "Error(keylime/tpm): Unit tests failed"
     exit 1
 fi
 

--- a/test/test-requirements.txt
+++ b/test/test-requirements.txt
@@ -1,5 +1,5 @@
 # Python dependencies only required for running the tests.
 
 coverage==4.5.2
-green==2.13.0
+green==4.0.2  # Python 3.12+ requires this.
 pytest-asyncio==0.10.0

--- a/test/test_algorithms.py
+++ b/test/test_algorithms.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import unittest
 
-from keylime.common.algorithms import Hash
+from keylime.common.algorithms import Encrypt, Hash, Sign
 
 
 class TestHash(unittest.TestCase):
@@ -95,4 +95,66 @@ class TestHash(unittest.TestCase):
                 mfile.write(contents)
 
             for c in test_cases:
-                self.assertEqual(Hash(c["hash"]).file_digest(targetfile), c["digest"])
+                self.assertEqual(Hash(c["hash"]).file_digest(targetfile), c["digest"], msg=f"hash = {c['hash']}")
+
+
+class TestEncrypt(unittest.TestCase):
+    def test_is_recognized(self):
+        test_cases = [
+            {
+                "enc": "foobar",
+                "valid": False,
+            },
+            {
+                "enc": "rsa",
+                "valid": True,
+            },
+            {
+                "enc": "",
+                "valid": False,
+            },
+            {
+                "enc": "ecc",
+                "valid": True,
+            },
+        ]
+
+        for c in test_cases:
+            self.assertEqual(Encrypt.is_recognized(c["enc"]), c["valid"], msg=f"enc = {c['enc']}")
+
+
+class TestSign(unittest.TestCase):
+    def test_is_recognized(self):
+        test_cases = [
+            {
+                "sign": "foobar",
+                "valid": False,
+            },
+            {
+                "sign": "rsassa",
+                "valid": True,
+            },
+            {
+                "sign": "rsapss",
+                "valid": True,
+            },
+            {
+                "sign": "",
+                "valid": False,
+            },
+            {
+                "sign": "ecdsa",
+                "valid": True,
+            },
+            {
+                "sign": "ecdaa",
+                "valid": True,
+            },
+            {
+                "sign": "ecschnorr",
+                "valid": True,
+            },
+        ]
+
+        for c in test_cases:
+            self.assertEqual(Sign.is_recognized(c["sign"]), c["valid"], msg=f"sign = {c['sign']}")

--- a/test/test_algorithms.py
+++ b/test/test_algorithms.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import unittest
 
 from keylime.common.algorithms import Hash
@@ -27,3 +29,70 @@ class TestHash(unittest.TestCase):
             Hash.SHA256.hash(b""),
             b"\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99o\xb9$'\xaeA\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U",
         )
+
+    def test_is_recognized(self):
+        test_cases = [
+            {
+                "hash": "foobar",
+                "valid": False,
+            },
+            {
+                "hash": "sha1",
+                "valid": True,
+            },
+            {
+                "hash": "",
+                "valid": False,
+            },
+            {
+                "hash": "sm3_256",
+                "valid": True,
+            },
+        ]
+
+        for c in test_cases:
+            self.assertEqual(Hash.is_recognized(c["hash"]), c["valid"])
+
+    def test_hexdigest_len(self):
+        test_cases = [
+            {"hash": "sha1", "len": 40},
+            {"hash": "sha256", "len": 64},
+            {"hash": "sha384", "len": 96},
+            {"hash": "sha512", "len": 128},
+            {
+                "hash": "sm3_256",
+                "len": 64,
+            },
+        ]
+
+        for c in test_cases:
+            self.assertEqual(Hash(c["hash"]).hexdigest_len(), c["len"])
+
+    def test_file_digest(self):
+        contents = "x" * (1024 * 1024)
+        test_cases = [
+            {
+                "hash": "sha1",
+                "digest": "e37f4d5be56713044d62525e406d250a722647d6",
+            },
+            {
+                "hash": "sha256",
+                "digest": "8f990ba0b577b51cf009ea049368c16bbda1b21e1b93be07a824758bb253c39b",
+            },
+            {
+                "hash": "sha384",
+                "digest": "f0ec47c12284409dcd83c83d865d261c5cba38a686ae10b138972c8b086f89426c0f17a52f1483ef49ba6fc594932508",
+            },
+            {
+                "hash": "sha512",
+                "digest": "d42a194e9f95d26282ff043c788a39cd16b658462aafcbd978974c93733bc270f887e5689eb28710dad31ef992cec4fc7979a6ff2d12cd5a9986bc5442ab22ab",
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            targetfile = os.path.join(tmpdir, "dummy-file")
+            with open(targetfile, "w", encoding="UTF-8") as mfile:
+                mfile.write(contents)
+
+            for c in test_cases:
+                self.assertEqual(Hash(c["hash"]).file_digest(targetfile), c["digest"])

--- a/test/test_cert_utils.py
+++ b/test/test_cert_utils.py
@@ -265,3 +265,54 @@ class Cert_Utils_Test(unittest.TestCase):
             base64.b64decode(idevid_der), base64.b64decode(iak_der), TEST_CERT_DIR
         )
         self.assertTrue(error == "")
+
+    def test_is_x509_cert(self):
+        test_cases = [
+            {
+                "data": b"",
+                "valid": False,
+            },
+            {
+                "data": base64.b64decode(
+                    """MIIDyDCCArCgAwIBAgIBATANBgkqhkiG9w0BAQsFADBzMQswCQYDVQQGEwJVUzEm
+MCQGA1UEAwwdS2V5bGltZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxCzAJBgNVBAgM
+Ak1BMRIwEAYDVQQHDAlMZXhpbmd0b24xDjAMBgNVBAoMBU1JVExMMQswCQYDVQQL
+DAI1MzAeFw0yNDA2MjIxMjAxMDFaFw0zNDA2MjAxMjAxMDFaMHMxCzAJBgNVBAYT
+AlVTMSYwJAYDVQQDDB1LZXlsaW1lIENlcnRpZmljYXRlIEF1dGhvcml0eTELMAkG
+A1UECAwCTUExEjAQBgNVBAcMCUxleGluZ3RvbjEOMAwGA1UECgwFTUlUTEwxCzAJ
+BgNVBAsMAjUzMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwgO1/Evq
+wn0bJwu3aQ9mhgZ8rA6mGx7IFTCncJx1pFg4WIviFBoFydJhvvdxWw5eavXUNoXK
+/EjTEX8RRV/nw/JF2b8Cq2Ypn/Apzjx7TSUFS17A/CidR/+nDEiqfm1OIgzFkG0L
+eXLKn3MbkWmyM1LkamizbzM4PSfDpPJyQ+QNWZfaSebLP+a41HFWVyxMYAGnOxlv
+uIjjG32uB+2l2lwiHVq5WPzeQyIlF5I/k4rE2EyLaLyQvyzVkMuM/HVfsWw/WhYJ
+DM3Z9ZLpL9kEi/d/ytI21jlXkNJFyrh3xudhi9yrvYkRLj90UtCcEXXxsivq5G32
+T7via4I0yfkaZwIDAQABo2cwZTAMBgNVHRMEBTADAQH/MB0GA1UdDgQWBBRd6bco
+tMXw+7u2Jed12DefJa/TtDApBgNVHR8EIjAgMB6gHKAahhhodHRwOi8vbG9jYWxo
+b3N0L2NybC5wZW0wCwYDVR0PBAQDAgEGMA0GCSqGSIb3DQEBCwUAA4IBAQAAnRAU
+ZujKyl76ZQHE5sbA2oc7Gl13Ki9rj8SjkpkLr0kufaf3fEr89Mk6DDelyqb3YYd3
+Is8m8OKPhtA1CBQKph/FYPTV0PUozp7/Tn0qDxRDGVO819Dxe99mwwOh0d0LhH6A
+ZWhPWPde+NevjfO3AMQs6F0FrxyJlqV46Gc1ipCLrP6N3nujpIIfu+UJMQ4kiYGT
+hlXUEWpfno1blCRGDzyYL86rthQN6ZD+Zj9L2YrfsA2P0sdxFAIBI3KQ5TMVCP/t
+LApSvvVeV19fEod6DUYTYBuGkQAD1b88q8/J9NDeSWgfEB6UWEDY0vygHiiRF7iw
+VMuvlCzEwd8V/FIw"""
+                ),
+                "valid": True,
+            },
+            {
+                "data": base64.b64decode(st_sha256_with_rsa_der),
+                "valid": True,
+            },
+            {
+                "data": f"-----BEGIN CERTIFICATE-----\n{st_sha256_with_rsa_der}\n-----END CERTIFICATE-----".encode(
+                    "UTF-8"
+                ),
+                "valid": True,
+            },
+            {
+                "data": b"foobar",
+                "valid": False,
+            },
+        ]
+
+        for index, c in enumerate(test_cases):
+            self.assertEqual(cert_utils.is_x509_cert(c["data"]), c["valid"], msg=f"index is {index}")

--- a/test/test_create_runtime_policy.py
+++ b/test/test_create_runtime_policy.py
@@ -1,0 +1,552 @@
+"""
+SPDX-License-Identifier: Apache-2.0
+Copyright 2024 Red Hat, Inc.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from importlib import util
+
+from keylime.common import algorithms
+from keylime.ima import ima
+from keylime.policy import create_runtime_policy, initrd
+
+_HAS_LIBARCHIVE = util.find_spec("libarchive") is not None
+
+HELPER_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "data", "create-runtime-policy"))
+
+# The test initrds have the following content.
+INITRD_LEGACY_ALLOWLIST = """18eb0ba043d6fc5b06b6f785b4a411fa0d6d695c4a08d2497e8b07c4043048f7  /usr/bin/foo
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  /usr/lib/foobar.so
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  /usr/lib64/foobar64.so
+dd2ccf6ebfabbca501864a3ec5aebecfadd69d717ea9d9ddd509b49471d039db  /usr/sbin/bar
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  /dev/foo bar
+"""
+
+INITRD_DIGESTS_SHA256 = {
+    "/dev/foo_bar": ["e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"],
+    "/usr/bin/foo": ["18eb0ba043d6fc5b06b6f785b4a411fa0d6d695c4a08d2497e8b07c4043048f7"],
+    "/usr/lib/foobar.so": ["e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"],
+    "/usr/lib64/foobar64.so": ["e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"],
+    "/usr/sbin/bar": ["dd2ccf6ebfabbca501864a3ec5aebecfadd69d717ea9d9ddd509b49471d039db"],
+}
+
+INITRD_DIGESTS_SHA1 = {
+    "/dev/foo_bar": ["da39a3ee5e6b4b0d3255bfef95601890afd80709"],
+    "/usr/bin/foo": ["a26ce416a048883cd6ca8e890f6b0a62a8031e8a"],
+    "/usr/lib/foobar.so": ["da39a3ee5e6b4b0d3255bfef95601890afd80709"],
+    "/usr/lib64/foobar64.so": ["da39a3ee5e6b4b0d3255bfef95601890afd80709"],
+    "/usr/sbin/bar": ["ec6705ccdaafdf57261e35e40379cc339d36a204"],
+}
+
+
+EXCLUDE_LIST = """
+boot_aggregate
+/usr/sbin/bar
+/dev/foo bar
+"""
+
+
+def assertDigestsEqual(d1, d2):
+    # Ensuring we have only unique values in the digest lists.
+    d1_unique = {k: sorted(list(set(v))) for k, v in d1.items()}
+    d2_unique = {k: sorted(list(set(v))) for k, v in d2.items()}
+
+    unittest.TestCase().assertEqual(len(d1_unique), len(d2_unique), msg="number of files must match")
+
+    for file in d1_unique:
+        unittest.TestCase().assertTrue(file in d2_unique)
+        unittest.TestCase().assertEqual(
+            len(d1_unique[file]), len(d2_unique[file]), msg=f"number of files/digests for {file}"
+        )
+
+        for d in d1_unique[file]:
+            unittest.TestCase().assertTrue(d in d2_unique[file], msg=f"file={file} digest={d}")
+
+
+class CreateRuntimePolicy_Test(unittest.TestCase):
+    dirpath = ""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.dirpath = tempfile.mkdtemp(prefix="keylime-create-runtime-policy-test")
+
+        setup_script = os.path.abspath(os.path.join(HELPER_DIR, "setup-initrd-tests"))
+
+        result = subprocess.run(
+            [setup_script, cls.dirpath], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+        )
+        print("STDOUT:", result.stdout.decode("UTF-8"), file=sys.stderr)
+        print("STDERR:", result.stderr.decode("UTF-8"), file=sys.stderr)
+        CreateRuntimePolicy_Test().assertEqual(result.returncode, 0)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.dirpath is not None:
+            shutil.rmtree(cls.dirpath)
+
+    def test_InitrdReader(self):
+        initrd_dir = os.path.join(self.dirpath, "initrd")
+        for initrd_file in create_runtime_policy.list_initrds(basedir=initrd_dir):
+            ii = initrd.InitrdReader(initrd_file)
+            digests = create_runtime_policy.path_digests(ii.contents(), remove_prefix=True)
+
+            # Now let's validate the digests.
+            assertDigestsEqual(digests, INITRD_DIGESTS_SHA256)
+
+    @unittest.skipUnless(_HAS_LIBARCHIVE, "libarchive not available")
+    def test_InitrdReader_extract_at_offset_methods(self):
+        initrd_dir = os.path.join(self.dirpath, "initrd")
+
+        libarchive_digests = None
+        fallback_digests = None
+        cwd = os.getcwd()
+
+        for initrd_file in create_runtime_policy.list_initrds(basedir=initrd_dir):
+            with open(initrd_file, "rb") as infile:
+                offset = initrd.InitrdReader.skip_cpio(infile)
+
+                with tempfile.TemporaryDirectory() as libarchive_dir:
+                    os.chdir(libarchive_dir)
+                    try:
+                        initrd.InitrdReader.extract_at_offset_libarchive(infile, offset)
+                        digests = create_runtime_policy.path_digests(libarchive_dir, remove_prefix=True)
+                        if libarchive_digests is None:
+                            libarchive_digests = digests
+                        assertDigestsEqual(digests, libarchive_digests)
+                    except Exception as e:
+                        self.fail(f"No exception expected while testing libarchive extraction: {e}")
+                    finally:
+                        os.chdir(cwd)
+
+                with tempfile.TemporaryDirectory() as fallback_dir:
+                    os.chdir(fallback_dir)
+                    try:
+                        initrd.InitrdReader.extract_at_offset_fallback(infile, offset)
+                        digests = create_runtime_policy.path_digests(fallback_dir, remove_prefix=True)
+                        if fallback_digests is None:
+                            fallback_digests = digests
+                        assertDigestsEqual(digests, fallback_digests)
+                    except Exception as e:
+                        self.fail(f"No exception expected while testing fallback extraction: {e}")
+                    finally:
+                        os.chdir(cwd)
+
+        # Finally, let's make sure the result of libarchive and the fallback
+        # method are the same.
+        assertDigestsEqual(libarchive_digests, fallback_digests)
+
+        # Now let's check a "bad" file.
+        bad_file = os.path.abspath(os.path.join(HELPER_DIR, "setup-initrd-tests"))
+        with open(bad_file, "rb") as infile:
+            self.assertRaises(
+                Exception,
+                initrd.InitrdReader.extract_at_offset_libarchive,
+                infile,
+                0,
+            )
+            self.assertRaises(
+                Exception,
+                initrd.InitrdReader.extract_at_offset_fallback,
+                infile,
+                0,
+            )
+
+    def test_boot_aggregate(self):
+        default_alg = "sha256"
+        default_aggregate = "0" * algorithms.Hash(default_alg).hexdigest_len()
+        test_cases = [
+            {"input": "", "boot_aggregate": default_aggregate, "alg": default_alg},
+            {
+                "input": "10 0000000000000000000000000000000000000000 ima 0000000000000000000000000000000000000000 boot_aggregate",
+                "boot_aggregate": "0000000000000000000000000000000000000000",
+                "alg": "sha1",
+            },
+            {
+                "input": "10 0000000000000000000000000000000000000000 ima a00000000000000000000000000000000000000b boot_aggregate",
+                "boot_aggregate": "a00000000000000000000000000000000000000b",
+                "alg": "sha1",
+            },
+            {
+                "input": "FOO BAR",
+                "boot_aggregate": default_aggregate,
+                "alg": default_alg,
+            },
+            {
+                "input": "10 8d814e778e1fca7c551276523ac44455da1dc420 ima-ng sha256:0bc72531a41dbecb38557df75af4bc194e441e71dc677c659a1b179ac9b3e6ba boot_aggregate",
+                "boot_aggregate": "0bc72531a41dbecb38557df75af4bc194e441e71dc677c659a1b179ac9b3e6ba",
+                "alg": "sha256",
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            agg_file = os.path.join(tmpdir, "measurements")
+            for c in test_cases:
+                alg, aggregate = create_runtime_policy.boot_aggregate_parse(c["input"])
+                self.assertEqual(alg, c["alg"])
+                self.assertEqual(aggregate, c["boot_aggregate"])
+
+                # Now parsing it from a file.
+                with open(agg_file, "w", encoding="UTF-8") as mfile:
+                    mfile.write(c["input"])
+
+                alg, aggregate = create_runtime_policy.boot_aggregate_from_file(agg_file)
+                self.assertEqual(alg, c["alg"], msg=f"{c['input']}")
+                self.assertEqual(aggregate, c["boot_aggregate"])
+
+        # Now let's parse some bogus entries.
+        # These should throw an exception.
+        bad_entries = [
+            "pcr pcr-value img-ng sha999:fff boot_aggregate",
+            "pcr pcr-value img-ng sha1:fff boot_aggregate",
+            "pcr pcr-value img-ng sha256:fff boot_aggregate",
+            "pcr pcr-value ima fff boot_aggregate",
+        ]
+        for line in bad_entries:
+            alg, aggregate = create_runtime_policy.boot_aggregate_parse(line)
+            self.assertEqual(alg, default_alg, msg=f"line = {line}")
+            self.assertEqual(aggregate, default_aggregate, msg=f"line = {line}")
+
+    def test_file_digest(self):
+        initrd_file = os.path.join(self.dirpath, "initrd", "initramfs-keylime-fedora-cat.img")
+        r = initrd.InitrdReader(initrd_file)
+
+        file_path = os.path.join(r.contents(), "usr/bin/foo")
+        test_cases = [
+            {"file": file_path, "alg": "sha1", "digest": "a26ce416a048883cd6ca8e890f6b0a62a8031e8a"},
+            {
+                "file": file_path,
+                "alg": "sha384",
+                "digest": "d2fcda9b029aa42f511b2d954e4bebaff2f4f6431374c111ec8efa59204c74164491e14e43e144a3b18e98bf6043cf75",
+            },
+            {
+                "file": file_path,
+                "alg": "sha512",
+                "digest": "2f979b08be70d85814d56ff5e21628ab79de93e1e88facdb975c71237ea46c47afc61d39d2eb089a4f7e5faafc05d5c11ee38db9c65167ac22b8cc4ad89f080c",
+            },
+        ]
+
+        for c in test_cases:
+            self.assertTrue(algorithms.Hash.is_recognized(c["alg"]))
+            self.assertEqual(
+                algorithms.Hash(c["alg"]).file_digest(c["file"]),
+                c["digest"],
+            )
+
+    def test_get_initrds_digests(self):
+        initrd_dir = os.path.join(self.dirpath, "initrd")
+        test_cases = [
+            {
+                "algo": "sha1",
+                "expected": INITRD_DIGESTS_SHA1,
+            },
+            {
+                "algo": "sha256",
+                "expected": INITRD_DIGESTS_SHA256,
+            },
+        ]
+
+        for c in test_cases:
+            digests = create_runtime_policy.get_initrds_digests(initrd_dir, {}, c["algo"])
+            assertDigestsEqual(digests, c["expected"])
+
+    def test_process_flat_allowlist(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            allowlist = os.path.join(tmpdir, "allowlist")
+            with open(allowlist, "w", encoding="UTF-8") as mfile:
+                mfile.write(INITRD_LEGACY_ALLOWLIST)
+
+            digests, ok = create_runtime_policy.process_flat_allowlist(allowlist, {})
+            self.assertTrue(ok)
+            assertDigestsEqual(digests, INITRD_DIGESTS_SHA256)
+
+            malformed_allowlist = """checksum file oops
+#
+checksum-2
+checksum-3 foo bar file 01
+checksum-4 \
+         bar foo file 02
+
+
+
+
+"""
+            with open(allowlist, "w", encoding="UTF-8") as mfile:
+                mfile.write(malformed_allowlist)
+            digests, ok = create_runtime_policy.process_flat_allowlist(allowlist, {})
+            self.assertTrue(ok)
+            # 3 valid entries there, with some lines skipped:
+            # file oops -> with checksum: checksum
+            # foo bar file 01 -> with checksum: checksum-3
+            # bar foo file 02 -> with checksum: checksum-4
+            self.assertEqual(len(digests), 3)
+
+            # Now let's test some invalid file.
+            digests, ok = create_runtime_policy.process_flat_allowlist("/some/invalid/non/existing/file/here", {})
+            self.assertFalse(ok)
+            self.assertEqual(len(digests), 0)
+
+    def test_path_digest_owned_by_root(self):
+        homedir = os.path.join(self.dirpath, "dummy-rootfs", "home")
+        fpath = os.path.join(homedir, "foobar", "non-root")
+
+        test_cases = [
+            {
+                "path": [fpath],
+                "checksum": {fpath: ["e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]},
+                "algo": "sha256",
+                "owned_by_root": False,
+            },
+            {"path": [], "checksum": {}, "algo": "sha256", "owned_by_root": True},
+        ]
+
+        for c in test_cases:
+            digests = create_runtime_policy.path_digests(homedir, alg=c["algo"], only_owned_by_root=c["owned_by_root"])
+            self.assertEqual(len(digests), len(c["path"]))
+            for ff in digests:
+                self.assertTrue(ff in c["path"])
+            assertDigestsEqual(digests, c["checksum"])
+
+    def test_path_digest_dirs_to_exclude(self):
+        rootfsdir = os.path.join(self.dirpath, "dummy-rootfs")
+        homedir = os.path.join(rootfsdir, "home")
+
+        digests = create_runtime_policy.path_digests(homedir)
+        self.assertEqual(len(digests), 1)
+
+        digests = create_runtime_policy.path_digests(homedir, dirs_to_exclude=None)
+        self.assertEqual(len(digests), 1)
+
+        digests = create_runtime_policy.path_digests(homedir, dirs_to_exclude=[])
+        self.assertEqual(len(digests), 1)
+
+        digests = create_runtime_policy.path_digests(homedir, dirs_to_exclude=[homedir])
+        self.assertEqual(len(digests), 0)
+
+        digests = create_runtime_policy.path_digests(homedir, dirs_to_exclude=[rootfsdir])
+        self.assertEqual(len(digests), 0)
+
+    def test_process_exclude_list(self):
+        test_cases = [
+            {
+                "line": "boot_aggregate",
+                "valid": True,
+            },
+            {
+                "line": "boot.aggreg*$",
+                "valid": True,
+            },
+            {
+                "line": "*",
+                "valid": False,
+            },
+            {
+                "line": "foobar.so(.*)?",
+                "valid": True,
+            },
+            {
+                "line": "",
+                "valid": False,
+            },
+        ]
+
+        for c in test_cases:
+            _, ok = create_runtime_policy.process_exclude_list_line(c["line"])
+            self.assertEqual(ok, c["valid"])
+
+        test_cases = [
+            {
+                "lines": """boot_aggregate
+boot.aggreg*$
+*
+foobar.so(.*)?
+
+""",
+                "expected": [],
+                "valid": False,
+            },
+            {
+                "lines": """boot_aggregate
+boot.aggreg*$
+foobar.so(.*)?
+""",
+                "expected": ["boot_aggregate", "boot.aggreg*$", "foobar.so(.*)?"],
+                "valid": True,
+            },
+            {
+                "lines": """
+
+
+""",
+                "expected": [],
+                "valid": False,
+            },
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            excludelist = os.path.join(tmpdir, "excludelist")
+            for c in test_cases:
+                with open(excludelist, "w", encoding="UTF-8") as mfile:
+                    mfile.write(c["lines"])
+
+                exclude, ok = create_runtime_policy.process_exclude_list_file(excludelist, [])
+                self.assertEqual(ok, c["valid"], msg=f"lines = {c['lines']}")
+                self.assertEqual(sorted(c["expected"]), sorted(exclude), msg=f"lines = {c['lines']}")
+
+        # Now let's test some invalid file.
+        exclude, ok = create_runtime_policy.process_exclude_list_file("/some/invalid/non/existing/file/here", [])
+        self.assertFalse(ok)
+        self.assertEqual(len(exclude), 0)
+
+    def test_merge_lists(self):
+        test_cases = [
+            {
+                "a": [],
+                "b": [],
+                "expected": [],
+            },
+            {
+                "a": ["a"],
+                "b": [],
+                "expected": ["a"],
+            },
+            {
+                "a": [],
+                "b": ["b"],
+                "expected": ["b"],
+            },
+            {
+                "a": ["a"],
+                "b": ["a"],
+                "expected": ["a"],
+            },
+            {
+                "a": ["a", "b"],
+                "b": ["b"],
+                "expected": ["a", "b"],
+            },
+            {
+                "a": ["a", "b", "c"],
+                "b": ["b", "e"],
+                "expected": ["a", "b", "c", "e"],
+            },
+        ]
+
+        for c in test_cases:
+            self.assertEqual(create_runtime_policy.merge_lists(c["a"], c["b"]), c["expected"])
+
+    def test_merge_maplists(self):
+        test_cases = [
+            {
+                "a": {},
+                "b": {},
+                "expected": {},
+            },
+            {"a": {}, "b": {"file": ["checksum"]}, "expected": {"file": ["checksum"]}},
+            {"a": {"file": ["checksum"]}, "b": {}, "expected": {"file": ["checksum"]}},
+            {"a": {"file": ["checksum"]}, "b": {"file": ["checksum"]}, "expected": {"file": ["checksum"]}},
+            {
+                "a": {"file": ["checksum-1"]},
+                "b": {"file": ["checksum-2"]},
+                "expected": {"file": ["checksum-1", "checksum-2"]},
+            },
+            {
+                "a": {"file": ["checksum-1", "checksum-2", "checksum-3"]},
+                "b": {"file": ["checksum-2"], "file-2": ["checksum-4"]},
+                "expected": {"file": ["checksum-1", "checksum-2", "checksum-3"], "file-2": ["checksum-4"]},
+            },
+        ]
+        for c in test_cases:
+            self.assertEqual(create_runtime_policy.merge_maplists(c["a"], c["b"]), c["expected"])
+
+    def test_get_hashes_from_measurement_list(self):
+        test_cases = [
+            {
+                "ima-list": """
+
+""",
+                "expected": {},
+                "valid": True,
+            },
+            {
+                "ima-list": """10 0adefe762c149c7cec19da62f0da1297fcfbffff ima-ng sha256:0000000000000000000000000000000000000000000000000000000000000000 boot_aggregate
+10 cff3da2ff339a1f07bb0dbcbc0381e794ed09555 ima-ng sha256:3e5e8ad9d8b4dd191413aba6166c7a975c3eab903d1fad77ecfa2d5810d6585c /usr/bin/kmod
+10 13d5b414e08a45698ce9e3c66545b25ba694046c ima-ng sha256:f51de8688a2903b94016c06f186cf1f053ececd2a88a5f349f29b35a06e94c43 /usr/lib64/ld-linux-x86-64.so.2
+""",
+                "expected": {
+                    "boot_aggregate": ["0000000000000000000000000000000000000000000000000000000000000000"],
+                    "/usr/bin/kmod": ["3e5e8ad9d8b4dd191413aba6166c7a975c3eab903d1fad77ecfa2d5810d6585c"],
+                    "/usr/lib64/ld-linux-x86-64.so.2": [
+                        "f51de8688a2903b94016c06f186cf1f053ececd2a88a5f349f29b35a06e94c43"
+                    ],
+                },
+                "valid": True,
+            },
+            {
+                "ima-list": "",
+                "expected": {},
+                "valid": True,
+            },
+            {
+                "ima-list": "10 cff3da2ff339a1f07bb0dbcbc0381e794ed09555 ima-ng sha256:3e5e8ad9d8b4dd191413aba6166c7a975c3eab903d1fad77ecfa2d5810d6585c",
+                "expected": {},
+                "valid": True,
+            },
+            {
+                "ima-list": "10 6f3474e730fb7da4bb26cad2d8f5d9d5482735f6 ima-buf sha256:571016c9f57363c80e08dd4346391c4e70227e41b0247b8a3aa2240a178d3d14 dm_table_load 646d5f76657273696f6e3d342e34362e303b6e616d653d7268656c2d726f6f742c757569643d4c564d2d79543538654c3268616470746a55396c565131573078315035544679454e35627450416b375963386779586633446667647a6a7554466b4a39503661746868582c6d616a6f723d3235332c6d696e6f723d302c6d696e6f725f636f756e743d312c6e756d5f746172676574733d313b7461726765745f696e6465783d302c7461726765745f626567696e3d302c7461726765745f6c656e3d3133333133363338342c7461726765745f6e616d653d6c696e6561722c7461726765745f76657273696f6e3d312e342e302c6465766963655f6e616d653d3235323a332c73746172743d37333234363732303b",
+                "expected": {},
+                "valid": True,
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ima_list = os.path.join(tmpdir, "ascii_runtime_measurements")
+            for c in test_cases:
+                with open(ima_list, "w", encoding="UTF-8") as mfile:
+                    mfile.write(c["ima-list"])
+
+                hashes, ok = create_runtime_policy.get_hashes_from_measurement_list(ima_list, {})
+                self.assertEqual(ok, c["valid"], msg=f"ima-list: ({c['ima-list']})")
+                print("HASHES", hashes)
+                self.assertEqual(hashes, c["expected"], msg=f"ima-list: ({c['ima-list']})")
+
+        # Try non-existing file.
+        hashes, ok = create_runtime_policy.get_hashes_from_measurement_list(
+            "/some/invalid/non/existing/ima/list/here", {}
+        )
+        self.assertFalse(ok)
+        self.assertEqual(len(hashes), 0)
+
+    def test_merge_base_policy(self):
+        # TODO: add now some actual good cases, to test the more
+        # important flow.
+        # XXX: Need to clarify whether "verification-keys" is correct
+        # being a single string instead of an array of strings.
+        test_cases = [
+            {
+                "base-policy": "not-valid-json",
+                "policy": ima.empty_policy(),
+                "expected": None,
+            },
+            {
+                "base-policy": '{"valid": "json", "invalid": "policy"}',
+                "policy": ima.empty_policy(),
+                "expected": None,
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_policy = os.path.join(tmpdir, "base-policy")
+            for c in test_cases:
+                with open(base_policy, "w", encoding="UTF-8") as mfile:
+                    mfile.write(c["base-policy"])
+
+                policy = create_runtime_policy.merge_base_policy(c["policy"], base_policy)
+                self.assertEqual(policy, c["expected"])
+
+        # Try non-existing file.
+        policy = create_runtime_policy.merge_base_policy(ima.empty_policy(), "/some/invalid/non/existing/policy/here")
+        self.assertEqual(policy, None)

--- a/test/test_rpm_repo.py
+++ b/test/test_rpm_repo.py
@@ -1,0 +1,252 @@
+"""
+SPDX-License-Identifier: Apache-2.0
+Copyright 2024 Red Hat, Inc.
+"""
+
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from importlib import util
+from threading import Thread
+
+from keylime.policy import rpm_repo
+
+_HAS_RPM = util.find_spec("rpm") is not None
+
+HELPER_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "data", "create-runtime-policy"))
+
+RPM_DIGESTS = {
+    "/usr/bin/dummy-foobar": ["2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"],
+    "/etc/dummy-foobar.conf": ["fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"],
+}
+
+
+@contextmanager
+def http_server(host: str, port: int, directory: str):
+    server = ThreadingHTTPServer((host, port), partial(SimpleHTTPRequestHandler, directory=directory))
+    server_thread = Thread(target=server.serve_forever, name="http_server")
+    server_thread.start()
+    try:
+        yield server
+    finally:
+        server.server_close()
+        server.shutdown()
+        server_thread.join()
+
+
+def assertMaplistsEqual(d1, d2, extramsg=""):
+    # Ensuring we have only unique values in the digest lists.
+    d1_unique = {k: sorted(list(set(v))) for k, v in d1.items()}
+    d2_unique = {k: sorted(list(set(v))) for k, v in d2.items()}
+
+    unittest.TestCase().assertEqual(len(d1_unique), len(d2_unique), msg=f"number of files must match {extramsg}")
+
+    for file in d1_unique:
+        unittest.TestCase().assertTrue(file in d2_unique)
+        unittest.TestCase().assertEqual(
+            len(d1_unique[file]), len(d2_unique[file]), msg=f"number of files/digests for {file} {extramsg}"
+        )
+
+        for d in d1_unique[file]:
+            unittest.TestCase().assertTrue(d in d2_unique[file], msg=f"file={file} digest={d} {extramsg}")
+
+
+class RpmRepo_Test(unittest.TestCase):
+    dirpath = ""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.dirpath = tempfile.mkdtemp(prefix="keylime-rpm-repo-test")
+
+        setup_script = os.path.abspath(os.path.join(HELPER_DIR, "setup-rpm-tests"))
+
+        result = subprocess.run(
+            [setup_script, cls.dirpath], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+        )
+        print("STDOUT:", result.stdout.decode("UTF-8"), file=sys.stderr)
+        print("STDERR:", result.stderr.decode("UTF-8"), file=sys.stderr)
+        RpmRepo_Test().assertEqual(result.returncode, 0)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.dirpath is not None:
+            shutil.rmtree(cls.dirpath)
+
+    def test_analyze_local_repo(self):
+        test_cases = [
+            {
+                "repo": os.path.join(self.dirpath, "repo", "signed-ecc"),
+                "valid": True,
+                "hashes": RPM_DIGESTS,
+                "ima-sig": {},
+            },
+            {
+                "repo": os.path.join(self.dirpath, "repo", "signed-rsa"),
+                "valid": True,
+                "hashes": RPM_DIGESTS,
+                "ima-sig": {},
+            },
+            {
+                "repo": os.path.join(self.dirpath, "repo", "unsigned"),
+                "valid": True,
+                "hashes": RPM_DIGESTS,
+                "ima-sig": {},
+            },
+            {
+                "repo": os.path.join(self.dirpath, "repo", "signed-mismatch"),
+                "valid": False,
+                "hashes": {},
+                "ima-sig": {},
+            },
+            {
+                "repo": os.path.join(self.dirpath, "repo", "no-repomd"),
+                "valid": False,
+                "hashes": {},
+                "ima-sig": {},
+            },
+            {
+                "repo": os.path.join(self.dirpath, "repo", "signed-no-key"),
+                "valid": False,
+                "hashes": {},
+                "ima-sig": {},
+            },
+            {
+                "repo": "",
+                "valid": False,
+                "hashes": {},
+                "ima-sig": {},
+            },
+            {
+                "repo": "foo/bar/",
+                "valid": False,
+                "hashes": {},
+                "ima-sig": {},
+            },
+        ]
+
+        for c in test_cases:
+            hashes, _ima_sig, ok = rpm_repo.analyze_local_repo(c["repo"])
+            self.assertEqual(ok, c["valid"], msg=f"repo = {c['repo']}")
+            self.assertEqual(hashes, c["hashes"], msg=f"repo = {c['repo']}")
+            # TODO: verify the ima_sig.
+
+    def test_analyze_rpm_pkg(self):
+        test_cases = [
+            {
+                "rpm": os.path.join(self.dirpath, "repo", "unsigned", "DUMMY-empty-42.0.0-el42.noarch.rpm"),
+                "hashes": {},
+                "ima-sig": {},
+            },
+            {
+                "rpm": os.path.join(self.dirpath, "repo", "signed-rsa", "DUMMY-empty-42.0.0-el42.noarch.rpm"),
+                "hashes": {},
+                "ima-sig": {},  # FIXME
+            },
+            {
+                "rpm": os.path.join(self.dirpath, "repo", "signed-rsa", "DUMMY-foo-42.0.0-el42.noarch.rpm"),
+                "hashes": RPM_DIGESTS,
+                "ima-sig": {},
+            },
+        ]
+
+        for c in test_cases:
+            hashes, _ima_sig = rpm_repo.analyze_rpm_pkg(pathlib.Path(c["rpm"]))
+            self.assertEqual(hashes, c["hashes"], msg=f"rpm = {c['rpm']}")
+            # TODO: verify ima-sig.
+
+    def test__analyze_remote_repo(self):
+        test_cases = [
+            {
+                "repo": os.path.join(self.dirpath, "repo", "signed-ecc"),
+                "valid": True,
+                "hashes": RPM_DIGESTS,
+                "ima-sig": {},
+            },
+            {
+                "repo": os.path.join(self.dirpath, "repo", "signed-rsa"),
+                "valid": True,
+                "hashes": RPM_DIGESTS,
+                "ima-sig": {},  # FIXME
+            },
+            {
+                "repo": os.path.join(self.dirpath, "repo", "unsigned"),
+                "valid": True,
+                "hashes": RPM_DIGESTS,
+                "ima-sig": {},
+            },
+            {
+                "repo": os.path.join(self.dirpath, "repo", "signed-mismatch"),
+                "valid": False,
+                "hashes": {},
+                "ima-sig": {},
+            },
+            {
+                "repo": os.path.join(self.dirpath, "repo", "no-repomd"),
+                "valid": False,
+                "hashes": {},
+                "ima-sig": {},
+            },
+            {
+                "repo": os.path.join(self.dirpath, "repo", "signed-no-key"),
+                "valid": False,
+                "hashes": {},
+                "ima-sig": {},
+            },
+            {
+                "repo": os.path.join(self.dirpath, "repo", "filelist-ext-mismatch"),
+                "valid": False,
+                "hashes": {},
+                "ima-sig": {},
+            },
+        ]
+
+        for c in test_cases:
+            with http_server("localhost", 0, c["repo"]) as httpd:
+                url = f"http://localhost:{httpd.server_port}"
+                digests, _ima_sig, ok = rpm_repo.analyze_remote_repo(url)
+                assertMaplistsEqual(digests, c["hashes"], c["repo"])
+                self.assertEqual(ok, c["valid"])
+                # TODO: test the IMA signatures.
+
+        # Now let us test a repo using unsupported (i.e. != gzip)
+        # compression.
+        unsupported_comp = os.path.join(self.dirpath, "repo", "unsupported-compression")
+        with http_server("localhost", 0, unsupported_comp) as httpd:
+            url = f"http://localhost:{httpd.server_port}"
+            self.assertRaises(Exception, rpm_repo._analyze_remote_repo, url)  # pylint: disable=protected-access
+
+            # The public method does not raise an exception.
+            digests, _imasigs, ok = rpm_repo.analyze_remote_repo(url)
+            self.assertFalse(ok, msg=f"repo = {unsupported_comp}")
+            self.assertEqual(digests, {})
+
+    def test_analyze_rpm_pkg_url(self):
+        test_cases = [
+            {
+                "repo": os.path.join(self.dirpath, "repo", "signed-rsa"),
+                "rpm": "DUMMY-bar-42.0.0-el42.noarch.rpm",
+                "hashes": RPM_DIGESTS,
+                "ima-sig": {},  # FIXME
+            },
+            {
+                "repo": os.path.join(self.dirpath, "repo", "signed-rsa"),
+                "rpm": "DUMMY-empty-42.0.0-el42.noarch.rpm",
+                "hashes": {},
+                "ima-sig": {},
+            },
+            {"repo": os.path.join(self.dirpath, "repo", "signed-rsa"), "rpm": "foo/bar", "hashes": {}, "ima-sig": {}},
+        ]
+
+        for c in test_cases:
+            with http_server("localhost", 0, c["repo"]) as httpd:
+                url = f"http://localhost:{httpd.server_port}/{c['rpm']}"
+                digests, _ima_sig = rpm_repo.analyze_rpm_pkg_url(url)
+                assertMaplistsEqual(digests, c["hashes"])
+                # TODO: test the IMA signatures.


### PR DESCRIPTION
Initial steps of enhancement #110, which is to provide a single
tool that provides the functionality of the existing tools we
have.

In this commit, we add the `keylime_policy` tool, that is currently
able to handle the creation of runtime policies.

To see the available options:

`keylime_policy --help`

To see the options available related to creating runtime policies:

`keylime_policy create runtime --help`

Some of the options available include e.g. using an IMA measurement
list, legacy allowlist/excludelist files, local/remote RPM repositories,
specifying a rootfs filesystem, initrds, a base policy, etc.