### PR TITLE
revocation_notifier: Explicitly add CA certificate bundle

### DIFF
--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -140,7 +140,7 @@ def notify_webhook(tosend: Dict[str, Any]) -> None:
             for i in range(config.getint("verifier", "max_retries")):
                 next_retry = retry.retry_time(exponential_backoff, interval, i, logger)
                 try:
-                    response = session.post(url, json=tosend, timeout=5)
+                    response = session.post(url, json=tosend, timeout=5, verify=requests.utils.DEFAULT_CA_BUNDLE_PATH)
                     if response.status_code in [200, 202]:
                         break
 


### PR DESCRIPTION
This is a workaround for the regression added by `python-requests` version `2.32.3`, reported upstream as https://github.com/psf/requests/issues/6730

Resolves: #1569