### PR TITLE
docker: Update images to use Fedora 40

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -5,9 +5,9 @@
 # It is not recommended for use beyond testing scenarios.
 ##############################################################################
 
-FROM quay.io/fedora/fedora:37-x86_64@sha256:eab075950eeef382b80b6c2ffb693381e6a7c507d3337949197c37ad244842e9
+FROM quay.io/fedora/fedora:40-x86_64@sha256:6ddf7ca1459428ea737090ffd4c7560c0463c2d7af8c32732fae878afa90b8a4
 MAINTAINER Luke Hinds <lhinds@redhat.com>
-LABEL version="1.1.0" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
+LABEL version="1.2.0" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
 
 # environment variables
 ARG BRANCH=master

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -25,6 +25,7 @@ RUN dnf groupinstall -y \
 # Packaged dependencies
 ENV PKGS_DEPS="automake \
 clang clang-devel \
+createrepo_c \
 czmq-devel \
 dbus \
 dbus-daemon \
@@ -59,6 +60,8 @@ python3-virtualenv \
 python3-yaml \
 python3-zmq \
 redhat-rpm-config \
+rpm-build \
+rpm-sign \
 rust clippy cargo \
 swtpm \
 swtpm-tools \

--- a/docker/release/base/Dockerfile.in
+++ b/docker/release/base/Dockerfile.in
@@ -1,13 +1,12 @@
-FROM index.docker.io/library/fedora:37@sha256:de153a3928b8901ad05d8d3314a1f7680570979bd2c04c4562b817daa8358a33 AS keylime_base
+FROM fedora:40@sha256:6ddf7ca1459428ea737090ffd4c7560c0463c2d7af8c32732fae878afa90b8a4 AS keylime_base
 LABEL version="_version_" description="Keylime Base - Only used as an base image for derived packages"
 MAINTAINER Keylime Team <main@keylime.groups.io>
 
 RUN dnf -y install dnf-plugins-core git efivar-libs efivar-devel && dnf -y builddep tpm2-tools 
-RUN git clone -b 5.5 https://github.com/tpm2-software/tpm2-tools.git && \
+RUN git clone -b 5.7 https://github.com/tpm2-software/tpm2-tools.git && \
     cd tpm2-tools && \
     git config user.email "main@keylime.groups.io" && \
     git config user.name "Keylime" && \
-    git cherry-pick 9735dc332b782ce94371aff8746ce6a68094b038 576a31bcc910da517067b29667f45fbe78e812e0 && \
     ./bootstrap && \
     ./configure && \
     make && make install && \

--- a/docker/release/build_locally.sh
+++ b/docker/release/build_locally.sh
@@ -7,8 +7,16 @@
 VERSION=${1:-latest}
 KEYLIME_DIR=${2:-"../../"}
 
+if [ -z "${REGISTRY}" ]; then
+    REGISTRY="quay.io"
+fi
+
+if [ -z "${IMAGE_BASE}" ]; then
+    IMAGE_BASE="${REGISTRY}/keylime"
+fi
+
 ./generate-files.sh ${VERSION}
 for part in base registrar verifier tenant; do
-  docker buildx build -t keylime_${part}:${VERSION} -f ${part}/Dockerfile $KEYLIME_DIR --progress plain ${@:3}
+  docker buildx build -t keylime_${part}:${VERSION} -f "${part}/Dockerfile" --security-opt label=disable --progress plain ${@:3} "$KEYLIME_DIR"
   rm -f ${part}/Dockerfile
 done


### PR DESCRIPTION
The Fedora 37 is no longer supported. This updates the images to be based on Fedora 40.

Also add some small changes to fix the `build_locally.sh` script by disabling SELinux relabeling during the build.

EDIT: Added test dependencies needed for #1568 