### PR TITLE
docker/release/base: Explicitly add the registry for base

### DIFF
--- a/docker/release/base/Dockerfile.in
+++ b/docker/release/base/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM fedora:40@sha256:6ddf7ca1459428ea737090ffd4c7560c0463c2d7af8c32732fae878afa90b8a4 AS keylime_base
+FROM quay.io/fedora/fedora:40@sha256:8af205680ee38c3d9ed3178ace5dd23ac39d0d4cdb8e799ac9ab902ef83d4060 AS keylime_base
 LABEL version="_version_" description="Keylime Base - Only used as an base image for derived packages"
 MAINTAINER Keylime Team <main@keylime.groups.io>
 


### PR DESCRIPTION
The docker/build-push-action tries to download the base image from the docker registry instead of quay.io when the registry is omitted in the Dockerfile.

This leads the build to fail as the requested pinned image version is not available in the docker registry.

Add quay.io registry explicitly.

(Hopefully)
Resolves #1579 