### PR TITLE
ci: disable Packit testing for Rawhide

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,6 +3,6 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-all
+    - fedora-branched
     - centos-stream-10-x86_64
     skip_build: true


### PR DESCRIPTION
Due to the various braking changes made recently in Rawhide we have decided to disable Rawhide in CI. We will continue testing on Rawhide on keylime-tests side so we can spot issues early.