### PR TITLE
docker: Automate base image updates

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -1,0 +1,56 @@
+name: Build containers base image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - docker/release/base/Dockerfile.in
+  workflow_dispatch:
+
+env:
+  REGISTRY: quay.io
+  IMAGE_BASE: quay.io/keylime
+
+jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Generate docker metadata for keylime_base
+        id: meta_base
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175
+        with:
+          images: |
+            ${{ env.IMAGE_BASE }}/keylime_base
+          tags: |
+            type=ref,enable=true,priority=600,prefix=,suffix=,event=branch
+            type=ref,enable=true,priority=600,prefix=,suffix=,event=tag
+            type=sha,prefix=sha-
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=raw,monthly
+
+      - name: Prepare Dockerfile
+        run: |
+          cd docker/release/base
+          sed "s#_version_#${{ steps.meta_base.outputs.version }}#" "Dockerfile.in" > Dockerfile
+
+      - name: Build and push base image
+        id: build
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9
+        with:
+          context: .
+          file: docker/release/base/Dockerfile
+          push: true
+          tags: ${{ steps.meta_base.outputs.tags }}
+          labels: ${{ steps.meta_base.outputs.labels }}
+

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,25 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
 
       - name: Log in to the Container registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v2
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
-
-      - name: Generate docker metadata for keylime_base
-        id: meta_base
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v4
-        with:
-          images: |
-            ${{ env.IMAGE_BASE }}/keylime_base
-          tags: |
-            type=ref,enable=true,priority=600,prefix=,suffix=,event=branch
-            type=ref,enable=true,priority=600,prefix=,suffix=,event=tag
-            type=sha,prefix=sha-
 
       - name: Generate docker metadata for keylime_verifier
         id: meta_verifier
@@ -72,19 +61,15 @@ jobs:
             type=ref,enable=true,priority=600,prefix=,suffix=,event=tag
             type=sha,prefix=sha-
 
+      - name: Install skopeo and jq
+        run: sudo apt-get install -y skopeo jq
+
+      - name: Get digest of the latest version of the base image
+        run: echo "BASE_DIGEST=$(skopeo inspect docker://${{ env.IMAGE_BASE }}/keylime_base:master | jq '.Digest')" >> "$GITHUB_ENV"
+
       - name: Prepare dockerfiles
         run: |
-          cd docker/release && ./generate-files.sh "${{ steps.meta_base.outputs.version }}" "${{ env.IMAGE_BASE }}/"
-
-      - name: Build and push base
-        id: build_base
-        uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v4
-        with:
-          context: .
-          file: docker/release/base/Dockerfile
-          push: true
-          tags: ${{ steps.meta_base.outputs.tags }}
-          labels: ${{ steps.meta_base.outputs.labels }}
+          cd docker/release && ./generate-files.sh "${{ steps.meta_base.outputs.version }}" "${{ env.IMAGE_BASE }}/" "#{{ env.BASE_DIGEST }}"
 
       - name: Build and push registrar
         id: build_registrar

--- a/.github/workflows/update-base-image.yml
+++ b/.github/workflows/update-base-image.yml
@@ -1,0 +1,52 @@
+name: Create PR updating containers base image
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 1 * *"
+
+env:
+  FEDORA_IMAGE: quay.io/fedora/fedora
+  TAG: latest
+  IMAGE_BASE: quay.io/keylime
+
+jobs:
+  update-base-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
+      - name: Install skopeo and jq
+        run: sudo apt-get install -y skopeo jq
+
+      - name: Get hash of the latest stable version of Fedora
+        run: echo "FEDORA_HASH=$(skopeo inspect docker://${{ env.FEDORA_IMAGE }}:${{ env.TAG }} | jq '.Digest')" >> "$GITHUB_ENV"
+
+      - name: Update the Dockerfile template
+        run: |
+          cd docker/release/base
+          sed -i "s#\(FROM \)[^ ]*#\1${{ env.FEDORA_IMAGE }}@${{ env.FEDORA_HASH }}#" Dockerfile.in
+
+      - name: Get current date for message
+        id: date
+        run: echo "DATE=$(date +"%Y-%m-%d")" >> "$GITHUB_ENV"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
+        with:
+          add-paths: docker/release/base/Dockerfile.in
+          title: "[Automatic] Update Keylime base image (${{ env.DATE }})"
+          body: |
+            Automatically update the Keylime base image using:
+
+            Base image: ${{ env.FEDORA_IMAGE }}@${{ env.FEDORA_HASH }}
+          commit-message: |
+            [Automatic] Update Keylime base image ${{ env.DATE }}
+
+            Automatically update the Keylime base image using:
+
+            Base image: ${{ env.FEDORA_IMAGE }}@${{ env.FEDORA_HASH }}
+

--- a/docker/release/base/Dockerfile.in
+++ b/docker/release/base/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:40@sha256:8af205680ee38c3d9ed3178ace5dd23ac39d0d4cdb8e799ac9ab902ef83d4060 AS keylime_base
+FROM quay.io/fedora/fedora@"sha256:9b16c414d86478f6ec2d5946ab5f692627c163db91d5549b8378169e31e9c551" AS keylime_base
 LABEL version="_version_" description="Keylime Base - Only used as an base image for derived packages"
 MAINTAINER Keylime Team <main@keylime.groups.io>
 

--- a/docker/release/build_locally.sh
+++ b/docker/release/build_locally.sh
@@ -15,7 +15,17 @@ if [ -z "${IMAGE_BASE}" ]; then
     IMAGE_BASE="${REGISTRY}/keylime"
 fi
 
+FEDORA_IMAGE="${REGISTRY}/fedora/fedora"
+FEDORA_DIGEST="$(skopeo inspect docker://${FEDORA_IMAGE}:latest | jq '.Digest')"
+
+# Prepare base image Dockerfile
+sed -i "s#\(FROM \)[^ ]*#\1${FEDORA_IMAGE}@${FEDORA_DIGEST}#" base/Dockerfile.in
+sed "s#_version_#${VERSION}#" base/Dockerfile.in > base/Dockerfile
+
+# Prepare other components Dockerfile
 ./generate-files.sh ${VERSION}
+
+# Build images
 for part in base registrar verifier tenant; do
   docker buildx build -t keylime_${part}:${VERSION} -f "${part}/Dockerfile" --security-opt label=disable --progress plain ${@:3} "$KEYLIME_DIR"
   rm -f ${part}/Dockerfile

--- a/docker/release/generate-files.sh
+++ b/docker/release/generate-files.sh
@@ -7,11 +7,17 @@
 
 VERSION=${1:-latest}
 SOURCE=${2:-""}
+DIGEST=${3:-""}
 
 # Docker only allows lower case repositories
 SOURCE=$(echo -n ${SOURCE} | tr '[:upper:]' '[:lower:]')
-for part in base registrar verifier tenant; do
+for part in registrar verifier tenant; do
   echo "Generating ${part}"
   sed "s#_version_#${VERSION}#" "${part}/Dockerfile.in" > ${part}/Dockerfile
   sed -i "s#_source_#${SOURCE}#" ${part}/Dockerfile
+  if [ -n "$DIGEST" ]; then
+    sed -i "s#_digest_#@${DIGEST}#" ${part}/Dockerfile
+  else
+    sed -i "s#_digest_#:${VERSION}#" ${part}/Dockerfile
+  fi
 done

--- a/docker/release/registrar/Dockerfile.in
+++ b/docker/release/registrar/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM _source_keylime_base:_version_ AS keylime_registrar
+FROM _source_keylime_base_digest_ AS keylime_registrar
 LABEL version="_version_" description="Keylime Registrar - Bootstrapping and Maintaining Trust in the Cloud"
 MAINTAINER Keylime Team <main@keylime.groups.io>
 

--- a/docker/release/tenant/Dockerfile.in
+++ b/docker/release/tenant/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM _source_keylime_base:_version_ AS keylime_tenant
+FROM _source_keylime_base_digest_ AS keylime_tenant
 
 # install latest stable kubectl version - required for Kubernetes init job in the helm charts
 RUN export GOARCH="$( uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/' )" && \

--- a/docker/release/verifier/Dockerfile.in
+++ b/docker/release/verifier/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM _source_keylime_base:_version_ AS keylime_verifier
+FROM _source_keylime_base_digest_ AS keylime_verifier
 LABEL version="_version_" description="Keylime Verifier - Bootstrapping and Maintaining Trust in the Cloud"
 MAINTAINER Keylime Team <main@keylime.groups.io>
 


### PR DESCRIPTION
Add a workflow to automatically create pull requests updating the Fedora image used to build the base image.
The workflow should run monthly and can also be triggered manually on demand.

Build the base image separately when the Dockerfile template is updated.

Modify the other images build to use the master base image from the registry.

Fixes #1579