### PR TITLE
workflows/base-image: Add latest tag to the CI image build

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -52,6 +52,7 @@ jobs:
             type=sha,prefix=sha-
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=raw,monthly
+            type=raw,latest
 
       - name: Prepare Dockerfile
         run: |


### PR DESCRIPTION
The CI uses the 'latest' tag for the CI image