### PR TITLE
mba: Add a skip custom policies option when loading mba.

### DIFF
--- a/keylime/mba/mba.py
+++ b/keylime/mba/mba.py
@@ -56,17 +56,20 @@ _mba_imports = []
 # ###########
 
 
-def load_imports() -> None:
+def load_imports(skip_custom_policies: Optional[bool] = False) -> None:
     """
     MBA API front-end for importing any modules needed by measured boot attestation.
-    No inputs.
+    :param skip_custom_policies: may be used to prevent the loading of custom policies.
     No outputs.
     Side effects: Reads from keylime configuration files.
       After execution all imports required by MBA are loaded and initialized.
     Exceptions: If any policy engine in the list cannot be loaded.
     """
     try:
-        imports = config.getlist("verifier", "measured_boot_imports")
+        imports: List[Any] = []
+        if not skip_custom_policies:
+            # import custom policies
+            imports = config.getlist("verifier", "measured_boot_imports")
         # these are the defaults
         imports.append("keylime.mba.elchecking.elchecker")
         imports.append("keylime.mba.elchecking.example")

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -158,7 +158,7 @@ class Tenant:
         else:
             logger.warning("TLS is disabled.")
 
-        mba.load_imports()
+        mba.load_imports(skip_custom_policies=True)
 
     @property
     def verifier_base_url(self) -> str:


### PR DESCRIPTION
Allowing the skipping of custom policies, known only to the verifier, will enable the tenant to call MBA without consulting the verifier config file.

Resolves: #1541