### PR TITLE
Lint: ignore reportArgumentType and reportInvalidTypeForm errors

### DIFF
--- a/keylime/ca_impl_openssl.py
+++ b/keylime/ca_impl_openssl.py
@@ -185,7 +185,7 @@ def mk_signed_cert(
         cert_req = cert_req.add_extension(ext, critical=False)
 
     cert = cert_req.sign(
-        private_key=ca_privkey,
+        private_key=ca_privkey,  # pyright: ignore[reportArgumentType]
         algorithm=hashes.SHA256(),
         backend=default_backend(),
     )

--- a/keylime/web/base/controller.py
+++ b/keylime/web/base/controller.py
@@ -70,7 +70,7 @@ class Controller:
     FormParams: TypeAlias = Union[QueryParams, MultipartParams]
     JSONConvertible: TypeAlias = Union[str, int, float, bool, None, "JSONObjectConvertible", "JSONArrayConvertible"]
     JSONObjectConvertible: TypeAlias = Mapping[str, JSONConvertible]
-    JSONArrayConvertible: TypeAlias = Sequence[JSONConvertible]
+    JSONArrayConvertible: TypeAlias = Sequence[JSONConvertible]  # pyright: ignore[reportInvalidTypeForm]
     Params: TypeAlias = Mapping[
         str, Union[str, bytes, Sequence[str | bytes], JSONObjectConvertible, JSONArrayConvertible]
     ]


### PR DESCRIPTION
Ignoring pyright reportArgumentType and reportInvalidTypeForm errors until a better solution can be found.