### PR TITLE
docker: Install latest Keylime during image build

### DIFF
--- a/docker/release/base/Dockerfile.in
+++ b/docker/release/base/Dockerfile.in
@@ -1,8 +1,8 @@
-FROM quay.io/fedora/fedora@sha256:0053784e743aecb195111752b07d24f787b29e69016ba47ecd3d10411829f73f AS keylime_base
+FROM quay.io/fedora/fedora@"sha256:5b0aea5317aab3d3066612f7c8ee37e86284942179fb53ebcb9f008ea309e813" AS keylime_base
 LABEL version="_version_" description="Keylime Base - Only used as an base image for derived packages"
 MAINTAINER Keylime Team <main@keylime.groups.io>
 
-RUN dnf -y install dnf-plugins-core git efivar-libs efivar-devel && dnf -y builddep tpm2-tools 
+RUN dnf -y install dnf-plugins-core git efivar-libs efivar-devel python3-jinja2 python3-PyMySQL && dnf -y builddep tpm2-tools
 RUN git clone -b 5.7 https://github.com/tpm2-software/tpm2-tools.git && \
     cd tpm2-tools && \
     git config user.email "main@keylime.groups.io" && \
@@ -11,8 +11,3 @@ RUN git clone -b 5.7 https://github.com/tpm2-software/tpm2-tools.git && \
     ./configure && \
     make && make install && \
     cd .. && rm -rf tpm2-tools
-
-ENV GOPATH=/root/go
-RUN --mount=target=/keylime,type=bind,source=.,rw \
-    cd /keylime && ./installer.sh -o && \
-    dnf -y install python3-PyMySQL

--- a/docker/release/registrar/Dockerfile.in
+++ b/docker/release/registrar/Dockerfile.in
@@ -2,6 +2,9 @@ FROM _source_keylime_base_digest_ AS keylime_registrar
 LABEL version="_version_" description="Keylime Registrar - Bootstrapping and Maintaining Trust in the Cloud"
 MAINTAINER Keylime Team <main@keylime.groups.io>
 
+RUN --mount=target=/keylime,type=bind,source=.,rw \
+    cd /keylime && ./installer.sh -o
+
 EXPOSE 8890
 EXPOSE 8891
 

--- a/docker/release/tenant/Dockerfile.in
+++ b/docker/release/tenant/Dockerfile.in
@@ -13,4 +13,7 @@ RUN export GOARCH="$( uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/' 
 LABEL version="_version_" description="Keylime Tenant - Bootstrapping and Maintaining Trust in the Cloud"
 MAINTAINER Keylime Team <main@keylime.groups.io>
 
+RUN --mount=target=/keylime,type=bind,source=.,rw \
+    cd /keylime && ./installer.sh -o
+
 ENTRYPOINT ["keylime_tenant"]

--- a/docker/release/verifier/Dockerfile.in
+++ b/docker/release/verifier/Dockerfile.in
@@ -2,6 +2,9 @@ FROM _source_keylime_base_digest_ AS keylime_verifier
 LABEL version="_version_" description="Keylime Verifier - Bootstrapping and Maintaining Trust in the Cloud"
 MAINTAINER Keylime Team <main@keylime.groups.io>
 
+RUN --mount=target=/keylime,type=bind,source=.,rw \
+    cd /keylime && ./installer.sh -o
+
 EXPOSE 8880
 EXPOSE 8881
 


### PR DESCRIPTION
Previously, the image build would not install Keylime, but simply reuse the version installed during the base image build.

This fixes the issue, installing the latest Keylime version during image build.

Since the images were using outdated Keylime, the tests in https://github.com/RedHat-SP-Security/keylime-tests/pull/602 were failing.