### PR TITLE
keylime_policy: setting `log_hash_alg` to `sha1` (template-hash algo)

### DIFF
--- a/keylime/policy/create_runtime_policy.py
+++ b/keylime/policy/create_runtime_policy.py
@@ -745,14 +745,13 @@ def create_runtime_policy(args: argparse.Namespace) -> Optional[RuntimePolicyTyp
         )
 
     algo = args.algo
-    if args.algo == "":
-        # Need to find the algo from the boot_aggregate.
-        algo, _ = boot_aggregate_from_file(args.ima_measurement_list)
+    if algo == "":
+        algo = FALLBACK_HASH_ALGO
 
     policy = ima.empty_policy()
 
-    # Set hash algo.
-    policy["ima"]["log_hash_alg"] = algo
+    # Set the algorithm for the template-hash; the kernel currently hardcodes it to sha1.
+    policy["ima"]["log_hash_alg"] = "sha1"
 
     if args.base_policy:
         merged_policy = merge_base_policy(policy, cast(str, args.base_policy))


### PR DESCRIPTION
Set the algorithm for the template-hash (`log_hash_alg`) to `sha1`; the kernel currently hardcodes it to sha1. Now, the specified algorithm is only used for hashing the ramdisk and rootfs. If one is not provided, it defaults to sha256.
This change fixes #1609 because the policy schema prevents the use of sm3 for `log_hash_alg`. It also fixes #1623 since it removes the lookup for the boot_aggregate algorithm by setting `log_hash_alg` to sha1 instead.