### PR TITLE
docs: Fix Runtime Policy JSON schema to reflect the reality

### DIFF
--- a/docs/user_guide/runtime_ima.rst
+++ b/docs/user_guide/runtime_ima.rst
@@ -202,18 +202,22 @@ Depending of the use case the object can also be constructed manually instead of
 
     {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "Keylime IMA policy",
+        "title": "Keylime Runtime policy",
         "type": "object",
         "properties": {
             "meta": {
                 "type": "object",
                 "properties": {
+                    "generator": {
+                        "type": "integer",
+                        "description": "Identifier of the origin of the policy."
+                    },
                     "version": {
                         "type": "integer",
                         "description": "Version number of the IMA policy schema"
                     }
                 },
-                "required": ["version"],
+                "required": ["version", "generator"],
                 "additionalProperties": false
             },
             "release": {
@@ -237,7 +241,7 @@ Depending of the use case the object can also be constructed manually instead of
             },
             "excludes": {
                 "type": "array",
-                "title": "Excluded file paths",
+                "title": "Regular expression strings to match file paths to exclude",
                 "items": {
                     "type": "string",
                     "format": "regex"
@@ -263,11 +267,9 @@ Depending of the use case the object can also be constructed manually instead of
                 }
             },
             "verification-keys": {
-                "type": "array",
-                "title": "Public keys to verify IMA attached signatures",
-                "items": {
-                    "type": "string"
-                }
+                "type": "string",
+                "title": "A JSON encoded IMA Keyring object",
+                "description": "A JSON encoded IMA Keyring object. It contains public keys used to verify IMA attached signatures",
             },
             "ima": {
                 "type": "object",
@@ -294,6 +296,43 @@ Depending of the use case the object can also be constructed manually instead of
             }
         },
         "required": ["meta", "release", "digests", "excludes", "keyrings", "ima", "ima-buf", "verification-keys"],
+        "additionalProperties": false
+    }
+
+IMA Keyring JSON Schema
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The `verification-keys` field of the Runtime Policy is a JSON encoded IMA Keyring object.
+The following schema can be used to validate it:
+
+.. sourcecode:: json
+
+    {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "IMA Keyring JSON schema",
+        "type": "object",
+        "properties": {
+            "meta": {
+                "type": "object",
+                "required": ["version"],
+                "properties": {
+                    "version": {"type": "integer", "minimum": 1},
+                },
+            },
+            "keyids": {
+                "type": "array",
+                "description": "Lowest 4 bytes of the SHA-1 hash over the DER encoded public key",
+                "title": "Identifier of the public keys.",
+                "items": {"type": "integer"}
+            },
+            "pubkeys": {
+                "type": "array",
+                "description": "An array of Base64 encoded public keys in DER format"
+                "title": "The keyring public keys"
+                "items": {"type": "string"}
+            },
+        },
+        "required": ["keyids", "pubkeys"],
         "additionalProperties": false
     }
 


### PR DESCRIPTION
Previously, the documented Runtime Policy JSON schema did not correspond to the actual implementation.

This change aligns the documented JSON Schema to the actual implementation.

Fixes #1564