### PR TITLE
keylime-policy: use consistent names for create runtime

### DIFF
--- a/keylime/cmd/keylime_policy.py
+++ b/keylime/cmd/keylime_policy.py
@@ -20,11 +20,11 @@ except ModuleNotFoundError:
 
 from keylime.policy import create_runtime_policy
 
-logger = logging.getLogger("keylime_policy")
+logger = logging.getLogger("keylime-policy")
 
 
 def main() -> None:
-    """keylime_policy entry point."""
+    """keylime-policy entry point."""
     if os.geteuid() != 0:
         logger.critical("Please, run this program as root")
         sys.exit(1)

--- a/keylime/policy/create_runtime_policy.py
+++ b/keylime/policy/create_runtime_policy.py
@@ -503,7 +503,7 @@ def get_arg_parser(create_parser: _SubparserType, parent_parser: argparse.Argume
     )
     runtime_p.add_argument(
         "-e",
-        "--exclude-list",
+        "--excludelist",
         dest="exclude_list_file",
         required=False,
         help="An IMA exclude list file whose contents will be added to the policy",
@@ -527,7 +527,6 @@ def get_arg_parser(create_parser: _SubparserType, parent_parser: argparse.Argume
         default=IMA_MEASUREMENT_LIST,
     )
     runtime_p.add_argument(
-        "-i",
         "--ignored-keyrings",
         dest="ignored_keyrings",
         action="append",
@@ -536,7 +535,6 @@ def get_arg_parser(create_parser: _SubparserType, parent_parser: argparse.Argume
         default=IGNORED_KEYRINGS,
     )
     runtime_p.add_argument(
-        "-A",
         "--add-ima-signature-verification-key",
         action="append",
         dest="ima_signature_keys",

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,4 +56,4 @@ console_scripts =
         keylime_sign_runtime_policy = keylime.cmd.sign_runtime_policy:main
         keylime_upgrade_config = keylime.cmd.convert_config:main
         keylime_create_policy = keylime.cmd.create_policy:main
-        keylime_policy = keylime.cmd.keylime_policy:main
+        keylime-policy = keylime.cmd.keylime_policy:main

--- a/test/test_create_runtime_policy.py
+++ b/test/test_create_runtime_policy.py
@@ -714,7 +714,7 @@ foobar.so(.*)?
                     "algo_opt": [],
                     "base_policy": [],
                     "allowlist": [],
-                    "ima_log": ["--use-ima-measurement-list", "--ima-measurement-list", ima_log],
+                    "ima_log": ["--ima-measurement-list", ima_log],
                     "rootfs": [],
                     "expected_algo": f"{algo}",
                     "expected_source": "IMA measurement list",
@@ -722,7 +722,7 @@ foobar.so(.*)?
             )
 
             # Cases where the algorithm from the allowlist should be kept
-            for il in [[], ["--use-ima-measurement-list", "--ima-measurement-list", ima_log]]:
+            for il in [[], ["--ima-measurement-list", ima_log]]:
                 for rfs in [[], ["--rootfs", rootfs]]:
                     test_cases.append(
                         {


### PR DESCRIPTION
This PR has a few changes related to consistency within the policy tool, and has the following changes:

1) Let's keep option names consistent, i.e. use `--allowlist`/`--excludelist`, instead of `--allowlist`/`--exclude-list`
2) drop some confusing "short" shortcuts, like `-i` and `-A`, and keep long versions instead, for those
3) drop superfluous option `--use-ima-measurement-list`, as we already have `--ima-measurement-list`; the behavior is the following: if `--ima-measurement-list` is used without any argument, it will use the default IMA measurement list file, `/sys/kernel/security/ima/ascii_runtime_measurements`; if a parameter is given as argument, that parameter indicates the file to read as a source for the IMA measurement list
4) rename the tool itself from `keylime_policy` to `keylime-policy`


Fixes: #1610 