### PR TITLE
pylintrc: Ignore too-many-positional-arguments check

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -4,7 +4,7 @@ ignore-paths=^.*test/data/template-invalid-adjust/.*$
 load-plugins=keylime.models.base.pylint
 
 [MESSAGES CONTROL]
-disable=C0103,C0111,C0115,C0116,C0301,C0302,W0511,W0603,W0703,W0719,R0801,R0902,R0903,R0904,R0911,R0912,R0913,R0914,R0915
+disable=C0103,C0111,C0115,C0116,C0301,C0302,W0511,W0603,W0703,W0719,R0801,R0902,R0903,R0904,R0911,R0912,R0913,R0914,R0915,R0917
 
 [TYPECHECK]
 ignored-modules=zmq,alembic.op,alembic.context,cryptography.hazmat.primitives.asymmetric.rsa,gpg


### PR DESCRIPTION
The CI started failing due to the `too-many-positional-arguments` check from `pylint`.

This makes this check to be ignored.