### PR TITLE
Drop pending SPDX-License-Identifier headers

### DIFF
--- a/demo/agent_monitor/tenant_agent_monitor.py
+++ b/demo/agent_monitor/tenant_agent_monitor.py
@@ -1,10 +1,5 @@
 #!/usr/bin/python3
 
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 # wget  --ca-certificate=/var/lib/keylime/secure/unzipped/cacert.crt --post-data '{}'
 #       --certificate=/var/lib/keylime/secure/unzipped/d432fbb3-d2f1-4a97-9ef7-75bd81c00000-cert.crt
 #       --private-key=/var/lib/keylime/secure/unzipped/d432fbb3-d2f1-4a97-9ef7-75bd81c00000-private.pem

--- a/keylime/cmd/attest.py
+++ b/keylime/cmd/attest.py
@@ -1,9 +1,5 @@
 #!/usr/bin/python3
 
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
 import sys
 
 from keylime import keylime_logging

--- a/keylime/cmd/keylime_policy.py
+++ b/keylime/cmd/keylime_policy.py
@@ -2,9 +2,6 @@
 
 """
 Utility to assist with runtime policies.
-
-SPDX-License-Identifier: Apache-2.0
-Copyright 2024 Red Hat, Inc.
 """
 
 import argparse

--- a/keylime/dsse/dsse.py
+++ b/keylime/dsse/dsse.py
@@ -1,8 +1,6 @@
 r"""DSSE signing implementation.
 
 Based on the reference implementation at: https://github.com/secure-systems-lab/dsse/tree/master/implementation.
-
-SPDX-License-Identifier: Apache-2.0
 """
 
 import base64

--- a/keylime/dsse/ecdsa.py
+++ b/keylime/dsse/ecdsa.py
@@ -1,6 +1,4 @@
-"""ECDSA signing/verification implementation.
-SPDX-License-Identifier: Apache-2.0
-"""
+"""ECDSA signing/verification implementation."""
 
 import hashlib
 

--- a/keylime/dsse/x509.py
+++ b/keylime/dsse/x509.py
@@ -1,6 +1,4 @@
-"""x509 signing/verification implementation.
-SPDX-License-Identifier: Apache-2.0
-"""
+"""x509 signing/verification implementation."""
 
 import base64
 import datetime

--- a/keylime/policy/create_runtime_policy.py
+++ b/keylime/policy/create_runtime_policy.py
@@ -1,8 +1,5 @@
 """
 Module to assist with creating runtime policies.
-
-SPDX-License-Identifier: Apache-2.0
-Copyright 2024 Red Hat, Inc.
 """
 
 import argparse

--- a/keylime/policy/initrd.py
+++ b/keylime/policy/initrd.py
@@ -2,9 +2,6 @@
 
 """
 Module to help with extracting initrds.
-
-SPDX-License-Identifier: Apache-2.0
-Copyright 2024 Red Hat, Inc.
 """
 
 import logging

--- a/keylime/policy/utils.py
+++ b/keylime/policy/utils.py
@@ -1,8 +1,5 @@
 """
 Module to assist with creating runtime policies.
-
-SPDX-License-Identifier: Apache-2.0
-Copyright 2024 Red Hat, Inc.
 """
 
 import enum

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import configparser
 import os
 import sys

--- a/test/test_api_version.py
+++ b/test/test_api_version.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 Red Hat, Inc
-"""
-
 import unittest
 
 from keylime import api_version

--- a/test/test_ca_impl_openssl.py
+++ b/test/test_ca_impl_openssl.py
@@ -1,7 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
 import os
 import sys
 import unittest

--- a/test/test_ca_util.py
+++ b/test/test_ca_util.py
@@ -1,9 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 Red Hat, Inc.
-"""
-
-
 import os
 import shutil
 import sys

--- a/test/test_cert_utils.py
+++ b/test/test_cert_utils.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2022 Red Hat, Inc.
-"""
-
 import base64
 import os
 import unittest

--- a/test/test_create_runtime_policy.py
+++ b/test/test_create_runtime_policy.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2024 Red Hat, Inc.
-"""
-
 import argparse
 import os
 import pathlib

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2017 Massachusetts Institute of Technology.
-"""
-
 import unittest
 
 from keylime.crypto import (

--- a/test/test_ima_ast.py
+++ b/test/test_ima_ast.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 Thore Sommer
-"""
-
 import unittest
 
 from keylime.common.algorithms import Hash

--- a/test/test_ima_verification.py
+++ b/test/test_ima_verification.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2020 IBM Corporation
-"""
-
 import codecs
 import copy
 import hashlib

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 Red Hat, Inc.
-"""
-
 import unittest
 
 from keylime import json as keylime_json

--- a/test/test_policy_conversion.py
+++ b/test/test_policy_conversion.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2022 Red Hat, Inc.
-"""
-
 import json
 import tempfile
 import unittest

--- a/test/test_registrar_db.py
+++ b/test/test_registrar_db.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2020 Luke Hinds (lhinds@redhat.com), Red Hat, Inc.
-"""
-
 import unittest
 
 from sqlalchemy import create_engine

--- a/test/test_retry_algo.py
+++ b/test/test_retry_algo.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2021 Angelo Ruocco - IBM Research Lab Zurich
-"""
-
 import random
 import unittest
 

--- a/test/test_rpm_repo.py
+++ b/test/test_rpm_repo.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2024 Red Hat, Inc.
-"""
-
 import os
 import pathlib
 import shutil

--- a/test/test_signing.py
+++ b/test/test_signing.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2022 Red Hat, Inc.
-"""
-
 import unittest
 from pathlib import Path
 

--- a/test/test_verifier_db.py
+++ b/test/test_verifier_db.py
@@ -1,8 +1,3 @@
-"""
-SPDX-License-Identifier: Apache-2.0
-Copyright 2020 Luke Hinds (lhinds@redhat.com), Red Hat, Inc.
-"""
-
 import unittest
 
 from sqlalchemy import create_engine


### PR DESCRIPTION
As clarified in #830, license headers should be removed from source code to ease homogeneity among them