### PR TITLE
fix docker build by bumping fedora baseimage

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -5,7 +5,7 @@
 # It is not recommended for use beyond testing scenarios.
 ##############################################################################
 
-FROM quay.io/fedora/fedora@sha256:1ba88682f9ccc835f87ea8b81b46cafbd0a0214c200d5eb9fdf2808b13cdd070
+FROM quay.io/fedora/fedora@sha256:fb6b7814deb770c0bd99ad618f6f53d9a12261df061989f1dfd3d90ad1ac193e
 MAINTAINER Luke Hinds <lhinds@redhat.com>
 LABEL version="1.2.0" description="Keylime - Bootstrapping and Maintaining Trust in the Cloud"
 


### PR DESCRIPTION
Dockerbuild does not work as the sha256 pinned fedora image no longer exists in Quay. Bumping it to latest sha256 fixes it.

Fixes: #1666