### PR TITLE
PostgreSQL support for docker using psycopg2

### DIFF
--- a/docker/release/base/Dockerfile.in
+++ b/docker/release/base/Dockerfile.in
@@ -2,7 +2,7 @@ FROM quay.io/fedora/fedora@sha256:1ba88682f9ccc835f87ea8b81b46cafbd0a0214c200d5e
 LABEL version="_version_" description="Keylime Base - Only used as an base image for derived packages"
 MAINTAINER Keylime Team <main@keylime.groups.io>
 
-RUN dnf -y install dnf-plugins-core git efivar-libs efivar-devel python3-jinja2 python3-PyMySQL && dnf -y builddep tpm2-tools
+RUN dnf -y install dnf-plugins-core git efivar-libs efivar-devel python3-jinja2 python3-PyMySQL python3-psycopg2 nc && dnf -y builddep tpm2-tools
 RUN git clone -b 5.7 https://github.com/tpm2-software/tpm2-tools.git && \
     cd tpm2-tools && \
     git config user.email "main@keylime.groups.io" && \


### PR DESCRIPTION
Adds `psycopg2` module to support PostgreSQL by adding it to the base docker image build as `python3-psycopg2`.

Also includes `nc` to support healthchecks in docker.

Fixes #1672 