### PR TITLE
docs: update TCTI environment variable usage

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -160,17 +160,20 @@ the :code:`tpm2_checkquote` utility in your path.
     resource manager (available `here <https://github.com/tpm2-software/tpm2-abrmd>`_).
 
 How the TPM is accessed by tpm2-tools can be set using the :code:`TPM2TOOLS_TCTI` environment
-variable. More information about that can be found
+variable. Keylime Rust agent understands :code:`TCTI` without the prefix.
+More information about that can be found
 `here <https://github.com/tpm2-software/tpm2-tools/blob/master/man/common/tcti.md>`_.
 
 Talk to the swtpm emulator directly::
 
     export TPM2TOOLS_TCTI="mssim:port=2321"
+    export TCTI="mssim:port=2321"
 
 
 To talk to the TPM directly (not recommended)::
 
     export TPM2TOOLS_TCTI="device:/dev/tpm0"
+    export TCTI="device:/dev/tpm0"
 
 
 Install Keylime


### PR DESCRIPTION
Keylime Rust agent does not understand `TPM2TOOLS_` prefixed configuration. For example, `TPM2TOOLS_TCTI` is ignored when setting up swtpm.

`.ci/test_wrapper.sh` is already exporting both formats, but installation documentation is not mentioning the shorter format at all. 