### PR TITLE
tests: Use Fedora 41 to generate code coverage

### DIFF
--- a/.github/workflows/submit-HEAD-coverage.yaml
+++ b/.github/workflows/submit-HEAD-coverage.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Install testing-farm script
       run: pip3 -v install tft-cli
     - name: Run tests on Testing Farm
-      run: testing-farm request --context distro=fedora-39 --arch x86_64 --compose Fedora-39 --plan '/e2e-with-revocation' -e UPLOAD_COVERAGE=1 2>&1 | tee tt_output
+      run: testing-farm request --context distro=fedora-41 --arch x86_64 --compose Fedora-41 --plan '/e2e-with-revocation' -e UPLOAD_COVERAGE=1 2>&1 | tee tt_output
       env:
         TESTING_FARM_API_TOKEN: ${{ secrets.TESTING_FARM_API_TOKEN }}
     - name: Find PR Packit tests to finish and download coverage.xml file

--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -97,8 +97,8 @@ adjust:
 
   adjust+:
    # discover step adjustments
-   # disable code coverage measurement everywhere except F39
-   - when: distro != fedora-39
+   # disable code coverage measurement everywhere except F41
+   - when: distro != fedora-41
      discover+:
        test-:
         - /setup/enable_keylime_coverage

--- a/scripts/download_packit_coverage.sh
+++ b/scripts/download_packit_coverage.sh
@@ -35,8 +35,8 @@ PROJECT="keylime/keylime"
 
 # TF_JOB_DESC points to a Testing farm job that does code coverage measurement and 
 # uploads coverage XML files to a web drive
-# currently we are doing that in a job running tests on Fedora-39
-TF_JOB_DESC="testing-farm:fedora-39-x86_64"
+# currently we are doing that in a job running tests on Fedora-41
+TF_JOB_DESC="testing-farm:fedora-41-x86_64"
 TF_TEST_OUTPUT="/setup/generate_coverage_report.*/output.txt"
 TF_ARTIFACTS_URL_PREFIX="https://artifacts.dev.testing-farm.io"
 


### PR DESCRIPTION
Replace the Fedora 39 usage to generate code coverage with Fedora 41.

This is necessary because Fedora 39 is now EOL and the tests are no longer triggered for it.