### PR TITLE
Misc fixes for keylime-policy

### DIFF
--- a/keylime/cmd/keylime_policy.py
+++ b/keylime/cmd/keylime_policy.py
@@ -56,7 +56,9 @@ def main() -> None:
         main_parser.exit()
 
     try:
-        args.func(args)
+        ret = args.func(args)
+        if ret is None:
+            sys.exit(1)
     except BrokenPipeError:
         # Python flushes standard streams on exit; redirect remaining output
         # to devnull to avoid another BrokenPipeError at shutdown.

--- a/keylime/policy/create_runtime_policy.py
+++ b/keylime/policy/create_runtime_policy.py
@@ -14,10 +14,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, TextIO, Tuple
 
 import psutil
 
-from keylime import cert_utils
 from keylime.common import algorithms, validators
 from keylime.ima import file_signatures, ima
 from keylime.ima.types import RuntimePolicyType
+from keylime.models.base import Certificate
 from keylime.policy import initrd
 from keylime.policy.logger import Logger
 from keylime.policy.utils import merge_lists, merge_maplists
@@ -767,7 +767,7 @@ def process_ima_buf_in_measurement_list(
 
                 # check whether buf's bindata contains a key; if so, we will only
                 # append it to 'keyrings', never to 'ima-buf'
-                if bindata and cert_utils.is_x509_cert(bindata):
+                if bindata and Certificate().asn1_compliant(bindata):
                     if path in ignored_keyrings or not get_keyrings:
                         continue
 

--- a/keylime/policy/sign_runtime_policy.py
+++ b/keylime/policy/sign_runtime_policy.py
@@ -30,7 +30,7 @@ VALID_BACKENDS = ["ecdsa", "x509"]
 
 def get_arg_parser(create_parser: _SubparserType, parent_parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """Perform the setup of the command-line arguments for this module."""
-    sign_p = create_parser.add_parser("runtime", help="create runtime policies", parents=[parent_parser])
+    sign_p = create_parser.add_parser("runtime", help="sign runtime policies", parents=[parent_parser])
 
     sign_p.add_argument(
         "-o",

--- a/keylime/policy/sign_runtime_policy.py
+++ b/keylime/policy/sign_runtime_policy.py
@@ -124,8 +124,8 @@ def _get_signer(
         else:
             signer = ecdsa.Signer.create(out_keyfile_path)
     elif backend == "x509":
-        if out_certfile is None:
-            logger.debug("x509 backend and no cerficate output file specified")
+        if out_certfile is None or out_certfile == "":
+            logger.error("x509 backend and no cerficate output file specified")
             return None
 
         if ec_privkey:

--- a/keylime/policy/sign_runtime_policy.py
+++ b/keylime/policy/sign_runtime_policy.py
@@ -107,8 +107,12 @@ def _get_signer(
 
     ec_privkey: Optional[ec.EllipticCurvePrivateKey] = None
     if in_ec_keyfile_path:
-        with open(in_ec_keyfile_path, "rb") as pem_in:
-            pemlines = pem_in.read()
+        try:
+            with open(in_ec_keyfile_path, "rb") as pem_in:
+                pemlines = pem_in.read()
+        except FileNotFoundError:
+            logger.error("The specified key '%s' does not exist", in_ec_keyfile_path)
+            return None
         privkey = load_pem_private_key(pemlines, None, default_backend())
 
         if not isinstance(privkey, ec.EllipticCurvePrivateKey):


### PR DESCRIPTION
- fix help for "keylime-policy sign" verb
- check for valid cert file when using x509 backend (sign)
- use Certificate() from models.base to validate certs
- exit with status 1 when the commands failed
-  improve error handling when provided a bad key (sign)