### PR TITLE
tenant: Correctly log number of tries when deleting

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -862,7 +862,7 @@ class Tenant:
                         #                            numtries,
                         #                        )
                         raise UserError(
-                            f"{self.agent_fid_str,} was not deleted from {self.verifier_fid_str} after %d tries"
+                            f"{self.agent_fid_str,} was not deleted from {self.verifier_fid_str} after {numtries} tries"
                         )
 
                     next_retry = retry.retry_time(self.exponential_backoff, self.retry_interval, numtries, logger)


### PR DESCRIPTION
The change to a f-string format for the error raised when the deletion of an agent failed was not done correctly, resulting in the number of tries before giving up to not be printed.

A message similar to the following would be logged instead:

```
2024-12-02 12:54:11.424 - keylime.tenant - ERROR - ('Agent d432fbb3-d2f1-4a97-9ef7-75bd81c00000 (127.0.0.1:9002)',) was not deleted from Verifier default (127.0.0.1:8881) after %d tries
```