### PR TITLE
docker/ci: Add xxd to the CI image

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -69,7 +69,8 @@ tpm2-tss \
 tpm2-tss-devel \
 uthash-devel \
 wget \
-which"
+which \
+xxd"
 
 RUN dnf makecache && \
   dnf -y install $PKGS_DEPS && \


### PR DESCRIPTION
The `xxd` tool is used to generate IAK and IDevID certificates during tests