### PR TITLE
packit: Fix typo to run keylime-policy-commands test

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -75,7 +75,7 @@ adjust:
      - /functional/install-rpm-with-ima-signature
      - /functional/keylime-non-default-ports
      - /functional/keylime_create_policy-static-data
-     - /functional/keylime_policy-commands
+     - /functional/keylime-policy-commands
      - /functional/keylime_tenant-commands-on-localhost
      - /functional/keylime_tenant-ima-signature-sanity
      - /functional/measured-boot-swtpm-sanity


### PR DESCRIPTION
Fix the typo replacing `keylime_policy-commands` with `keylime-policy-commands` on packit configuration.