### PR TITLE
Misc test fixes

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,6 @@ dbus-python
 setuptools
 # packages required for mypy
 sqlalchemy-stubs
-typed-ast
 types-python-dateutil
 types-PyYAML
 types-redis

--- a/test/data/create-runtime-policy/setup-rpm-tests
+++ b/test/data/create-runtime-policy/setup-rpm-tests
@@ -275,10 +275,20 @@ prepare_rpms() {
         cp -a "${RPM_REPO_UNSIGNED}"/* "${_repodir}"/
     done
 
+    # --filelists-ext was introduced in createrepo_c 0.21; some distros
+    # - e.g. CentOS Stream 9 at the time of writing - have an older
+    # version of it, so that option is not available.
+    fext=
+    crepo_maj="$(createrepo_c --version | cut -f2 -d' ' | cut -f1 -d'.')"
+    crepo_min="$(createrepo_c --version | cut -f2 -d' ' | cut -f2 -d'.')"
+    if [ "${crepo_maj}" -gt 0 ] || [ "${crepo_min}" -ge 21 ]; then
+        fext=--filelists-ext
+    fi
+
     # For ${RPM_REPO_SIGNED_RSA}", let us also pass --filelist-ext
-    # to createrepo_c.
+    # to createrepo_c, if it is supported.
     pushd "${RPM_REPO_SIGNED_RSA}" >/dev/null
-        createrepo_c --general-compress-type=gz --filelists-ext .
+        createrepo_c --general-compress-type=gz ${fext} .
     popd >/dev/null
 
     # Sign the repo metadata for the signed repos with both an RSA
@@ -307,11 +317,15 @@ prepare_rpms() {
     cp "${RPM_REPO_SIGNED_RSA}"/* -a "${RPM_REPO_SIGNED_NO_KEY}"/
     rm -f "${RPM_REPO_SIGNED_NO_KEY}"/repodata/repomd.xml.key
 
-    # And a repo without the filelists-ext file, although it indicates
-    # it has one.
-    mkdir -p "${RPM_REPO_FILELIST_EXT_MISMATCH}"
-    cp "${RPM_REPO_SIGNED_RSA}"/* -a "${RPM_REPO_FILELIST_EXT_MISMATCH}"/
-    rm -f "${RPM_REPO_FILELIST_EXT_MISMATCH}"/repodata/*-filelists-ext.xml*
+    # If createrepo_c does not support --filelists-ext, let us not
+    # test for mismatch.
+    if [ -n "${fext}" ]; then
+        # And a repo without the filelists-ext file, although it indicates
+        # it has one.
+        mkdir -p "${RPM_REPO_FILELIST_EXT_MISMATCH}"
+        cp "${RPM_REPO_SIGNED_RSA}"/* -a "${RPM_REPO_FILELIST_EXT_MISMATCH}"/
+        rm -f "${RPM_REPO_FILELIST_EXT_MISMATCH}"/repodata/*-filelists-ext.xml*
+    fi
 
     # Add a repo using non-supported compression for the files.
     # We currently support only gzip.

--- a/test/test_rpm_repo.py
+++ b/test/test_rpm_repo.py
@@ -194,13 +194,19 @@ class RpmRepo_Test(unittest.TestCase):
                 "hashes": {},
                 "ima-sig": {},
             },
-            {
-                "repo": os.path.join(self.dirpath, "repo", "filelist-ext-mismatch"),
+        ]
+
+        # Let us test also for filelists-ext mismatch, in case createrepo_c
+        # supports it -- if it does, the respective test directory will exist.
+        fext_dir = os.path.join(self.dirpath, "repo", "filelist-ext-mismatch")
+        if os.path.isdir(fext_dir):
+            fext_test_case = {
+                "repo": fext_dir,
                 "valid": False,
                 "hashes": {},
                 "ima-sig": {},
-            },
-        ]
+            }
+            test_cases.append(fext_test_case)
 
         for c in test_cases:
             with http_server("localhost", 0, c["repo"]) as httpd:


### PR DESCRIPTION
- fix rpm tests to account for older createrepo_c versions
- remove typed-ast from test-requirements.txt