### PR TITLE
templates: Add the new agent.conf option 'api_versions'

### DIFF
--- a/templates/2.4/agent.j2
+++ b/templates/2.4/agent.j2
@@ -6,6 +6,16 @@
 # The configuration file version number
 version = "{{ agent.version }}"
 
+# The enabled API versions
+# This sets which of the supported API versions to enable.
+# Only supported versions can be set, which are defined by
+# api::SUPPORTED_API_VERSIONS
+# A list of versions to enable can be provided (e.g. "2.1, 2.2")
+# The following keywords are also supported:
+# - "default": Enables all supported API versions
+# - "latest": Enables only the latest supported API version
+api_versions = "{{ agent.api_versions }}"
+
 # The agent's UUID.
 # If you set this to "generate", Keylime will create a random UUID.
 # If you set this to "hash_ek", Keylime will set the UUID to the result

--- a/templates/2.4/mapping.json
+++ b/templates/2.4/mapping.json
@@ -2,6 +2,11 @@
     "version": "2.4",
     "type": "update",
     "components": {
+        "agent": {
+            "add": {
+                "api_versions": "default"
+            }
+        },
         "registrar": {
             "add" : {
                 "malformed_cert_action": "warn"


### PR DESCRIPTION
The introduced configuraton option allows the user to select a subset of the supported API versions to enable.

This is part of the implementation of the enhancement proposal 114: https://github.com/keylime/enhancements/pull/115