### PR TITLE
Enable autocompletion using argcomplete

### DIFF
--- a/keylime/cmd/keylime_policy.py
+++ b/keylime/cmd/keylime_policy.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# PYTHON_ARGCOMPLETE_OK
+# The comment above enables global autocomplete using argcomplete
 
 """
 Utility to assist with runtime policies.


### PR DESCRIPTION
Enable autocompletion using argcomplete by adding the comment with the string `PYTHON_ARGCOMPLETE_OK` on the first 1024 bytes of the script.