### PR TITLE
scripts/create_runtime_policy.sh: fix path for the exclude list

### DIFF
--- a/scripts/create_runtime_policy.sh
+++ b/scripts/create_runtime_policy.sh
@@ -269,7 +269,7 @@ sed -i "s/^\\\//g" $ALLOWLIST_DIR/${OUTPUT}
 mkdir -p $OUTPUT_DIR
 announce "Converting created allowlist ($ALLOWLIST_DIR/${OUTPUT}) to Keylime runtime policy ($OUTPUT_DIR/${OUTPUT}) ..."
 CONVERT_CMD_OPTS="--allowlist $ALLOWLIST_DIR/${OUTPUT} --output_file $OUTPUT_DIR/${OUTPUT}"
-[ -f $EXCLUDE_LIST ] && CONVERT_CMD_OPTS="$CONVERT_CMD_OPTS --excludelist $EXCLUDE_LIST"
+[ -f $EXCLUDE_LIST ] && CONVERT_CMD_OPTS="$CONVERT_CMD_OPTS --excludelist "$(readlink -f -- "${EXCLUDE_LIST}")""
 
 pushd $KCRP_BASE_DIR  > /dev/null 2>&1
 export PYTHONPATH=$KCRP_BASE_DIR:$PYTHONPATH


### PR DESCRIPTION
Let's use the full path of the exclude list when passing it to convert_runtime_policy.py, so that the script will be able to find and process it as expected, otherwise it will fail with the following trace:

./create_runtime_policy.sh -a sha256sum -e excludelist.txt -o runtime_policy.json

[...]

Traceback (most recent call last):
  File "/root/keylime/./keylime/cmd/convert_runtime_policy.py", line 229, in <module>
    main()
    ~~~~^^
  File "/root/keylime/./keylime/cmd/convert_runtime_policy.py", line 214, in main
    policy_out = update_runtime_policy(
        policy, excludelist_path=args.excludelist, verification_keys=args.verification_keys
    )
  File "/root/keylime/./keylime/cmd/convert_runtime_policy.py", line 144, in update_runtime_policy
    with open(excludelist_path, "r", encoding="utf8") as f:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'excludelist.txt'

--

Note that this script is in the process of becoming deprecated and the users are encouraged to move to the new keylime-policy tool.