### PR TITLE
Remove excessive logging on exception

### DIFF
--- a/demo/agent_monitor/tenant_agent_monitor.py
+++ b/demo/agent_monitor/tenant_agent_monitor.py
@@ -153,8 +153,7 @@ class AgentsHandler(BaseHandler):
                 logger.warning("POST returning 400 response. uri not supported")
         except Exception as err:
             keylime.web_util.echo_json_response(self, 400, "Exception error: %s" % err)
-            logger.warning("POST returning 400 response. Exception error: %s" % err)
-            logger.exception(err)
+            logger.exception("POST returning 400 response.")
 
     def put(self):
         """This method handles the PUT requests to add agents to the Agent Monitor.

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -785,8 +785,7 @@ class AgentsHandler(BaseHandler):
                 logger.warning("POST returning 400 response. uri not supported")
         except Exception as e:
             web_util.echo_json_response(self, 400, f"Exception error: {str(e)}")
-            logger.warning("POST returning 400 response. Exception error: %s", e)
-            logger.exception(e)
+            logger.exception("POST returning 400 response.")
 
     def put(self) -> None:
         """This method handles the PUT requests to add agents to the Cloud Verifier.
@@ -845,8 +844,7 @@ class AgentsHandler(BaseHandler):
 
         except Exception as e:
             web_util.echo_json_response(self, 400, f"Exception error: {str(e)}")
-            logger.warning("PUT returning 400 response. Exception error: %s", e)
-            logger.exception(e)
+            logger.exception("PUT returning 400 response.")
 
     def data_received(self, chunk: Any) -> None:
         raise NotImplementedError()
@@ -1944,8 +1942,7 @@ async def process_agent(
         raise Exception("nothing should ever fall out of this!")
 
     except Exception as e:
-        logger.error("Polling thread error for agent ID %s: %s", agent["agent_id"], e)
-        logger.exception(e)
+        logger.exception("Polling thread error for agent ID %s", agent["agent_id"])
         failure.add_event(
             "exception", {"context": "Agent caused the verifier to throw an exception", "data": str(e)}, False
         )

--- a/keylime/db/keylime_db.py
+++ b/keylime/db/keylime_db.py
@@ -15,7 +15,7 @@ logger = keylime_logging.init_logging("keylime_db")
 
 # make sure referential integrity is working for SQLite
 @event.listens_for(Engine, "connect")  # type: ignore
-def _set_sqlite_pragma(dbapi_connection: SQLite3Connection, _) -> None:
+def _set_sqlite_pragma(dbapi_connection: SQLite3Connection, _: Any) -> None:
     if isinstance(dbapi_connection, SQLite3Connection):
         cursor = dbapi_connection.cursor()
         cursor.execute("PRAGMA foreign_keys=ON")

--- a/keylime/models/base/db.py
+++ b/keylime/models/base/db.py
@@ -17,7 +17,7 @@ logger = keylime_logging.init_logging("keylime_db")
 
 # make sure referential integrity is working for SQLite
 @event.listens_for(Engine, "connect")  # type: ignore
-def _set_sqlite_pragma(dbapi_connection: SQLite3Connection, _) -> None:
+def _set_sqlite_pragma(dbapi_connection: SQLite3Connection, _: Any) -> None:
     if isinstance(dbapi_connection, SQLite3Connection):
         cursor = dbapi_connection.cursor()
         cursor.execute("PRAGMA foreign_keys=ON")

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -43,9 +43,8 @@ class Tpm:
             credentialblob = tpm_util.makecredential(ek_tpm, challenge, bytes.fromhex(aik_name))
             keyblob = base64.b64encode(credentialblob)
 
-        except Exception as e:
-            logger.error("Error encrypting AIK with EK: %s", str(e))
-            logger.exception(e)
+        except Exception:
+            logger.exception("Error encrypting AIK with EK")
             raise
 
         return (keyblob, key)
@@ -145,9 +144,8 @@ class Tpm:
 
         try:
             return tpm2_objects.get_tpms_attest_clock_info(quoteblob)
-        except Exception as e:
-            logger.error("Error extracting clock info from quote: %s", str(e))
-            logger.exception(e)
+        except Exception:
+            logger.exception("Error extracting clock info from quote")
             return {}
 
     @staticmethod
@@ -175,8 +173,7 @@ class Tpm:
         try:
             pcrs_dict = tpm_util.checkquote(aikFromRegistrar, nonce, sigblob, quoteblob, pcrblob, hash_alg)
         except Exception as e:
-            logger.error("Error verifying quote: %s", str(e))
-            logger.exception(e)
+            logger.exception("Error verifying quote")
             return {}, str(e)
 
         return pcrs_dict, ""


### PR DESCRIPTION
log.exception already contains exception info, there is no need to log twice with separate logging levels.