### PR TITLE
Extend meta_data field in verifierdb

### DIFF
--- a/keylime/db/verifier_db.py
+++ b/keylime/db/verifier_db.py
@@ -24,7 +24,7 @@ class VerfierMain(Base):
     operational_state = Column(Integer)
     public_key = Column(String(500))
     tpm_policy = Column(JSONPickleType(pickler=JSONPickler))
-    meta_data = Column(String(200))
+    meta_data = Column(Text().with_variant(Text(429400000), "mysql"))
     ima_policy = relationship("VerifierAllowlist", back_populates="agent", uselist=False)
     ima_policy_id = Column(Integer, ForeignKey("allowlists.id"))
     ima_sign_verification_keys = Column(Text().with_variant(Text(429400000), "mysql"))

--- a/keylime/migrations/versions/57b24ee21dfa_extend_meta_data_field.py
+++ b/keylime/migrations/versions/57b24ee21dfa_extend_meta_data_field.py
@@ -1,0 +1,51 @@
+"""Extend meta_data field
+
+Revision ID: 57b24ee21dfa
+Revises: 330024be7bef
+Create Date: 2025-03-19 11:30:04.556745
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "57b24ee21dfa"
+down_revision = "330024be7bef"
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()[f"upgrade_{engine_name}"]()
+
+
+def downgrade(engine_name):
+    globals()[f"downgrade_{engine_name}"]()
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+    with op.batch_alter_table("verifiermain") as batch_op:
+        batch_op.alter_column(
+            "meta_data",
+            existing_type=sa.String(length=200),
+            type_=sa.Text().with_variant(sa.Text(length=429400000), "mysql"),
+            existing_nullable=True,
+        )
+
+
+def downgrade_cloud_verifier():
+    with op.batch_alter_table("verifiermain") as batch_op:
+        batch_op.alter_column(
+            "meta_data",
+            existing_type=sa.Text().with_variant(sa.Text(length=429400000), "mysql"),
+            type_=sa.String(length=200),
+            existing_nullable=True,
+        )


### PR DESCRIPTION
# Extend the meta_data field in verifierdb to allow for more data

## Type of Change
- [x] Bug fix (non-breaking change)

## Change Description

### Concise Summary
Added a database migration to allow the meta_data field in the verifierdb to contain more data. This field is used to store a json that Keylime uses to store cert details in some cases but can also be added to by the user to contain more metadata related to the agent (eg. by using the meta-data field in the API), so it should be extended to contain that data.

### Technical Details
 
Generated a new db migration (`57b24ee21dfa_extend_meta_data_field`) that has an upgrade and downgrade strategy to change from the existing length 200 String type to the new Text type and vice-versa. This change is also reflected in the `VerifierMain` model in `verifier_db.py`.

## Documentation Updates Required
- [x] No docs needed (requires maintainer approval)
The documentation does not mention a length limit so the docs are actually more accurate after this change.

## Verification Process
1. Describe test environment
2. Step-by-step validation procedure
3. Expected vs actual results

## Checklist
- [x] Code follows project style guidelines
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [x] All tests pass (local & CI)