### PR TITLE
Fix create_runtime_policy in python < 3.12

### DIFF
--- a/keylime/policy/create_runtime_policy.py
+++ b/keylime/policy/create_runtime_policy.py
@@ -972,7 +972,7 @@ def create_runtime_policy(args: argparse.Namespace) -> Optional[RuntimePolicyTyp
                 )
                 abort = True
         else:
-            if a not in algorithms.Hash:
+            if a not in set(algorithms.Hash):
                 if a == SHA256_OR_SM3:
                     algo = a
                 else:


### PR DESCRIPTION
# [Fix create_runtime_policy in python < 3.12](https://github.com/keylime/keylime/pull/1765/commits/6ac1ca87ba12c47c22058fcf0439cb1fc618df86)

## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
*(If you use an issue tracker, please put references to them)*  
**Resolves:** #1764 

## Change Description

Python <3.12 does not support the "in" operator on Enums So we need to explicitly enumerate the potential values of an enum before using "in".


## Checklist
- [ ] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [ ] Documentation updated (per above section)
- [ ] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [ ] All tests pass (local & CI)

## Additional Context
*(Optional: follow-up tasks, special considerations)*