### PR TITLE
templates: duplicate str_to_version() in the adjust script

### DIFF
--- a/keylime/cmd/create_policy.py
+++ b/keylime/cmd/create_policy.py
@@ -345,10 +345,10 @@ def _get_rpm_urls(repo: str, repomd_xml: str) -> List[str]:
         print("Error. Primary XML file cannot be downloaded", file=sys.stderr)
         return []
 
-    root = ET.parse(gzip.open(primary_xml_tmp))
+    root_primary = ET.parse(gzip.open(primary_xml_tmp))
     os.remove(primary_xml_tmp)
 
-    locations = root.findall(
+    locations = root_primary.findall(
         "./{http://linux.duke.edu/metadata/common}package[@type='rpm']"
         "/{http://linux.duke.edu/metadata/common}location"
     )

--- a/keylime/policy/rpm_repo.py
+++ b/keylime/policy/rpm_repo.py
@@ -13,7 +13,7 @@ import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 from contextlib import contextmanager
-from typing import Dict, Generator, List, Optional, Tuple
+from typing import Any, Dict, Generator, List, Optional, Tuple
 
 import rpm  # pylint: disable=import-error
 
@@ -225,9 +225,8 @@ def get_rpm_urls_from_repomd(repo: str, repomd_xml: str) -> List[str]:
             logger.error("Error. Primary XML file cannot be downloaded")
             return []
 
-        root = _parse_xml_file(primary_xml)
-
-        locations = root.findall(
+        root_primary = _parse_xml_file(primary_xml)
+        locations = root_primary.findall(
             "./{http://linux.duke.edu/metadata/common}package[@type='rpm']"
             "/{http://linux.duke.edu/metadata/common}location"
         )
@@ -235,7 +234,7 @@ def get_rpm_urls_from_repomd(repo: str, repomd_xml: str) -> List[str]:
         return [urllib.parse.urljoin(repo, ll.attrib["href"]) for ll in locations]
 
 
-def _parse_xml_file(filepath: str) -> ET.ElementTree:
+def _parse_xml_file(filepath: str) -> Any:
     # We support only gzip compression, currently.
     ctype = Compression.detect_from_file(filepath)
     if ctype:

--- a/keylime/revocation_notifier.py
+++ b/keylime/revocation_notifier.py
@@ -61,7 +61,7 @@ def start_broker() -> None:
             f"{config.getint('verifier', 'zmq_port', section='revocations')}"
         )
         try:
-            zmq.device(zmq.FORWARDER, frontend, backend)
+            zmq.proxy(frontend, backend)
         except (KeyboardInterrupt, SystemExit):
             context.destroy()
 

--- a/templates/2.0/adjust.py
+++ b/templates/2.0/adjust.py
@@ -4,9 +4,27 @@ import logging
 import re
 from configparser import RawConfigParser
 from logging import Logger
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Tuple, Union
 
-from keylime.common.version import str_to_version
+
+def str_to_version(v_str: str) -> Union[Tuple[int, int], None]:
+    """
+    Validates the string format and converts the provided string to a tuple of
+    ints which can be sorted and compared.
+
+    :returns: Tuple with version number parts converted to int. In case of
+    invalid version string, returns None
+    """
+
+    # Strip to remove eventual quotes and spaces
+    v_str = v_str.strip('" ')
+
+    m = re.match(r"^(\d+)\.(\d+)$", v_str)
+
+    if not m:
+        return None
+
+    return (int(m.group(1)), int(m.group(2)))
 
 
 def adjust(

--- a/test/data/create-runtime-policy/setup-rpm-tests
+++ b/test/data/create-runtime-policy/setup-rpm-tests
@@ -217,20 +217,32 @@ create_rpm() {
     # https://github.com/rpm-software-management/rpm/commit/96467dce18f264b278e17ffe1859c88d9b5aa4b6
     _pkgname="DUMMY-${_name}-${_version}-${_rel}.noarch.rpm"
 
-    _expected_pkg="${RPMSDIR}/noarch/${_pkgname}"
-    [ -e "${_expected_pkg}" ] && return 0
+    # For some reason, it may not store the built package within the
+    # noarch directory, but directly in RPMS, so let's check both
+    # locations.
+    _expected_pkg="${RPMSDIR}/noarch/${_pkgname} ${RPMSDIR}/${_pkgname}"
+    for _expected in ${_expected_pkg}; do
+        if [ -e "${_expected}" ]; then
+            echo "(create_rpm) CREATED RPM: ${_expected}" >&2
+            return 0
+        fi
+    done
 
     # OK, the package was not built where it should. Let us see if
     # it was built in ~/rpmbuild instead, and if that is the case,
     # copy it to the expected location.
-    _bad_location_pkg="${HOME}/rpmbuild/RPMS/noarch/${_pkgname}"
-    if [ -e "${_bad_location_pkg}" ]; then
-        echo "WARNING: the package ${_pkgname} was built into ~/rpmbuild despite rpmbuild being instructed to build it at a different location. Probably a fallout from https://github.com/rpm-software-management/rpm/commit/96467dce" >&2
-        install -D -m644 "${_bad_location_pkg}" "${_expected_pkg}"
-        return 0
-    fi
+    _bad_location_pkg="${HOME}/rpmbuild/RPMS/noarch/${_pkgname} ${HOME}/rpmbuild/RPMS/${_pkgname}"
+    for _bad_l in ${_bad_location_pkg}; do
+        if [ -e "${_bad_l}" ]; then
+            echo "WARNING: the package ${_pkgname} was built into ~/rpmbuild despite rpmbuild being instructed to build it at a different location. Probably a fallout from https://github.com/rpm-software-management/rpm/commit/96467dce" >&2
+            install -D -m644 "${_bad_l}" "${RPMSDIR}/noarch/${_pkgname}"
+            echo "(create_rpm) CREATED RPM: ${RPMSDIR}/noarch/${_pkgname}" >&2
+            return 0
+        fi
+    done
 
     # Should not be here.
+    echo "create_rpm() ended with error; probably an issue with the location where the RPMs were built" >&2
     return 1
 }
 

--- a/test/test_create_mb_policy.py
+++ b/test/test_create_mb_policy.py
@@ -5,6 +5,7 @@ Copyright 2024 Red Hat, Inc.
 
 import argparse
 import os
+import platform
 import unittest
 
 from keylime.policy import create_mb_policy
@@ -12,6 +13,7 @@ from keylime.policy import create_mb_policy
 DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "data", "create-mb-policy"))
 
 
+@unittest.skipIf(platform.machine() in ["ppc64le", "s390x"], "ppc64le and s390x are not supported")
 class CreateMeasuredBootPolicy_Test(unittest.TestCase):
     def test_event_to_sha256(self):
         test_cases = [

--- a/test/test_mba_parsing.py
+++ b/test/test_mba_parsing.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import tempfile
 import unittest
 from configparser import RawConfigParser
@@ -11,6 +12,7 @@ from keylime.mba import mba
 TEMPLATES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "templates"))
 
 
+@unittest.skipIf(platform.machine() in ["ppc64le", "s390x"], "ppc64le and s390x are not supported")
 class TestMBAParsing(unittest.TestCase):
     def test_parse_bootlog(self):
         """Test parsing binary measured boot event log"""


### PR DESCRIPTION
# templates: duplicate str_to_version() in the adjust script
- Additional test fixes

## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
*(If you use an issue tracker, please put references to them)*  
N/A

## Change Description
- templates: duplicate str_to_version() in the adjust script
- tests: skip measured-boot related tests for s390x and ppc64le
- tests: fix rpm repo tests from create-runtime-policy
- Fix (unrelated) mypy issues reported

Explain the problem being solved and why this change is necessary. Focus on:
- The change in the templates is necessary so that we can run the upgrade script without needing the keylime modules installed
- Additional test fixes, disabling the measured boot-related tests for s390x and ppc64le architectures and improving error handling for the create-runtime-policy test

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [ ] No docs needed (requires maintainer approval)

## Verification Process
1. Describe test environment
2. Step-by-step validation procedure
3. Expected vs actual results

## Checklist
- [x] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [ ] Documentation updated (per above section)
- [ ] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context
* N/A