### PR TITLE
verifier: Gracefully shutdown webhook workers during signal handling

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -2087,7 +2087,7 @@ def main() -> None:
             revocation_notifier.stop_broker()
         for p in processes:
             p.join()
-        sys.exit(0)
+        # Do not call sys.exit(0) here as it interferes with multiprocessing cleanup
 
     signal.signal(signal.SIGINT, sig_handler)
     signal.signal(signal.SIGTERM, sig_handler)
@@ -2108,3 +2108,11 @@ def main() -> None:
         process = multiprocessing.Process(target=server_process, args=(task_id, active_agents))
         process.start()
         processes.append(process)
+
+    # Wait for all worker processes to complete
+    try:
+        for p in processes:
+            p.join()
+    except KeyboardInterrupt:
+        # Signal handler will take care of cleanup
+        pass


### PR DESCRIPTION
# verifier: Gracefully shutdown webhook workers during signal handling

## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [x] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues

## Change Description

### Concise Summary
Fix webhook worker connection tracebacks during verifier shutdown by implementing graceful worker management and prioritizing critical revocation notification delivery.

### Technical Details

**Problem:**
Stopping the verifier generated connection error tracebacks from webhook workers attempting to send revocation notifications during shutdown:
```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    ...
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

**Root Cause:**
Webhook worker threads continued attempting HTTP requests while the service was shutting down, causing connections to be aborted mid-request without graceful error handling.

**Solution:**
- Implemented `WebhookNotificationManager` class to encapsulate worker thread state management
- Added graceful shutdown coordination for webhook workers with 30-second timeout
- Enabled best-effort delivery of critical revocation notifications during shutdown (reduced retries but still attempted)
- Integrated webhook worker shutdown into verifier's main signal handlers

**Changes Made:**
- Refactored global webhook state into `WebhookNotificationManager` class (`keylime/revocation_notifier.py`)
- Added `shutdown_workers()` method with graceful worker termination
- Modified worker error handling to suppress connection errors only on final retry during shutdown
- Integrated webhook shutdown into `sig_handler()` and `server_sig_handler()` (`keylime/cloud_verifier_tornado.py`)

This ensures critical revocation notifications are attempted during shutdown while eliminating connection error tracebacks.

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [x] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. **Test Environment**: Keylime verifier with webhook notifications enabled
2. **Validation Procedure**:
   - Configure webhook URL in verifier config: `webhook_url = http://example.com/webhook`
   - Start keylime verifier: `keylime_verifier`
   - Trigger revocation notifications (compromise an agent)
   - Stop verifier during notification activity: `systemctl stop keylime_verifier`
   - Check logs for absence of connection error tracebacks
3. **Expected Results**: Clean shutdown logs showing graceful worker termination instead of connection tracebacks

## Checklist
- [x] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [ ] All tests pass (local & CI)

## Additional Context
This fix is critical for security-focused deployments where revocation notifications inform other systems about compromised agents. The solution prioritizes delivery of these critical security events while eliminating noisy error tracebacks that could mask real issues in monitoring systems.