### PR TITLE
CI: Enable test add-agent-with-malformed-ek-cert

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -69,6 +69,7 @@ adjust:
      - /compatibility/api_version_compatibility
      - /compatibility/basic-attestation-on-localhost-api-version-bump
      - /compatibility/basic-attestation-on-localhost-with-allowlist-excludelist
+     - /functional/add-agent-with-malformed-ek-cert
      - /functional/agent_UUID_assignment_options
      - /functional/basic-attestation-on-localhost
      - /functional/basic-attestation-with-custom-certificates


### PR DESCRIPTION
Enables test `/functional/add-agent-with-malformed-ek-cert` in Packit CI.