### PR TITLE
Add support for specific cryptographic algorithm variants

### DIFF
--- a/keylime/common/algorithms.py
+++ b/keylime/common/algorithms.py
@@ -9,7 +9,18 @@ def is_accepted(algorithm: str, accepted: List[Any]) -> bool:
     @param algorithm: algorithm to be checked
     @param accepted: a list of acceptable algorithms
     """
-    return algorithm in accepted
+    # Check direct match first.
+    if algorithm in accepted:
+        return True
+
+    # Check if any accepted algorithm normalizes to the same value as our algorithm
+    # This handles backwards compatibility cases like "ecc" accepting "ecc256".
+    normalized_algorithm = Encrypt.normalize(algorithm)
+    for accepted_alg in accepted:
+        if Encrypt.normalize(str(accepted_alg)) == normalized_algorithm:
+            return True
+
+    return False
 
 
 class Hash(str, enum.Enum):
@@ -74,10 +85,25 @@ class Hash(str, enum.Enum):
 class Encrypt(str, enum.Enum):
     RSA = "rsa"
     ECC = "ecc"
+    ECC192 = "ecc192"
+    ECC224 = "ecc224"
+    ECC256 = "ecc256"
+    ECC384 = "ecc384"
+    ECC521 = "ecc521"
 
     @staticmethod
     def is_recognized(algorithm: str) -> bool:
+        # Handle aliases to match agent behavior
+        if algorithm == "ecc":
+            algorithm = "ecc256"  # Default ECC alias maps to P-256, same as the agent.
         return algorithm in list(Encrypt)
+
+    @staticmethod
+    def normalize(algorithm: str) -> str:
+        """Normalize algorithm string to handle aliases, matching the agent behavior"""
+        if algorithm == "ecc":
+            return "ecc256"  # Default ECC alias maps to P-256.
+        return algorithm
 
 
 class Sign(str, enum.Enum):

--- a/keylime/common/algorithms.py
+++ b/keylime/common/algorithms.py
@@ -84,6 +84,10 @@ class Hash(str, enum.Enum):
 
 class Encrypt(str, enum.Enum):
     RSA = "rsa"
+    RSA1024 = "rsa1024"
+    RSA2048 = "rsa2048"
+    RSA3072 = "rsa3072"
+    RSA4096 = "rsa4096"
     ECC = "ecc"
     ECC192 = "ecc192"
     ECC224 = "ecc224"
@@ -96,6 +100,8 @@ class Encrypt(str, enum.Enum):
         # Handle aliases to match agent behavior
         if algorithm == "ecc":
             algorithm = "ecc256"  # Default ECC alias maps to P-256, same as the agent.
+        if algorithm == "rsa":
+            algorithm = "rsa2048"  # Default RSA alias maps to RSA-2048, same as the agent.
         return algorithm in list(Encrypt)
 
     @staticmethod
@@ -103,6 +109,8 @@ class Encrypt(str, enum.Enum):
         """Normalize algorithm string to handle aliases, matching the agent behavior"""
         if algorithm == "ecc":
             return "ecc256"  # Default ECC alias maps to P-256.
+        if algorithm == "rsa":
+            return "rsa2048"  # Default RSA alias maps to RSA-2048.
         return algorithm
 
 

--- a/test/test_algorithms.py
+++ b/test/test_algorithms.py
@@ -181,7 +181,7 @@ class TestEncrypt(unittest.TestCase):
             },
             {
                 "input": "rsa",
-                "expected": "rsa",
+                "expected": "rsa2048",
             },
         ]
 
@@ -198,6 +198,17 @@ class TestEncrypt(unittest.TestCase):
 
         # Test that direct ecc256 works
         self.assertTrue(Encrypt.is_recognized("ecc256"))
+
+    def test_normalize_rsa_alias_behavior(self):
+        """Test that RSA alias normalization matches agent behavior"""
+        # Test that "rsa" is recognized through alias handling
+        self.assertTrue(Encrypt.is_recognized("rsa"))
+
+        # Test that normalize converts "rsa" to "rsa2048"
+        self.assertEqual(Encrypt.normalize("rsa"), "rsa2048")
+
+        # Test that direct rsa2048 works
+        self.assertTrue(Encrypt.is_recognized("rsa2048"))
 
 
 class TestSign(unittest.TestCase):


### PR DESCRIPTION
# PR Title 
Add support for specific cryptographic algorithm variants


## Type of Change
*(Select all that apply)*
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [x] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Change Description
  This PR extends the cryptographic algorithm support to allow specifying exact key sizes and curves instead of just
  generic types:

  ECC algorithms:
  - Added ecc192, ecc224, ecc256, ecc384, ecc521 for specific NIST curves
  - Maintains backward compatibility: ecc alias → ecc256 (P-256)

  RSA algorithms:
  - Added rsa1024, rsa2048, rsa3072, rsa4096 for specific key sizes
  - Maintains backward compatibility: rsa alias → rsa2048



### Concise Summary
Add support for specific algs/curves, e.g. rsa3072/ecc256, instead of simply rsa/ecc.

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

