### PR TITLE
Remove deprecated disabled_signing_algorithms configuration option

### DIFF
--- a/templates/2.5/agent.j2
+++ b/templates/2.5/agent.j2
@@ -47,9 +47,6 @@ verifier_url = "{{ agent_verifier_url }}"
 # Server identifier for certification keys
 certification_keys_server_identifier = "{{ agent_certification_keys_server_identifier }}"
 
-# Comma-separated list of signing algorithms to disable
-disabled_signing_algorithms = "{{ agent_disabled_signing_algorithms }}"
-
 # File to store the IMA measurement list count
 ima_ml_count_file = "{{ agent_ima_ml_count_file }}"
 

--- a/templates/2.5/mapping.json
+++ b/templates/2.5/mapping.json
@@ -10,7 +10,6 @@
                 "exponential_backoff_initial_delay": "10000",
                 "exponential_backoff_max_delay": "360000",
                 "certification_keys_server_identifier": "ak",
-                "disabled_signing_algorithms": "",
                 "ima_ml_count_file": "/tmp/ima_ml_count",
                 "uefi_logs_evidence_version": "1.0"
             }


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [x] Other (please specify: Configuration grooming)

## Related Issues
N/A

## Change Description

### Concise Summary
This removes the disabled_signing_algorithms configuration option from both the agent template and default mappings, aligning the configuration with rust-keylime which no longer uses this option. Algorithm control is now handled through the specific algorithm support added in recent commits (RSA and ECC curve algorithms).

### Technical Details
- Configuration alignment for Rust based agent 

## Documentation Updates Required
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. CI verification

## Checklist
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [x] All tests pass (local & CI)

## Additional Context
N/A