### PR TITLE
docs: Fix man page RST formatting for rst2man compatibility

### DIFF
--- a/docs/man/keylime-policy.1.rst
+++ b/docs/man/keylime-policy.1.rst
@@ -1,19 +1,14 @@
-==================
-keylime-policy.1
-==================
+==============
+keylime-policy
+==============
 
---------------------------------
-Keylime policy creation tool
---------------------------------
+------------------------------------------
+Keylime policy creation and signing tool
+------------------------------------------
 
 :Manual section: 1
 :Author: Keylime Developers
 :Date: September 2025
-
-NAME
-====
-
-keylime-policy - Keylime policy creation and signing tool
 
 SYNOPSIS
 ========
@@ -37,48 +32,100 @@ COMMANDS
    Create runtime policies from filesystem, allowlists, RPM repositories, or IMA measurement lists.
 
    Options:
-   - **-o, --output** OUTPUT: Output file (defaults to stdout)
-   - **-p, --base-policy** BASE_POLICY: Merge new data into existing JSON runtime policy
-   - **-k, --keyrings**: Create keyrings policy entries
-   - **-b, --ima-buf**: Process ima-buf entries other than keyrings
-   - **-a, --allowlist** ALLOWLIST: Read checksums from plain-text allowlist
-   - **-e, --excludelist** EXCLUDE_LIST_FILE: Add IMA exclude list to policy
-   - **-m, --ima-measurement-list** [IMA_MEASUREMENT_LIST]: Use IMA measurement list for hash/keyring extraction
-   - **--ignored-keyrings** IGNORED_KEYRINGS: Ignore specified keyring (repeatable)
-   - **--add-ima-signature-verification-key** IMA_SIGNATURE_KEYS: Add x509/key to tenant_keyring (repeatable)
-   - **--show-legacy-allowlist**: Display digests in legacy allowlist format
-   - **-v, --verbose**: Set log level to DEBUG
+
+   **-o, --output** *OUTPUT*
+      Output file (defaults to stdout)
+
+   **-p, --base-policy** *BASE_POLICY*
+      Merge new data into existing JSON runtime policy
+
+   **-k, --keyrings**
+      Create keyrings policy entries
+
+   **-b, --ima-buf**
+      Process ima-buf entries other than keyrings
+
+   **-a, --allowlist** *ALLOWLIST*
+      Read checksums from plain-text allowlist
+
+   **-e, --excludelist** *EXCLUDE_LIST_FILE*
+      Add IMA exclude list to policy
+
+   **-m, --ima-measurement-list** *[IMA_MEASUREMENT_LIST]*
+      Use IMA measurement list for hash/keyring extraction
+
+   **--ignored-keyrings** *IGNORED_KEYRINGS*
+      Ignore specified keyring (repeatable)
+
+   **--add-ima-signature-verification-key** *IMA_SIGNATURE_KEYS*
+      Add x509/key to tenant_keyring (repeatable)
+
+   **--show-legacy-allowlist**
+      Display digests in legacy allowlist format
+
+   **-v, --verbose**
+      Set log level to DEBUG
 
    Filesystem scanning:
-   - **--algo** {sha1,sha256,sha384,sha512,sm3_256}: Checksum algorithm
-   - **--ramdisk-dir** RAMDISK_DIR: Path to initrds (e.g., /boot)
-   - **--rootfs** ROOTFS: Path to root filesystem (e.g., /)
-   - **-s, --skip-path** SKIP_PATH: Comma-separated directories to skip
+
+   **--algo** *{sha1,sha256,sha384,sha512,sm3_256}*
+      Checksum algorithm
+
+   **--ramdisk-dir** *RAMDISK_DIR*
+      Path to initrds (e.g., /boot)
+
+   **--rootfs** *ROOTFS*
+      Path to root filesystem (e.g., /)
+
+   **-s, --skip-path** *SKIP_PATH*
+      Comma-separated directories to skip
 
    Repository scanning:
-   - **--local-rpm-repo** LOCAL_RPM_REPO: Local RPM repository directory
-   - **--remote-rpm-repo** REMOTE_RPM_REPO: Remote RPM repository URL
+
+   **--local-rpm-repo** *LOCAL_RPM_REPO*
+      Local RPM repository directory
+
+   **--remote-rpm-repo** *REMOTE_RPM_REPO*
+      Remote RPM repository URL
 
 **keylime-policy create measured-boot** [*OPTIONS*]
 
    Create measured boot reference state policies from UEFI event logs.
 
    Options:
-   - **-e, --eventlog-file** EVENTLOG_FILE: Binary UEFI eventlog (required)
-   - **--without-secureboot, -i**: Create policy without SecureBoot (MeasuredBoot only)
-   - **-o, --output** OUTPUT: Output path for generated measured boot policy
+
+   **-e, --eventlog-file** *EVENTLOG_FILE*
+      Binary UEFI eventlog (required)
+
+   **--without-secureboot, -i**
+      Create policy without SecureBoot (MeasuredBoot only)
+
+   **-o, --output** *OUTPUT*
+      Output path for generated measured boot policy
 
 **keylime-policy sign runtime** [*OPTIONS*]
 
    Sign runtime policies using DSSE.
 
    Options:
-   - **-o, --output** OUTPUT_FILE: Output file for DSSE-signed policy
-   - **-r, --runtime-policy** POLICY: Runtime policy file to sign (required)
-   - **-k, --keyfile** KEYFILE: EC private key for signing
-   - **-p, --keypath** KEYPATH: Output filename for created private key
-   - **-b, --backend** {ecdsa,x509}: DSSE backend (ecdsa or x509)
-   - **-c, --cert-outfile** CERT_OUTFILE: Output file for x509 certificate (x509 backend)
+
+   **-o, --output** *OUTPUT_FILE*
+      Output file for DSSE-signed policy
+
+   **-r, --runtime-policy** *POLICY*
+      Runtime policy file to sign (required)
+
+   **-k, --keyfile** *KEYFILE*
+      EC private key for signing
+
+   **-p, --keypath** *KEYPATH*
+      Output filename for created private key
+
+   **-b, --backend** *{ecdsa,x509}*
+      DSSE backend (ecdsa or x509)
+
+   **-c, --cert-outfile** *CERT_OUTFILE*
+      Output file for x509 certificate (x509 backend)
 
 EXAMPLES
 ========
@@ -110,7 +157,8 @@ EXAMPLES
 ENVIRONMENT
 ===========
 
-- **KEYLIME_LOGGING_CONFIG**: Path to logging.conf
+**KEYLIME_LOGGING_CONFIG**
+   Path to logging.conf
 
 NOTES
 =====
@@ -123,9 +171,9 @@ NOTES
 SEE ALSO
 ========
 
-**keylime_tenant**(1), **keylime_verifier**(8), **keylime_registrar**(8)
+**keylime_tenant**\(1), **keylime_verifier**\(8), **keylime_registrar**\(8)
 
 BUGS
 ====
 
-Report bugs at https://github.com/keylime/keylime/issues 
+Report bugs at https://github.com/keylime/keylime/issues

--- a/docs/man/keylime_agent.8.rst
+++ b/docs/man/keylime_agent.8.rst
@@ -1,19 +1,14 @@
-=================
-keylime_agent.8
-=================
+=============
+keylime_agent
+=============
 
------------------------
-Keylime agent service
------------------------
+-----------------------------------------------
+Keylime agent service for TPM-based attestation
+-----------------------------------------------
 
 :Manual section: 8
 :Author: Keylime Developers
 :Date: September 2025
-
-NAME
-====
-
-keylime_agent - Keylime agent service for TPM-based attestation
 
 SYNOPSIS
 ========
@@ -38,60 +33,142 @@ Configuration uses TOML format. All options are under the ``[agent]`` section.
 
 Drop-in overrides: files in ``/etc/keylime/agent.conf.d/`` are applied in lexicographic order.
 
-Essentials:
-- **uuid**: Agent identifier (``generate``, ``hash_ek``, ``environment``, ``dmidecode``, ``hostname``, or explicit UUID)
-- **ip**, **port**: Bind address and port (default: 9002)
-- **contact_ip**, **contact_port**: External contact address (optional)
-- **registrar_ip**, **registrar_port**: Registrar endpoint
-- **enable_agent_mtls**: Enable mTLS communication
-- **tls_dir**: TLS material location
-  - ``generate``: auto-generate under ``$KEYLIME_DIR/cv_ca``
-  - ``default``: use ``$KEYLIME_DIR/secure``
-- **server_key**, **server_key_password**, **server_cert**: TLS files (self-signed cert)
-- **trusted_client_ca**: Trusted client CA list
-- **enc_keyname**: Payload encryption key file name
-- **dec_payload_file**: Decrypted payload file name
-- **secure_size**: tmpfs partition size for secure storage
-- **tpm_ownerpassword**: TPM owner password (``generate`` for random)
-- **extract_payload_zip**: Auto-extract zip payloads (bool)
-- **enable_revocation_notifications**: Listen for revocation via ZeroMQ (bool)
-- **revocation_notification_ip**, **revocation_notification_port**: ZeroMQ endpoint
-- **revocation_cert**: Certificate to verify revocation messages
-- **revocation_actions**: Python scripts to run on revocation
-- **payload_script**: Script to run after payload extraction
-- **enable_insecure_payload**: Allow payloads without mTLS (insecure)
-- **measure_payload_pcr**: PCR to extend with payload (-1 to disable)
-- **exponential_backoff**, **retry_interval**, **max_retries**: TPM communication retry
-- **tpm_hash_alg**, **tpm_encryption_alg**, **tpm_signing_alg**: TPM algorithms
-- **ek_handle**: EK handle (``generate`` or explicit handle like ``0x81000000``)
-- **enable_iak_idevid**: Enable IAK/IDevID usage (bool)
-- **iak_idevid_template**, **iak_idevid_asymmetric_alg**, **iak_idevid_name_alg**: IAK/IDevID config
-- **idevid_password**, **idevid_handle**, **iak_password**, **iak_handle**: Persistent key handles
-- **iak_cert**, **idevid_cert**: Certificate file names
-- **run_as**: User:group to drop privileges to
-- **ima_ml_path**: IMA measurement log path (default: ``/sys/kernel/security/ima/ascii_runtime_measurements``)
-- **measuredboot_ml_path**: Measured boot log path (default: ``/sys/kernel/security/tpm0/binary_bios_measurements``)
+Essential configuration options:
+
+**uuid**
+   Agent identifier (``generate``, ``hash_ek``, ``environment``, ``dmidecode``, ``hostname``, or explicit UUID)
+
+**ip**, **port**
+   Bind address and port (default: 9002)
+
+**contact_ip**, **contact_port**
+   External contact address (optional)
+
+**registrar_ip**, **registrar_port**
+   Registrar endpoint
+
+**enable_agent_mtls**
+   Enable mTLS communication
+
+**tls_dir**
+   TLS material location (``generate`` for auto-generate under ``$KEYLIME_DIR/cv_ca``, ``default`` for ``$KEYLIME_DIR/secure``)
+
+**server_key**, **server_key_password**, **server_cert**
+   TLS files (self-signed cert)
+
+**trusted_client_ca**
+   Trusted client CA list
+
+**enc_keyname**
+   Payload encryption key file name
+
+**dec_payload_file**
+   Decrypted payload file name
+
+**secure_size**
+   tmpfs partition size for secure storage
+
+**tpm_ownerpassword**
+   TPM owner password (``generate`` for random)
+
+**extract_payload_zip**
+   Auto-extract zip payloads (bool)
+
+**enable_revocation_notifications**
+   Listen for revocation via ZeroMQ (bool)
+
+**revocation_notification_ip**, **revocation_notification_port**
+   ZeroMQ endpoint
+
+**revocation_cert**
+   Certificate to verify revocation messages
+
+**revocation_actions**
+   Python scripts to run on revocation
+
+**payload_script**
+   Script to run after payload extraction
+
+**enable_insecure_payload**
+   Allow payloads without mTLS (insecure)
+
+**measure_payload_pcr**
+   PCR to extend with payload (-1 to disable)
+
+**exponential_backoff**, **retry_interval**, **max_retries**
+   TPM communication retry
+
+**tpm_hash_alg**, **tpm_encryption_alg**, **tpm_signing_alg**
+   TPM algorithms
+
+**ek_handle**
+   EK handle (``generate`` or explicit handle like ``0x81000000``)
+
+**enable_iak_idevid**
+   Enable IAK/IDevID usage (bool)
+
+**iak_idevid_template**, **iak_idevid_asymmetric_alg**, **iak_idevid_name_alg**
+   IAK/IDevID config
+
+**idevid_password**, **idevid_handle**, **iak_password**, **iak_handle**
+   Persistent key handles
+
+**iak_cert**, **idevid_cert**
+   Certificate file names
+
+**run_as**
+   User:group to drop privileges to
+
+**ima_ml_path**
+   IMA measurement log path (default: ``/sys/kernel/security/ima/ascii_runtime_measurements``)
+
+**measuredboot_ml_path**
+   Measured boot log path (default: ``/sys/kernel/security/tpm0/binary_bios_measurements``)
 
 ENVIRONMENT
 ===========
 
-- **KEYLIME_AGENT_CONFIG**: Path to agent.conf (highest priority)
-- **KEYLIME_LOGGING_CONFIG**: Path to logging.conf
-- **KEYLIME_DIR**: Working directory (default: ``/var/lib/keylime``)
-- **KEYLIME_AGENT_UUID**: UUID when ``uuid = environment``
-- **KEYLIME_AGENT_IAK_CERT**: Override iak_cert path
-- **KEYLIME_AGENT_IDEVID_CERT**: Override idevid_cert path
-- **KEYLIME_TEST**: ``on/true/1`` enables testing mode
+**KEYLIME_AGENT_CONFIG**
+   Path to agent.conf (highest priority)
+
+**KEYLIME_LOGGING_CONFIG**
+   Path to logging.conf
+
+**KEYLIME_DIR**
+   Working directory (default: ``/var/lib/keylime``)
+
+**KEYLIME_AGENT_UUID**
+   UUID when ``uuid = environment``
+
+**KEYLIME_AGENT_IAK_CERT**
+   Override iak_cert path
+
+**KEYLIME_AGENT_IDEVID_CERT**
+   Override idevid_cert path
+
+**KEYLIME_TEST**
+   ``on/true/1`` enables testing mode
 
 FILES
 =====
 
-- ``/etc/keylime/agent.conf`` (TOML format)
-- ``/etc/keylime/agent.conf.d/`` (drop-in snippets; read in lexicographic order)
-- ``/etc/keylime/logging.conf``
-- ``$KEYLIME_DIR/secure/`` (secure tmpfs mount for keys/payloads)
-- ``$KEYLIME_DIR/cv_ca/`` (when ``tls_dir = generate``)
-- ``$KEYLIME_DIR/tpmdata.yml`` (TPM state persistence)
+``/etc/keylime/agent.conf``
+   TOML format configuration file
+
+``/etc/keylime/agent.conf.d/``
+   Drop-in snippets; read in lexicographic order
+
+``/etc/keylime/logging.conf``
+   Logging configuration
+
+``$KEYLIME_DIR/secure/``
+   Secure tmpfs mount for keys/payloads
+
+``$KEYLIME_DIR/cv_ca/``
+   TLS certificates when ``tls_dir = generate``
+
+``$KEYLIME_DIR/tpmdata.yml``
+   TPM state persistence
 
 RUNTIME
 =======
@@ -133,9 +210,9 @@ NOTES
 SEE ALSO
 ========
 
-**keylime_verifier**(8), **keylime_registrar**(8), **keylime_tenant**(1)
+**keylime_verifier**\(8), **keylime_registrar**\(8), **keylime_tenant**\(1)
 
 BUGS
 ====
 
-Report bugs at https://github.com/keylime/keylime/issues 
+Report bugs at https://github.com/keylime/rust-keylime/issues

--- a/docs/man/keylime_registrar.8.rst
+++ b/docs/man/keylime_registrar.8.rst
@@ -1,19 +1,14 @@
-=====================
-keylime_registrar.8
-=====================
+=================
+keylime_registrar
+=================
 
-------------------------------
-Keylime registrar service
-------------------------------
+------------------------------------------------
+Keylime registrar service for agent registration
+------------------------------------------------
 
 :Manual section: 8
 :Author: Keylime Developers
 :Date: September 2025
-
-NAME
-====
-
-keylime_registrar - Keylime registrar service for agent registration
 
 SYNOPSIS
 ========
@@ -35,38 +30,76 @@ CONFIGURATION
 Primary configuration is read from ``/etc/keylime/registrar.conf`` (or an override via env).
 All options are under the ``[registrar]`` section.
 
-Essentials:
-- **ip**: Bind address
-- **port**: HTTP port
-- **tls_port**: HTTPS port
-- **tls_dir**: TLS material location
-  - ``generate``: auto-generate CA, keys, certs under ``$KEYLIME_DIR/reg_ca``
-  - ``default``: use shared verifier CA under ``$KEYLIME_DIR/cv_ca``
-- **server_key**, **server_key_password**, **server_cert**, **trusted_client_ca**: TLS files
-- **database_url**: SQLAlchemy URL; value ``sqlite`` maps to ``$KEYLIME_DIR/reg_data.sqlite``
-- **database_pool_sz_ovfl**: Pool size, overflow (non-sqlite)
-- **auto_migrate_db**: Apply DB migrations on startup
-- **max_upload_size**: Request body limit (bytes)
-- **tpm_identity**: Allowed identity (``default``, ``ek_cert_or_iak_idevid``, ``ek_cert``, ``iak_idevid``)
-- **malformed_cert_action**: ``warn`` (default), ``reject``, or ``ignore``
-- **durable_attestation_import** (optional): Python import path to enable Durable Attestation
+Essential configuration options:
+
+**ip**
+   Bind address
+
+**port**
+   HTTP port
+
+**tls_port**
+   HTTPS port
+
+**tls_dir**
+   TLS material location (``generate`` for auto-generate CA, keys, certs under ``$KEYLIME_DIR/reg_ca``, ``default`` for shared verifier CA under ``$KEYLIME_DIR/cv_ca``)
+
+**server_key**, **server_key_password**, **server_cert**, **trusted_client_ca**
+   TLS files
+
+**database_url**
+   SQLAlchemy URL; value ``sqlite`` maps to ``$KEYLIME_DIR/reg_data.sqlite``
+
+**database_pool_sz_ovfl**
+   Pool size, overflow (non-sqlite)
+
+**auto_migrate_db**
+   Apply DB migrations on startup
+
+**max_upload_size**
+   Request body limit (bytes)
+
+**tpm_identity**
+   Allowed identity (``default``, ``ek_cert_or_iak_idevid``, ``ek_cert``, ``iak_idevid``)
+
+**malformed_cert_action**
+   ``warn`` (default), ``reject``, or ``ignore``
+
+**durable_attestation_import** (optional)
+   Python import path to enable Durable Attestation
 
 ENVIRONMENT
 ===========
 
-- **KEYLIME_REGISTRAR_CONFIG**: Path to registrar.conf (highest priority)
-- **KEYLIME_LOGGING_CONFIG**: Path to logging.conf
-- **KEYLIME_DIR**: Working directory (default: ``/var/lib/keylime``)
-- **KEYLIME_TEST**: ``on/true/1`` enables testing mode (looser checks; WORK_DIR becomes CWD)
+**KEYLIME_REGISTRAR_CONFIG**
+   Path to registrar.conf (highest priority)
+
+**KEYLIME_LOGGING_CONFIG**
+   Path to logging.conf
+
+**KEYLIME_DIR**
+   Working directory (default: ``/var/lib/keylime``)
+
+**KEYLIME_TEST**
+   ``on/true/1`` enables testing mode (looser checks; WORK_DIR becomes CWD)
 
 FILES
 =====
 
-- ``/etc/keylime/registrar.conf``
-- ``/etc/keylime/logging.conf``
-- ``$KEYLIME_DIR/reg_data.sqlite`` (when ``database_url = sqlite``)
-- ``$KEYLIME_DIR/reg_ca`` (when ``tls_dir = generate``)
-- ``$KEYLIME_DIR/cv_ca`` (when ``tls_dir = default``)
+``/etc/keylime/registrar.conf``
+   Registrar configuration file
+
+``/etc/keylime/logging.conf``
+   Logging configuration
+
+``$KEYLIME_DIR/reg_data.sqlite``
+   Database file when ``database_url = sqlite``
+
+``$KEYLIME_DIR/reg_ca``
+   TLS certificates when ``tls_dir = generate``
+
+``$KEYLIME_DIR/cv_ca``
+   Shared verifier certificates when ``tls_dir = default``
 
 RUNTIME
 =======
@@ -101,7 +134,7 @@ NOTES
 SEE ALSO
 ========
 
-**keylime_verifier**(8), **keylime_tenant**(1), **keylime_agent**(8)
+**keylime_verifier**\(8), **keylime_tenant**\(1), **keylime_agent**\(8)
 
 BUGS
 ====

--- a/docs/man/keylime_tenant.1.rst
+++ b/docs/man/keylime_tenant.1.rst
@@ -1,19 +1,14 @@
-================
-keylime_tenant.1
-================
+==============
+keylime_tenant
+==============
 
----------------------------------
-Keylime tenant management tool
----------------------------------
+---------------------------------------------------------------------------
+Keylime tenant management tool for agent provisioning and policy management
+---------------------------------------------------------------------------
 
 :Manual section: 1
 :Author: Keylime Developers
 :Date: July 2025
-
-NAME
-====
-
-keylime_tenant - Keylime tenant management tool for agent provisioning and policy management
 
 SYNOPSIS
 ========
@@ -25,12 +20,12 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-keylime_tenant is the primary command-line interface for managing Keylime agents and policies. 
-It allows users to provision agents with TPM-based attestation, manage runtime policies, 
+keylime_tenant is the primary command-line interface for managing Keylime agents and policies.
+It allows users to provision agents with TPM-based attestation, manage runtime policies,
 measured boot policies, and interact with Keylime registrar and verifier services.
 
-The tenant can add, delete, update, and monitor agents, as well as manage various types of 
-policies including runtime policies (for IMA/EVM attestation) and measured boot policies 
+The tenant can add, delete, update, and monitor agents, as well as manage various types of
+policies including runtime policies (for IMA/EVM attestation) and measured boot policies
 (for boot-time attestation). It supports both push and pull models for agent communication.
 
 You can run keylime_tenant on the same system as the Keylime registrar or verifier, or on a separate system.
@@ -38,8 +33,7 @@ You can run keylime_tenant on the same system as the Keylime registrar or verifi
 COMMANDS
 ========
 
-.. option:: -c, --command COMMAND
-
+**-c, --command** *COMMAND*
    Specify the command to execute. Valid commands are:
 
    - **add**: Add a new agent to the system (default)
@@ -67,118 +61,91 @@ COMMANDS
 OPTIONS
 =======
 
-.. option:: -h, --help
-
+**-h, --help**
    Show help message and exit
 
-.. option:: --push-model
-
+**--push-model**
    Enable push model (avoid requests to keylime-agent)
 
-.. option:: -t, --targethost AGENT_IP
-
+**-t, --targethost** *AGENT_IP*
    The IP address of the host to provision
 
-.. option:: -tp, --targetport AGENT_PORT
-
+**-tp, --targetport** *AGENT_PORT*
    The port of the host to provision
 
-.. option:: -r, --registrarhost REGISTRAR_IP
-
+**-r, --registrarhost** *REGISTRAR_IP*
    The IP address of the registrar where to retrieve the agents data from
 
-.. option:: -rp, --registrarport REGISTRAR_PORT
-
+**-rp, --registrarport** *REGISTRAR_PORT*
    The port of the registrar
 
-.. option:: --cv_targethost CV_AGENT_IP
-
-   The IP address of the host to provision that the verifier will use (optional). 
+**--cv_targethost** *CV_AGENT_IP*
+   The IP address of the host to provision that the verifier will use (optional).
    Use only if different than argument to option -t/--targethost
 
-.. option:: -v, --cv VERIFIER_IP
-
+**-v, --cv** *VERIFIER_IP*
    The IP address of the cloud verifier
 
-.. option:: -vp, --cvport VERIFIER_PORT
-
+**-vp, --cvport** *VERIFIER_PORT*
    The port of the cloud verifier
 
-.. option:: -vi, --cvid VERIFIER_ID
-
+**-vi, --cvid** *VERIFIER_ID*
    The unique identifier of a cloud verifier
 
-.. option:: -nvc, --no-verifier-check
-
-   Disable the check to confirm if the agent is being processed by the specified verifier. 
+**-nvc, --no-verifier-check**
+   Disable the check to confirm if the agent is being processed by the specified verifier.
    Use only with -c/--command delete or reactivate
 
-.. option:: -u, --uuid AGENT_UUID
-
+**-u, --uuid** *AGENT_UUID*
    UUID for the agent to provision
 
-.. option:: -f, --file FILE
-
+**-f, --file** *FILE*
    Deliver the specified plaintext file to the provisioned agent
 
-.. option:: --cert CA_DIR
-
-   Create and deliver a certificate using a CA created by ca-util. 
+**--cert** *CA_DIR*
+   Create and deliver a certificate using a CA created by ca-util.
    Pass in the CA directory or use "default" to use the standard directory
 
-.. option:: -k, --key KEYFILE
-
+**-k, --key** *KEYFILE*
    An intermediate key file produced by user_data_encrypt
 
-.. option:: -p, --payload PAYLOAD
-
+**-p, --payload** *PAYLOAD*
    Specify the encrypted payload to deliver with encrypted keys specified by -k
 
-.. option:: --include INCL_DIR
-
-   Include additional files in provided directory in certificate zip file. 
+**--include** *INCL_DIR*
+   Include additional files in provided directory in certificate zip file.
    Must be specified with --cert
 
-.. option:: --runtime-policy RUNTIME_POLICY
-
+**--runtime-policy** *RUNTIME_POLICY*
    Specify the file path of a runtime policy
 
-.. option:: --runtime-policy-checksum RUNTIME_POLICY_CHECKSUM
-
+**--runtime-policy-checksum** *RUNTIME_POLICY_CHECKSUM*
    Specify the SHA-256 checksum of a runtime policy
 
-.. option:: --runtime-policy-sig-key RUNTIME_POLICY_SIG_KEY
-
+**--runtime-policy-sig-key** *RUNTIME_POLICY_SIG_KEY*
    Specify the public key file used to validate the runtime policy signature
 
-.. option:: --runtime-policy-url RUNTIME_POLICY_URL
-
+**--runtime-policy-url** *RUNTIME_POLICY_URL*
    Specify the URL of a remote runtime policy
 
-.. option:: --runtime-policy-name RUNTIME_POLICY_NAME
-
+**--runtime-policy-name** *RUNTIME_POLICY_NAME*
    The name of the runtime policy to operate with
 
-.. option:: --mb-policy MB_POLICY
-
+**--mb-policy** *MB_POLICY*
    The measured boot policy to operate with
 
-.. option:: --mb-policy-name MB_POLICY_NAME
-
+**--mb-policy-name** *MB_POLICY_NAME*
    The name of the measured boot policy to operate with
 
-.. option:: --tpm_policy TPM_POLICY
-
-   Specify a TPM policy in JSON format. 
+**--tpm_policy** *TPM_POLICY*
+   Specify a TPM policy in JSON format.
    Example: {"15":"0000000000000000000000000000000000000000"}
 
-.. option:: --verify
-
-   Block on cryptographically checked key derivation confirmation from the agent 
+**--verify**
+   Block on cryptographically checked key derivation confirmation from the agent
    once it has been provisioned
 
-.. option:: --supported-version SUPPORTED_VERSION
-
+**--supported-version** *SUPPORTED_VERSION*
    API version that is supported by the agent. Detected automatically by default
 
 DEPRECATED OPTIONS
@@ -186,34 +153,28 @@ DEPRECATED OPTIONS
 
 The following options are deprecated and may be removed in future versions:
 
-.. option:: --allowlist ALLOWLIST
-
-   **DEPRECATED**: Migrate to runtime policies for continued functionality. 
+**--allowlist** *ALLOWLIST*
+   **DEPRECATED**: Migrate to runtime policies for continued functionality.
    Specify the file path of an allowlist
 
-.. option:: --allowlist-url ALLOWLIST_URL
-
-   **DEPRECATED**: Migrate to runtime policies for continued functionality. 
+**--allowlist-url** *ALLOWLIST_URL*
+   **DEPRECATED**: Migrate to runtime policies for continued functionality.
    Specify the URL of a remote allowlist
 
-.. option:: --allowlist-name ALLOWLIST_NAME
-
-   **DEPRECATED**: Migrate to runtime policies for continued functionality. 
+**--allowlist-name** *ALLOWLIST_NAME*
+   **DEPRECATED**: Migrate to runtime policies for continued functionality.
    The name of allowlist to operate with
 
-.. option:: --exclude IMA_EXCLUDE
-
-   **DEPRECATED**: Migrate to runtime policies for continued functionality. 
+**--exclude** *IMA_EXCLUDE*
+   **DEPRECATED**: Migrate to runtime policies for continued functionality.
    Specify the location of an IMA exclude list
 
-.. option:: --mb_refstate MB_POLICY
-
-   **DEPRECATED**: Use --mb-policy instead. 
+**--mb_refstate** *MB_POLICY*
+   **DEPRECATED**: Use --mb-policy instead.
    Specify the location of a measured boot reference state
 
-.. option:: --signature-verification-key IMA_SIGN_VERIFICATION_KEYS
-
-   **DEPRECATED**: Provide verification keys as part of a runtime policy for continued functionality. 
+**--signature-verification-key** *IMA_SIGN_VERIFICATION_KEYS*
+   **DEPRECATED**: Provide verification keys as part of a runtime policy for continued functionality.
    Specify an IMA file signature verification key
 
 EXAMPLES
@@ -299,4 +260,4 @@ For more information about Keylime, visit: https://keylime.dev
 BUGS
 ====
 
-Report bugs to the Keylime project at: https://github.com/keylime/keylime/issues 
+Report bugs to the Keylime project at: https://github.com/keylime/keylime/issues

--- a/docs/man/keylime_verifier.8.rst
+++ b/docs/man/keylime_verifier.8.rst
@@ -1,19 +1,14 @@
-===================
-keylime_verifier.8
-===================
+================
+keylime_verifier
+================
 
--------------------------
-Keylime verifier service
--------------------------
+----------------------------------------------
+Keylime verifier service for agent attestation
+----------------------------------------------
 
 :Manual section: 8
 :Author: Keylime Developers
 :Date: September 2025
-
-NAME
-====
-
-keylime_verifier - Keylime verifier service for agent attestation
 
 SYNOPSIS
 ========
@@ -42,8 +37,10 @@ Essentials:
 - **registrar_ip**, **registrar_port**: Registrar endpoint
 - **enable_agent_mtls**: Enable mTLS with agents and tenant
 - **tls_dir**: TLS material location
+
   - ``generate``: auto-generate CA, client and server keys/certs under ``$KEYLIME_DIR/cv_ca``
   - ``default``: use existing materials under ``$KEYLIME_DIR/cv_ca``
+
 - **server_key**, **server_key_password**, **server_cert**: Server TLS files
 - **client_key**, **client_key_password**, **client_cert**: Client TLS files
 - **trusted_client_ca**, **trusted_server_ca**: CA lists
@@ -111,9 +108,9 @@ NOTES
 SEE ALSO
 ========
 
-**keylime_registrar**(8), **keylime_tenant**(1), **keylime_agent**(8)
+**keylime_registrar**\(8), **keylime_tenant**\(1), **keylime_agent**\(8)
 
 BUGS
 ====
 
-Report bugs at https://github.com/keylime/keylime/issues 
+Report bugs at https://github.com/keylime/keylime/issues


### PR DESCRIPTION
This commit resolves multiple RST formatting issues that prevented clean builds with rst2man:

- Convert Sphinx-specific `.. option::` directives to standard RST definition lists
- Fix bullet list formatting by converting to definition lists for better rendering
- Remove duplicate NAME sections by incorporating text into subtitles
- Fix title formatting by removing file extensions and adjusting underlines
- Fix SEE ALSO section markup to use proper escape sequences
- Extend subtitle underlines to match text length exactly

# PR Title 
 docs: Fix man page RST formatting for rst2man compatibility #1813 

## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [x] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

