### PR TITLE
Fix TypeError when using -m flag without IMA measurement list path

### DIFF
--- a/keylime/policy/create_runtime_policy.py
+++ b/keylime/policy/create_runtime_policy.py
@@ -1043,8 +1043,12 @@ def create_runtime_policy(args: argparse.Namespace) -> Optional[RuntimePolicyTyp
 
     policy["ima"]["ignored_keyrings"].extend(args.ignored_keyrings)
     if args.get_keyrings or args.get_ima_buf:
+        ima_list = args.ima_measurement_list
+        if ima_list is None:
+            # Use the default list, when one is not specified.
+            ima_list = IMA_MEASUREMENT_LIST
         policy["keyrings"], policy["ima-buf"], ok = process_ima_buf_in_measurement_list(
-            args.ima_measurement_list,
+            ima_list,
             policy["ima"]["ignored_keyrings"],
             args.get_keyrings,
             policy["keyrings"],


### PR DESCRIPTION
# PR Title 
`Fix TypeError when using -m flag without IMA measurement list path`

## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
N/A

## Change Description
When the --ima-measurement-list (-m) flag is used without providing a file path, argparse sets the value to None. This caused a TypeError when process_ima_buf_in_measurement_list() attempted to open the file.

The fix adds a None check before calling process_ima_buf_in_measurement_list, using the default IMA measurement list path when no path is specified, consistent with the existing behavior for other IMA measurement list processing.


## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. Describe test environment
2. Step-by-step validation procedure
3. Expected vs actual results

## Checklist
- [x] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [ ] Documentation updated (per above section)
- [ ] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)
