### PR TITLE
Remove operational_state field from status response in push mode

### DIFF
--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -727,9 +727,9 @@ class Tenant:
             response_json["results"] = {self.agent_uuid: res}
 
             # operational_state is a PULL-mode only field
-            # For PUSH mode (--push-model flag), show "Not applicable (Push Mode)"
+            # For PUSH mode (--push-model flag), remove it from the response
             if self.push_model:
-                response_json["results"][self.agent_uuid]["operational_state"] = "Not applicable (Push Mode)"
+                response_json["results"][self.agent_uuid].pop("operational_state", None)
             else:
                 op_state_value = response_json["results"][self.agent_uuid]["operational_state"]
                 if op_state_value is not None:


### PR DESCRIPTION
# PR Title 
**Example:** `feat: Add secure boot measurement support`

## Type of Change
*(Select all that apply)*
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
N/A

## Change Description

### Concise Summary

### Technical Details
The operational_state field is only meaningful for PULL mode attestation where the verifier actively polls agents. In PUSH mode, agents control their own attestation schedule, making the verifier's operational state not applicable. This change removes the field entirely from the tenant status response when --push-model flag is used, instead of displaying "Not applicable (Push Mode)".

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [x] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [ ] No docs needed (requires maintainer approval)

## Verification Process
Before change: `operational_state` appears on `--push-mode`:
```bash
python3 -m keylime.cmd.tenant -c status -u d432fbb3-d2f1-4a97-9ef7-75bd81c00000 --push-model | tail -1 | jq
{
  "d432fbb3-d2f1-4a97-9ef7-75bd81c00000": {
    "operational_state": "Not applicable (Push Mode)",
    "v": null,
    "ip": null,
    "port": null,
```
Before change: `operational_state` appears on `--push-model` tenant option:
```bash
python3 -m keylime.cmd.tenant -c status -u d432fbb3-d2f1-4a97-9ef7-75bd81c00000 --push-model | tail -1 | jq
{
  "d432fbb3-d2f1-4a97-9ef7-75bd81c00000": {
    "v": null,
    "ip": null,
    "port": null,
```
## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [ ] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context
N/A