### PR TITLE
Increase maximum_attestation_interval

### DIFF
--- a/keylime/push_agent_monitor.py
+++ b/keylime/push_agent_monitor.py
@@ -26,9 +26,9 @@ from keylime.db.verifier_db import VerfierMain
 logger = keylime_logging.init_logging("push_agent_monitor")
 
 # Timeout multiplier for quote_interval
-# We wait 2x the quote_interval before marking an agent as failed
+# We wait 5x the quote_interval before marking an agent as failed
 # This allows for network delays and processing time
-_TIMEOUT_MULTIPLIER = 2.0
+_TIMEOUT_MULTIPLIER = 5.0
 
 # In-memory map of agent_id -> timeout handle for active timeouts
 # This allows us to cancel/reschedule timeouts without database queries

--- a/test/test_push_agent_monitor.py
+++ b/test/test_push_agent_monitor.py
@@ -146,11 +146,11 @@ class TestPushAgentMonitor(unittest.TestCase):
         mock_time.return_value = self.current_time
 
         # Create a timed-out PUSH mode agent (received attestation 10 seconds ago)
-        # Timeout threshold is get_maximum_attestation_interval(2.0) = 4.0 seconds
+        # Timeout threshold is get_maximum_attestation_interval(2.0) = 10.0 seconds
         self._create_push_agent(
             agent_id="timed-out-agent",
             accept_attestations=True,
-            last_received_quote=self.current_time - 10,  # 10 seconds ago (> 4 second threshold)
+            last_received_quote=self.current_time - 20,  # 20 seconds ago (> 10 second threshold)
             operational_state=None,  # PUSH mode
         )
 
@@ -255,7 +255,7 @@ class TestPushAgentMonitor(unittest.TestCase):
     def test_check_push_agent_timeouts_multiple_agents(self, mock_time, mock_session_context, mock_config):
         """Test timeout detection with multiple agents in different states."""
         # Configure mocks
-        mock_config.getfloat.return_value = 2.0  # quote_interval = 2 seconds (threshold = 4 seconds)
+        mock_config.getfloat.return_value = 2.0  # quote_interval = 2 seconds (threshold = 10.0 seconds)
         mock_session_context.return_value.__enter__.return_value = self.session
         mock_session_context.return_value.__exit__.return_value = None
         mock_time.return_value = self.current_time
@@ -276,7 +276,7 @@ class TestPushAgentMonitor(unittest.TestCase):
         self._create_push_agent(
             agent_id="timed-out-1",
             accept_attestations=True,
-            last_received_quote=self.current_time - 5,  # Timed out (5s ago)
+            last_received_quote=self.current_time - 15,  # Timed out (15s ago)
             operational_state=None,
         )
         self._create_push_agent(
@@ -324,8 +324,8 @@ class TestPushAgentMonitor(unittest.TestCase):
         for interval in test_intervals:
             with self.subTest(quote_interval=interval):
                 expected_threshold = get_maximum_attestation_interval(interval)
-                # The threshold should be 2x the quote_interval
-                self.assertEqual(expected_threshold, interval * 2.0)
+                # The threshold should be 5x the quote_interval
+                self.assertEqual(expected_threshold, interval * 5.0)
 
     def test_is_push_mode_agent(self):
         """Test the is_push_mode_agent() function with various agent configurations."""


### PR DESCRIPTION
# PR Title 
Increase maximum_attestation_interval

## Type of Change
*(Select all that apply)*
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
N/A

## Change Description

### Concise Summary
Increase PUSH mode timeout multiplier from 2x to 5x quote_interval

### Technical Details
Problem: PUSH mode agents were being marked as FAILED too aggressively with the previous 2x timeout multiplier. In environments with variable network latency or higher processing loads, legitimate agents could be incorrectly flagged as failed when attestations arrived slightly late but were still within acceptable bounds.

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [x] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [ ] No docs needed (requires maintainer approval)

## Verification Process

## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [ ] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context
N/A