### PR TITLE
Do not require wheel for building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "wheel",
     "jinja2",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Type of Change
*(Select all that apply)*
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [x] CI/CD changes
- [ ] Other (please specify: ______)

## Change Description

setuptools 70.1+ does not need wheel at all;

older versions would fetch wheel when building wheels (but not sdists).

This dependency declaration is unnecessary and likely accidental.

### Concise Summary

Removed a declared build dependency on an unnecessary Python package "wheel".
This package is not needed at all, or is fetched as a dependency by setuptools,
when building with old versions of setuptools (< 70.1).

### Technical Details
 
There no more technical details here.

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. build a Python .whl

## Checklist
- [ ] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [ ] Documentation updated (per above section)
- [ ] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [ ] All tests pass (local & CI)

## Additional Context
