### PR TITLE
config: move push-mode options to [verifier] section in template

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -590,6 +590,9 @@ class AgentsHandler(BaseHandler):
 
             # Check verifier mode - push mode doesn't use operational_state state machine
             mode = config.get("verifier", "mode", fallback="pull")
+            # Handle empty string as pull mode (regression from config template changes)
+            if not mode:
+                mode = "pull"
 
             # In push mode, directly delete the agent since operational_state is not used
             # In pull mode, check operational_state to determine deletion vs termination
@@ -638,6 +641,9 @@ class AgentsHandler(BaseHandler):
         agents requests require a json block sent in the body
         """
         mode = config.get("verifier", "mode", fallback="pull")
+        # Handle empty string as pull mode (regression from config template changes)
+        if not mode:
+            mode = "pull"
 
         # TODO: exception handling needs fixing
         # Maybe handle exceptions with if/else if/else blocks ... simple and avoids nesting

--- a/templates/2.5/verifier.j2
+++ b/templates/2.5/verifier.j2
@@ -252,39 +252,15 @@ signed_attributes = {{ verifier.signed_attributes }}
 # Require that allowlists are signed with a key passed via the tenant tool
 require_allow_list_signatures = {{ verifier.require_allow_list_signatures }}
 
-[revocations]
-
-# List of revocation notification methods to enable.
-#
-# Available methods are:
-#
-# "agent": Deliver notification directly to the agent via the REST
-# protocol.
-#
-# "zeromq": Enable the ZeroMQ based revocation notification method;
-# zmq_ip and zmq_port options must be set. Currently this only works if you are
-# using keylime-CA.
-#
-# "webhook": Send notification via webhook. The endpoint URL must be
-# configured with 'webhook_url' option. This can be used to notify other
-# systems that do not have a Keylime agent running.
-enabled_revocation_notifications = {{ revocations.enabled_revocation_notifications }}
-
-# The binding address and port of the revocation notifier service via ZeroMQ.
-zmq_ip = {{ revocations.zmq_ip }}
-zmq_port = {{ revocations.zmq_port }}
-
-# Webhook url for revocation notifications.
-webhook_url = {{ revocations.webhook_url }}
-
 # Attestation mode. Can be 'pull' (traditional) or 'push' (agent-driven).
-mode = {{ verifier_mode }}
+# Default: pull
+mode = {{ verifier.mode }}
 #
 # Lifetime in seconds for challanges sent to agents in push mode.
-challenge_lifetime = {{ verifier_challenge_lifetime }}
+challenge_lifetime = {{ verifier.challenge_lifetime }}
 #
 # Timeout in seconds for a single evidence verification task (0 = auto).
-verification_timeout = {{ verifier_verification_timeout }}
+verification_timeout = {{ verifier.verification_timeout }}
 #
 # Rate limiting for session creation endpoint (POST /sessions) in push mode.
 # These settings prevent denial-of-service attacks where an attacker floods the verifier
@@ -318,3 +294,28 @@ session_lifetime = {{ verifier.session_lifetime }}
 # as long as they continue attesting within the session_lifetime window.
 # Default: true
 extend_token_on_attestation = {{ verifier.extend_token_on_attestation }}
+
+[revocations]
+
+# List of revocation notification methods to enable.
+#
+# Available methods are:
+#
+# "agent": Deliver notification directly to the agent via the REST
+# protocol.
+#
+# "zeromq": Enable the ZeroMQ based revocation notification method;
+# zmq_ip and zmq_port options must be set. Currently this only works if you are
+# using keylime-CA.
+#
+# "webhook": Send notification via webhook. The endpoint URL must be
+# configured with 'webhook_url' option. This can be used to notify other
+# systems that do not have a Keylime agent running.
+enabled_revocation_notifications = {{ revocations.enabled_revocation_notifications }}
+
+# The binding address and port of the revocation notifier service via ZeroMQ.
+zmq_ip = {{ revocations.zmq_ip }}
+zmq_port = {{ revocations.zmq_port }}
+
+# Webhook url for revocation notifications.
+webhook_url = {{ revocations.webhook_url }}


### PR DESCRIPTION
# PR Title 
config: move push-mode options to [verifier] section in template


## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [x] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
*(If you use an issue tracker, please put references to them)*  
**Resolves:** #123  
**See also:** #456, #789

## Change Description

### Summary

The push-mode configuration options (mode, challenge_lifetime,
verification_timeout, rate limiting, session_lifetime, and
extend_token_on_attestation) were placed under [revocations] in the
template, but the code reads them from [verifier]. This caused the
verifier to silently fall back to pull mode regardless of config.

Move these options above the [revocations] section header so they
are emitted into the [verifier] section where the code expects them.

Additionally, fix template variable naming inconsistencies that caused
empty config values:
- {{ verifier_mode }} -> {{ verifier.mode }}
- {{ verifier_challenge_lifetime }} -> {{ verifier.challenge_lifetime }}
- {{ verifier_verification_timeout }} -> {{ verifier.verification_timeout }}

Add defensive code to handle empty mode strings as "pull" (the default)
to support existing installations with malformed configs.

## Documentation Updates Required
*(Check all that apply)*
- [x] Updated markdown docs (file path: ______)
- [x] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)
