### PR TITLE
ca: Add Subject Alternative Names to auto-generated TLS certificates

### DIFF
--- a/keylime/ca_util.py
+++ b/keylime/ca_util.py
@@ -90,7 +90,23 @@ def ask_password(key_store_pw: Optional[str] = None) -> None:
     global_password = key_store_pw
 
 
-def cmd_mkcert(workingdir: str, name: str, password: Optional[str] = None) -> None:
+def cmd_mkcert(
+    workingdir: str,
+    name: str,
+    password: Optional[str] = None,
+    san_dns: Optional[List[str]] = None,
+    san_ips: Optional[List[str]] = None,
+) -> None:
+    """
+    Create a signed certificate for a server or client.
+
+    Args:
+        workingdir: The directory containing the CA certificate and private key.
+        name: The common name for the certificate (e.g., "server" or "client").
+        password: Optional password to encrypt the private key.
+        san_dns: Optional list of DNS names for the Subject Alternative Name.
+        san_ips: Optional list of IP addresses for the Subject Alternative Name.
+    """
     cwd = os.getcwd()
     mask = os.umask(0o037)
     try:
@@ -105,7 +121,9 @@ def cmd_mkcert(workingdir: str, name: str, password: Optional[str] = None) -> No
                 f"Private key of type {type(ca_pk).__name__} cannot be used for creating an x509 certificate"
             )
 
-        cert, pk = ca_impl.mk_signed_cert(cacert, ca_pk, name, priv[0]["lastserial"] + 1)
+        cert, pk = ca_impl.mk_signed_cert(
+            cacert, ca_pk, name, priv[0]["lastserial"] + 1, san_dns=san_dns, san_ips=san_ips
+        )
 
         with os.fdopen(os.open(f"{name}-cert.crt", os.O_WRONLY | os.O_CREAT, 0o640), "wb") as f:
             f.write(cert.public_bytes(serialization.Encoding.PEM))

--- a/templates/2.5/mapping.json
+++ b/templates/2.5/mapping.json
@@ -28,12 +28,14 @@
                 "session_create_rate_limit_window_agent": "60",
                 "session_lifetime": "180",
                 "extend_token_on_attestation": "True",
-                "authorization_provider": "simple"
+                "authorization_provider": "simple",
+                "cert_subject_alternative_names": ""
             }
         },
         "registrar": {
             "add": {
-                "authorization_provider": "simple"
+                "authorization_provider": "simple",
+                "cert_subject_alternative_names": ""
             }
         }
     }

--- a/templates/2.5/registrar.j2
+++ b/templates/2.5/registrar.j2
@@ -42,6 +42,27 @@ server_key_password = {{ registrar.server_key_password }}
 # If set as 'default', the 'server-cert.crt' value is used.
 server_cert = {{ registrar.server_cert }}
 
+# Additional Subject Alternative Names (SANs) to include in auto-generated
+# server certificates when 'tls_dir = generate'.
+#
+# This is a comma-separated list of hostnames and/or IP addresses that will be
+# added to the server certificate's SAN extension. This allows clients to verify
+# the server's hostname when connecting.
+#
+# By default, the certificate will automatically include:
+# - localhost, 127.0.0.1, and ::1
+# - The system's hostname and FQDN
+# - The IP address from the 'ip' option (if not 0.0.0.0 or ::)
+#
+# Use this option to add additional names, such as:
+# - External DNS names (e.g., registrar.example.com)
+# - Load balancer addresses
+# - Additional IP addresses
+#
+# Example: cert_subject_alternative_names = registrar.example.com,10.0.0.5,registrar-internal
+# Leave empty to use only the automatically detected names.
+cert_subject_alternative_names = {{ registrar.cert_subject_alternative_names }}
+
 # The list of trusted client CA certificates.
 # The files in the list should be stored in the directory set in the 'tls_dir'
 # option.

--- a/templates/2.5/verifier.j2
+++ b/templates/2.5/verifier.j2
@@ -56,6 +56,27 @@ server_key_password = {{ verifier.server_key_password }}
 # If set as 'default', the 'server-cert.crt' value is used.
 server_cert = {{ verifier.server_cert }}
 
+# Additional Subject Alternative Names (SANs) to include in auto-generated
+# server certificates when 'tls_dir = generate'.
+#
+# This is a comma-separated list of hostnames and/or IP addresses that will be
+# added to the server certificate's SAN extension. This allows clients to verify
+# the server's hostname when connecting.
+#
+# By default, the certificate will automatically include:
+# - localhost, 127.0.0.1, and ::1
+# - The system's hostname and FQDN
+# - The IP address from the 'ip' option (if not 0.0.0.0 or ::)
+#
+# Use this option to add additional names, such as:
+# - External DNS names (e.g., verifier.example.com)
+# - Load balancer addresses
+# - Additional IP addresses
+#
+# Example: cert_subject_alternative_names = verifier.example.com,10.0.0.5,verifier-internal
+# Leave empty to use only the automatically detected names.
+cert_subject_alternative_names = {{ verifier.cert_subject_alternative_names }}
+
 # The list of trusted client CA certificates.
 # The files in the list should be stored in the directory set in the 'tls_dir'
 # option.

--- a/test/test_ca_impl_openssl.py
+++ b/test/test_ca_impl_openssl.py
@@ -1,12 +1,14 @@
+import ipaddress
 import os
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from cryptography import exceptions as crypto_exceptions
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
-from cryptography.x509 import CRLDistributionPoints
+from cryptography.x509 import CRLDistributionPoints, SubjectAlternativeName
 
 from keylime import ca_impl_openssl
 
@@ -67,6 +69,170 @@ class OpenSSL_Test(unittest.TestCase):
             cert.extensions.get_extension_for_class(CRLDistributionPoints).value[0].full_name[0].value,
             os.environ["KEYLIME_CA_CERT_CRL_DIST"],
         )
+
+
+class TestGetSanEntries(unittest.TestCase):
+    """Tests for the get_san_entries function."""
+
+    @mock.patch("keylime.ca_impl_openssl.socket.gethostname")
+    @mock.patch("keylime.ca_impl_openssl.socket.getfqdn")
+    def test_get_san_entries_with_ip_bind_address(self, mock_getfqdn, mock_gethostname):
+        """Test that IP bind address is included in SANs."""
+        mock_gethostname.return_value = "testhost"
+        mock_getfqdn.return_value = "testhost.example.com"
+
+        dns_names, ip_addresses = ca_impl_openssl.get_san_entries(bind_address="192.168.1.100")
+
+        self.assertIn("localhost", dns_names)
+        self.assertIn("testhost", dns_names)
+        self.assertIn("testhost.example.com", dns_names)
+        self.assertIn("127.0.0.1", ip_addresses)
+        self.assertIn("::1", ip_addresses)
+        self.assertIn("192.168.1.100", ip_addresses)
+
+    @mock.patch("keylime.ca_impl_openssl.socket.gethostname")
+    @mock.patch("keylime.ca_impl_openssl.socket.getfqdn")
+    def test_get_san_entries_with_hostname_bind_address(self, mock_getfqdn, mock_gethostname):
+        """Test that hostname bind address is included in DNS SANs."""
+        mock_gethostname.return_value = "testhost"
+        mock_getfqdn.return_value = "testhost.example.com"
+
+        dns_names, ip_addresses = ca_impl_openssl.get_san_entries(bind_address="myserver.local")
+
+        self.assertIn("myserver.local", dns_names)
+        self.assertIn("localhost", dns_names)
+        self.assertNotIn("myserver.local", ip_addresses)
+
+    @mock.patch("keylime.ca_impl_openssl.socket.gethostname")
+    @mock.patch("keylime.ca_impl_openssl.socket.getfqdn")
+    def test_get_san_entries_with_wildcard_address(self, mock_getfqdn, mock_gethostname):
+        """Test that 0.0.0.0 is not included as an IP SAN."""
+        mock_gethostname.return_value = "testhost"
+        mock_getfqdn.return_value = "testhost.example.com"
+
+        dns_names, ip_addresses = ca_impl_openssl.get_san_entries(bind_address="0.0.0.0")
+
+        # Should still have localhost entries
+        self.assertIn("localhost", dns_names)
+        self.assertIn("127.0.0.1", ip_addresses)
+        # But not the wildcard address
+        self.assertNotIn("0.0.0.0", ip_addresses)
+
+    @mock.patch("keylime.ca_impl_openssl.socket.gethostname")
+    @mock.patch("keylime.ca_impl_openssl.socket.getfqdn")
+    def test_get_san_entries_with_additional_sans(self, mock_getfqdn, mock_gethostname):
+        """Test that additional SANs are included."""
+        mock_gethostname.return_value = "testhost"
+        mock_getfqdn.return_value = "testhost"
+
+        dns_names, ip_addresses = ca_impl_openssl.get_san_entries(
+            bind_address="192.168.1.1",
+            additional_dns=["extra.example.com", "another.example.com"],
+            additional_ips=["10.0.0.1", "10.0.0.2"],
+        )
+
+        self.assertIn("extra.example.com", dns_names)
+        self.assertIn("another.example.com", dns_names)
+        self.assertIn("10.0.0.1", ip_addresses)
+        self.assertIn("10.0.0.2", ip_addresses)
+
+    @mock.patch("keylime.ca_impl_openssl.socket.gethostname")
+    @mock.patch("keylime.ca_impl_openssl.socket.getfqdn")
+    def test_get_san_entries_with_ipv6(self, mock_getfqdn, mock_gethostname):
+        """Test IPv6 addresses in SANs."""
+        mock_gethostname.return_value = "testhost"
+        mock_getfqdn.return_value = "testhost"
+
+        _, ip_addresses = ca_impl_openssl.get_san_entries(
+            bind_address="::1",
+            additional_ips=["2001:db8::1"],
+        )
+
+        # ::1 is a wildcard-like address, so it's excluded from bind_address
+        # but we include it as part of localhost entries
+        self.assertIn("::1", ip_addresses)
+        self.assertIn("2001:db8::1", ip_addresses)
+
+
+class TestMkSignedCertWithSans(unittest.TestCase):
+    """Tests for mk_signed_cert with SAN parameters."""
+
+    def test_mk_signed_cert_with_dns_sans(self):
+        """Test certificate generation with DNS SANs."""
+        (ca_cert, ca_pk, _) = ca_impl_openssl.mk_cacert()
+        cert, _ = ca_impl_openssl.mk_signed_cert(
+            ca_cert,
+            ca_pk,
+            "server",
+            5,
+            san_dns=["localhost", "myhost.example.com"],
+        )
+
+        # Verify the certificate
+        pubkey = ca_cert.public_key()
+        assert isinstance(pubkey, RSAPublicKey)
+        assert cert.signature_hash_algorithm is not None
+        try:
+            pubkey.verify(
+                cert.signature,
+                cert.tbs_certificate_bytes,
+                padding.PKCS1v15(),
+                cert.signature_hash_algorithm,
+            )
+        except crypto_exceptions.InvalidSignature:
+            self.fail("Certificate signature validation failed.")
+
+        # Check SANs
+        san_ext = cert.extensions.get_extension_for_class(SubjectAlternativeName)
+        dns_names = [name.value for name in san_ext.value if hasattr(name, "value") and isinstance(name.value, str)]
+        self.assertIn("localhost", dns_names)
+        self.assertIn("myhost.example.com", dns_names)
+
+    def test_mk_signed_cert_with_ip_sans(self):
+        """Test certificate generation with IP SANs."""
+        (ca_cert, ca_pk, _) = ca_impl_openssl.mk_cacert()
+        cert, _ = ca_impl_openssl.mk_signed_cert(
+            ca_cert,
+            ca_pk,
+            "server",
+            6,
+            san_dns=["localhost"],
+            san_ips=["127.0.0.1", "192.168.1.100"],
+        )
+
+        # Verify the certificate
+        pubkey = ca_cert.public_key()
+        assert isinstance(pubkey, RSAPublicKey)
+        assert cert.signature_hash_algorithm is not None
+        try:
+            pubkey.verify(
+                cert.signature,
+                cert.tbs_certificate_bytes,
+                padding.PKCS1v15(),
+                cert.signature_hash_algorithm,
+            )
+        except crypto_exceptions.InvalidSignature:
+            self.fail("Certificate signature validation failed.")
+
+        # Check SANs
+        san_ext = cert.extensions.get_extension_for_class(SubjectAlternativeName)
+        ip_addresses = []
+        for name in san_ext.value:
+            if hasattr(name, "value"):
+                if isinstance(name.value, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
+                    ip_addresses.append(str(name.value))
+        self.assertIn("127.0.0.1", ip_addresses)
+        self.assertIn("192.168.1.100", ip_addresses)
+
+    def test_mk_signed_cert_fallback_to_name(self):
+        """Test that certificate falls back to name when no SANs provided."""
+        (ca_cert, ca_pk, _) = ca_impl_openssl.mk_cacert()
+        cert, _ = ca_impl_openssl.mk_signed_cert(ca_cert, ca_pk, "server", 7)
+
+        # Check SANs - should contain the fallback name
+        san_ext = cert.extensions.get_extension_for_class(SubjectAlternativeName)
+        dns_names = [name.value for name in san_ext.value if hasattr(name, "value") and isinstance(name.value, str)]
+        self.assertIn("server", dns_names)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# ca: Add Subject Alternative Names to auto-generated TLS certificates

## Type of Change
*(Select all that apply)*
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [x] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
#1826 

## Change Description

### Concise Summary
Add SANs (hostname, IPs) to auto-generated certificates

When keylime auto-generates TLS certificates (via `tls_dir = generate`), the server certificates now include Subject Alternative Names (SANs) that reflect the system's actual identity, enabling proper hostname verification by TLS clients.

### Technical Details

Previously, auto-generated server certificates only contained the literal string "server" as the Subject Alternative Name. This caused TLS hostname verification failures when clients connected using the server's actual hostname or IP address, since the certificate did not match the connection endpoint.

This change addresses the problem by automatically populating SANs with:

- **Localhost entries**: `localhost`, `127.0.0.1`, and `::1` (always included for local testing)
- **System hostname and FQDN**: detected via `socket.gethostname()` and `socket.getfqdn()`
- **Configured bind address**: the IP or hostname from the component's `ip` configuration option (wildcard addresses `0.0.0.0` and `::` are excluded)

Additionally, a new configuration option `cert_subject_alternative_names` is introduced for both the verifier and registrar, allowing operators to specify extra DNS names or IP addresses (comma-separated) to include in the certificate. This supports deployment scenarios such as:

- External DNS names (e.g., `verifier.example.com`)
- Load balancer addresses
- Additional network interfaces

**Files changed:**

- `keylime/ca_impl_openssl.py`: Added `get_san_entries()` function to gather SAN entries; extended `mk_signed_cert()` to accept and apply `san_dns` and `san_ips` parameters
- `keylime/ca_util.py`: Updated `cmd_mkcert()` to pass SAN parameters through to the certificate generation layer
- `keylime/web_util.py`: Updated `init_tls_dir()` to read the bind address and the new `cert_subject_alternative_names` config option, compute SANs via `get_san_entries()`, and pass them to `cmd_mkcert()`
- `templates/2.5/verifier.j2` and `templates/2.5/registrar.j2`: Added the `cert_subject_alternative_names` configuration option with documentation
- `templates/2.5/mapping.json`: Added default (empty) value for `cert_subject_alternative_names` in both verifier and registrar sections
- `test/test_ca_impl_openssl.py`: Added unit tests for `get_san_entries()` (hostname/IP/wildcard/IPv6/additional SANs) and for `mk_signed_cert()` with DNS SANs, IP SANs, and the fallback behavior

**Backward compatibility:** This is a non-breaking change. Certificates generated without explicit `cert_subject_alternative_names` configuration will automatically include the system hostname and localhost entries, which is strictly more permissive than the previous behavior of only including "server". The new config option defaults to empty, requiring no action from existing deployments.

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [x] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [ ] No docs needed (requires maintainer approval)

## Verification Process
1. Deploy keylime with `tls_dir = generate` for the verifier and/or registrar
2. Start the verifier or registrar and inspect the generated `server-cert.crt`:
   ```bash
   openssl x509 -in /var/lib/keylime/cv_ca/server-cert.crt -text -noout | grep -A 20 "Subject Alternative Name"
   ```
3. Verify that the SAN extension includes `localhost`, `127.0.0.1`, `::1`, the system hostname, the FQDN, and the configured bind IP
4. Optionally set `cert_subject_alternative_names = extra.example.com,10.0.0.5` and confirm those entries appear in the regenerated certificate
5. Run unit tests:
   ```bash
   python -m pytest test/test_ca_impl_openssl.py -v
   ```

## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [ ] All tests pass (local & CI)

## Additional Context
This change lays the groundwork for enabling strict TLS hostname verification in keylime components. With proper SANs in place, clients can verify that they are connecting to the intended server, improving the overall security posture of the trust chain.