### PR TITLE
tpm: use only policy's relevant PCRs for event log verification

### DIFF
--- a/docs/user_guide/use_measured_boot.rst
+++ b/docs/user_guide/use_measured_boot.rst
@@ -60,6 +60,18 @@ an agent node, the following actions will be taken.
 3. The `keylime_verifier` will replay the boot log from step 2, ensuring the correct values for PCRs collected in step 1. Again, this is very similar to what it is done with "IMA logs" and PCR 10.
 4. The very same `keylime_verifier` will take the boot log, now deemed "attested" and evaluate it against the measured boot policy, causing the attestation to fail if it does not conform.
 
+.. note::
+
+   The PCR replay in step 3 is restricted to the intersection of ``MEASUREDBOOT_PCRS``
+   (the PCRs Keylime collects) and the set returned by the active policy's
+   ``get_relevant_pcrs()`` method.  PCRs outside that set are excluded from the
+   replay check.  This allows policies to declare that certain PCRs (e.g. PCR 11,
+   which ``systemd-pcrphase`` extends at runtime) are not part of their trust
+   model, preventing spurious verification failures.
+   Policies that return an empty set from ``get_relevant_pcrs()`` (such as the
+   built-in ``accept-all`` and ``reject-all``) apply no restriction, so all
+   ``MEASUREDBOOT_PCRS`` are replayed.
+
 How to use 
 ---------- 
 

--- a/docs/user_guide/use_measured_boot.rst
+++ b/docs/user_guide/use_measured_boot.rst
@@ -81,7 +81,7 @@ by using the option '--mb-policy' with the command `keylime_tenant`.
 The simplest way to test this functionality is by providing an empty
 measured boot policy with the `accept-all` measured_boot_policy_name
 specified in `verifier.conf`, which will cause the `keylime_verifier`
-to simply skip the aforementioned step 4.
+to skip the aforementioned steps 3 and 4 (no PCR replay and no policy evaluation).
 
 An example follows::
 

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -38,6 +38,7 @@ def process_quote_response(
     runtime_policy: Optional[RuntimePolicyType],
     json_response: Dict[str, Any],
     agentAttestState: AgentAttestState,
+    mb_policy_name: str = "accept-all",
 ) -> Failure:
     """Validates the response from the Cloud agent.
 
@@ -202,6 +203,7 @@ def process_quote_response(
         ima_keyrings,
         mb_measurement_list,
         mb_policy,
+        mb_policy_name=mb_policy_name,
         compressed=(agent["supported_version"] == "1.0"),
         count=agent["attestation_count"],
     )  # TODO: change this to always False after initial update
@@ -450,6 +452,7 @@ def process_verify_attestation(
     mb_policy: str,
     ima_measurement_list: str,
     mb_measurement_list: str,
+    mb_policy_name: str = "accept-all",
 ) -> Failure:
     """Processes attestation data one time only without requiring registration
 
@@ -488,6 +491,7 @@ def process_verify_attestation(
             None,  # skip ima_keyrings
             mb_measurement_list,
             mb_policy,
+            mb_policy_name=mb_policy_name,
             skip_clock_check=True,
             skip_pcr_check=False,
             skip_data_pcr_check=True,

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -1892,7 +1892,8 @@ class VerifyEvidenceHandler(BaseHandler):
             # TODO - provide better error handling around bad runtime policy
             policy_obj = ima.deserialize_runtime_policy(runtime_policy)
             failure = cloud_verifier_common.process_verify_attestation(
-                tpm_ek, tpm_ak, quote, nonce, hash_alg, tpm_policy, policy_obj, mb_policy, ima_measurement_list, mb_log
+                tpm_ek, tpm_ak, quote, nonce, hash_alg, tpm_policy, policy_obj, mb_policy, ima_measurement_list, mb_log,
+                mb_policy_name=config.get("verifier", "measured_boot_policy_name", fallback="accept-all"),
             )
 
             if len(failure.events) > 0:
@@ -2213,6 +2214,7 @@ async def invoke_get_quote(
                 ima.deserialize_runtime_policy(runtime_policy),
                 json_response["results"],
                 agentAttestState,
+                mb_policy_name=config.get("verifier", "measured_boot_policy_name", fallback="accept-all"),
             )
             if not failure:
                 if agent["provide_V"]:

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -1892,7 +1892,17 @@ class VerifyEvidenceHandler(BaseHandler):
             # TODO - provide better error handling around bad runtime policy
             policy_obj = ima.deserialize_runtime_policy(runtime_policy)
             failure = cloud_verifier_common.process_verify_attestation(
-                tpm_ek, tpm_ak, quote, nonce, hash_alg, tpm_policy, policy_obj, mb_policy, ima_measurement_list, mb_log
+                tpm_ek,
+                tpm_ak,
+                quote,
+                nonce,
+                hash_alg,
+                tpm_policy,
+                policy_obj,
+                mb_policy,
+                ima_measurement_list,
+                mb_log,
+                mb_policy_name=config.get("verifier", "measured_boot_policy_name", fallback="accept-all"),
             )
 
             if len(failure.events) > 0:
@@ -2213,6 +2223,7 @@ async def invoke_get_quote(
                 ima.deserialize_runtime_policy(runtime_policy),
                 json_response["results"],
                 agentAttestState,
+                mb_policy_name=config.get("verifier", "measured_boot_policy_name", fallback="accept-all"),
             )
             if not failure:
                 if agent["provide_V"]:

--- a/keylime/da/attest.py
+++ b/keylime/da/attest.py
@@ -128,8 +128,10 @@ def main() -> None:
                 if "clock" in agent["tpm_clockinfo"]:
                     p_tpm_ts = agent["tpm_clockinfo"]["clock"]
 
+            mb_policy_fallback = config.get("verifier", "measured_boot_policy_name", fallback="accept-all")
             failure = cloud_verifier_common.process_quote_response(
-                agent, mb_policy, runtime_policy, json_response["results"], agentAttestState
+                agent, mb_policy, runtime_policy, json_response["results"], agentAttestState,
+                mb_policy_name=attestation_record.get("mb_policy_name", mb_policy_fallback),
             )
 
             if "tpm_clockinfo" in agent:

--- a/keylime/da/attest.py
+++ b/keylime/da/attest.py
@@ -128,8 +128,14 @@ def main() -> None:
                 if "clock" in agent["tpm_clockinfo"]:
                     p_tpm_ts = agent["tpm_clockinfo"]["clock"]
 
+            mb_policy_fallback = config.get("verifier", "measured_boot_policy_name", fallback="accept-all")
             failure = cloud_verifier_common.process_quote_response(
-                agent, mb_policy, runtime_policy, json_response["results"], agentAttestState
+                agent,
+                mb_policy,
+                runtime_policy,
+                json_response["results"],
+                agentAttestState,
+                mb_policy_name=attestation_record.get("mb_policy_name", mb_policy_fallback),
             )
 
             if "tpm_clockinfo" in agent:

--- a/keylime/mba/elchecking/policies.py
+++ b/keylime/mba/elchecking/policies.py
@@ -67,6 +67,11 @@ def register(name: str, policy: Policy) -> None:
     _registry[name] = policy
 
 
+def unregister(name: str) -> None:
+    """Remove the policy registered under the given name, if present"""
+    _registry.pop(name, None)
+
+
 register("accept-all", AcceptAll())
 register("reject-all", RejectAll())
 

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -16,6 +16,7 @@ from keylime.ima import ima
 from keylime.ima.file_signatures import ImaKeyrings
 from keylime.ima.types import RuntimePolicyType
 from keylime.mba import mba
+from keylime.mba.elchecking import policies as mb_policies
 from keylime.tpm import tpm2_objects, tpm_util
 from keylime.tpm.errors import (
     HashAlgorithmMismatch,
@@ -26,6 +27,28 @@ from keylime.tpm.errors import (
 )
 
 logger = keylime_logging.init_logging("tpm")
+
+
+def mb_pcrs_to_check(policy_name: str) -> Set[int]:
+    """Return the set of measured-boot PCRs to replay against the event log.
+
+    Intersects ``config.MEASUREDBOOT_PCRS`` (PCRs Keylime collects) with the
+    set returned by ``policy.get_relevant_pcrs()`` for *policy_name*.  PCRs
+    outside the policy's relevant set are excluded so that runtime extensions
+    not captured in the event log (e.g. PCR 11 from ``systemd-pcrphase``) do
+    not cause spurious verification failures.
+
+    Policies that return an empty set from ``get_relevant_pcrs()`` (such as
+    the built-in ``accept-all`` and ``reject-all``) apply no restriction, so
+    the full ``MEASUREDBOOT_PCRS`` set is returned unchanged.
+    """
+    pcr_set: Set[int] = set(config.MEASUREDBOOT_PCRS)
+    policy = mb_policies.get_policy(policy_name)
+    if policy is not None:
+        relevant = policy.get_relevant_pcrs()
+        if relevant:
+            pcr_set &= relevant
+    return pcr_set
 
 
 class Tpm:
@@ -366,6 +389,7 @@ class Tpm:
         hash_alg: Hash,
         count: int,
         skip_data_pcr_check: bool = False,
+        mb_policy_name: str = "accept-all",
     ) -> Failure:
         failure = Failure(Component.PCR_VALIDATION)
 
@@ -451,8 +475,8 @@ class Tpm:
             except Exception:
                 pass
 
-        if not mb_failure and mb_policy is not None and mba.policy_is_valid(mb_policy) and mb_policy_is_nonempty:
-            for pcr_num in set(config.MEASUREDBOOT_PCRS) & pcr_nums:
+        if not mb_failure and mb_policy is not None and mba.policy_is_valid(mb_policy):
+            for pcr_num in mb_pcrs_to_check(mb_policy_name) & pcr_nums:
                 if not mb_measurement_list:
                     logger.error(
                         "Measured Boot PCR %d in policy, but no measurement list provided by agent %s",
@@ -564,7 +588,7 @@ class Tpm:
                 logger.error("Invalid measured boot policy for agent '%s'", agent_id)
                 failure.add_event("invalid_mb_policy", "Invalid measured boot policy", True)
 
-        if not mb_failure and mba.policy_is_valid(mb_policy):
+        if not mb_failure and mb_policy_is_nonempty and mba.policy_is_valid(mb_policy):
             mb_evaluate = config.get("verifier", "measured_boot_evaluate", fallback="once")
 
             # Value of measured_boot_evaluate can be only 'once' or 'always'
@@ -598,6 +622,7 @@ class Tpm:
         ima_keyrings: Optional[ImaKeyrings] = None,
         mb_measurement_list: Optional[Union[bytes, str]] = None,
         mb_policy: Optional[str] = None,
+        mb_policy_name: str = "accept-all",
         compressed: bool = False,
         count: int = -1,
         skip_pcr_check: bool = False,
@@ -673,6 +698,7 @@ class Tpm:
                 hash_alg,
                 count,
                 skip_data_pcr_check,
+                mb_policy_name=mb_policy_name,
             )
 
         return failure

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -16,6 +16,7 @@ from keylime.ima import ima
 from keylime.ima.file_signatures import ImaKeyrings
 from keylime.ima.types import RuntimePolicyType
 from keylime.mba import mba
+from keylime.mba.elchecking import policies as mb_policies
 from keylime.tpm import tpm2_objects, tpm_util
 from keylime.tpm.errors import (
     HashAlgorithmMismatch,
@@ -352,6 +353,28 @@ class Tpm:
                 True,
             )
 
+    @staticmethod
+    def mb_pcrs_to_check(policy_name: str) -> Set[int]:
+        """Return the set of measured-boot PCRs to replay against the event log.
+
+        Intersects ``config.MEASUREDBOOT_PCRS`` (PCRs Keylime collects) with the
+        set returned by ``policy.get_relevant_pcrs()`` for *policy_name*.  PCRs
+        outside the policy's relevant set are excluded so that runtime extensions
+        not captured in the event log (e.g. PCR 11 from ``systemd-pcrphase``) do
+        not cause spurious verification failures.
+
+        Policies that return an empty set from ``get_relevant_pcrs()`` (such as
+        the built-in ``accept-all`` and ``reject-all``) apply no restriction, so
+        the full ``MEASUREDBOOT_PCRS`` set is returned unchanged.
+        """
+        pcr_set: Set[int] = set(config.MEASUREDBOOT_PCRS)
+        policy = mb_policies.get_policy(policy_name)
+        if policy is not None:
+            relevant = policy.get_relevant_pcrs()
+            if relevant:
+                pcr_set &= relevant
+        return pcr_set
+
     def check_pcrs(
         self,
         agentAttestState: Optional[AgentAttestState],
@@ -366,6 +389,7 @@ class Tpm:
         hash_alg: Hash,
         count: int,
         skip_data_pcr_check: bool = False,
+        mb_policy_name: str = "accept-all",
     ) -> Failure:
         failure = Failure(Component.PCR_VALIDATION)
 
@@ -452,7 +476,7 @@ class Tpm:
                 pass
 
         if not mb_failure and mb_policy is not None and mba.policy_is_valid(mb_policy) and mb_policy_is_nonempty:
-            for pcr_num in set(config.MEASUREDBOOT_PCRS) & pcr_nums:
+            for pcr_num in Tpm.mb_pcrs_to_check(mb_policy_name) & pcr_nums:
                 if not mb_measurement_list:
                     logger.error(
                         "Measured Boot PCR %d in policy, but no measurement list provided by agent %s",
@@ -564,7 +588,7 @@ class Tpm:
                 logger.error("Invalid measured boot policy for agent '%s'", agent_id)
                 failure.add_event("invalid_mb_policy", "Invalid measured boot policy", True)
 
-        if not mb_failure and mba.policy_is_valid(mb_policy):
+        if not mb_failure and mb_policy_is_nonempty and mba.policy_is_valid(mb_policy):
             mb_evaluate = config.get("verifier", "measured_boot_evaluate", fallback="once")
 
             # Value of measured_boot_evaluate can be only 'once' or 'always'
@@ -598,6 +622,7 @@ class Tpm:
         ima_keyrings: Optional[ImaKeyrings] = None,
         mb_measurement_list: Optional[Union[bytes, str]] = None,
         mb_policy: Optional[str] = None,
+        mb_policy_name: str = "accept-all",
         compressed: bool = False,
         count: int = -1,
         skip_pcr_check: bool = False,
@@ -673,6 +698,7 @@ class Tpm:
                 hash_alg,
                 count,
                 skip_data_pcr_check,
+                mb_policy_name=mb_policy_name,
             )
 
         return failure

--- a/keylime/verification/tpm_engine.py
+++ b/keylime/verification/tpm_engine.py
@@ -844,6 +844,7 @@ class TPMEngine(VerificationEngine):
             ima_keyrings=self.attest_state.get_ima_keyrings() if self.attest_state else None,  # type: ignore[arg-type]
             mb_measurement_list=uefi_entries,
             mb_policy=self.uefi_ref_state,
+            mb_policy_name=config.get("verifier", "measured_boot_policy_name", fallback="accept-all"),
             compressed=False,
             count=self.agent.attestation_count,
         )

--- a/test/test_tornado_mb_policy_name.py
+++ b/test/test_tornado_mb_policy_name.py
@@ -1,0 +1,215 @@
+"""
+Unit tests that cover the two call-sites in cloud_verifier_tornado.py where
+mb_policy_name is forwarded to the verifier-common layer:
+
+  1. VerifyEvidenceHandler._tpm_verify()   → process_verify_attestation(... mb_policy_name=...)
+  2. invoke_get_quote()                    → process_quote_response(... mb_policy_name=...)
+
+Both sites were introduced by PR #1879 and had 0 % patch-coverage because no
+unit test exercised them.  These tests keep the mock surface as small as
+possible and verify the argument wiring without running any real TPM logic.
+"""
+
+import json
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import keylime.cloud_verifier_tornado as cvt
+from keylime.cloud_verifier_tornado import VerifyEvidenceHandler
+from keylime.failure import Component, Failure
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _empty_failure() -> Failure:
+    return Failure(Component.DEFAULT)
+
+
+# ---------------------------------------------------------------------------
+# 1.  VerifyEvidenceHandler._tpm_verify()
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyEvidenceHandlerTpmVerify(unittest.TestCase):
+    """
+    Covers keylime/cloud_verifier_tornado.py lines ~1894-1906
+    (the process_verify_attestation call with mb_policy_name).
+    """
+
+    def _make_handler(self):
+        """
+        Build a VerifyEvidenceHandler without a running tornado Application or
+        Request object by bypassing __init__ and setting only the attributes
+        that _tpm_verify() actually reads (none — it only uses module-level
+        symbols).
+        """
+        handler = VerifyEvidenceHandler.__new__(VerifyEvidenceHandler)
+        return handler
+
+    # --- minimal valid data dict that passes all the early-return guards ----
+
+    _VALID_DATA = {
+        "quote": "r/1RDR4AYAC...",
+        "nonce": "deadbeef",
+        "hash_alg": "sha256",
+        "tpm_ek": "-----BEGIN PUBLIC KEY-----\nMIIB...\n-----END PUBLIC KEY-----",
+        "tpm_ak": "-----BEGIN PUBLIC KEY-----\nMIIB...\n-----END PUBLIC KEY-----",
+        "tpm_policy": '{"0": ["0000000000000000000000000000000000000000000000000000000000000000"]}',
+        # optional fields are left absent so we don't trigger extra paths
+    }
+
+    def test_mb_policy_name_read_from_config_and_forwarded(self):
+        """
+        _tpm_verify reads measured_boot_policy_name from config and forwards it
+        to process_verify_attestation as the mb_policy_name keyword argument.
+        """
+        handler = self._make_handler()
+
+        with (
+            patch("keylime.cloud_verifier_tornado.cloud_verifier_common.process_verify_attestation") as mock_pva,
+            patch("keylime.cloud_verifier_tornado.ima.deserialize_runtime_policy") as mock_drp,
+            patch("keylime.cloud_verifier_tornado.config.get", return_value="my-mb-policy") as mock_cfg,
+        ):
+            mock_drp.return_value = None
+            mock_pva.return_value = _empty_failure()
+
+            _data, _failure = handler._tpm_verify(dict(self._VALID_DATA))  # pylint: disable=protected-access
+
+        # config.get must have been called for measured_boot_policy_name
+        mock_cfg.assert_any_call("verifier", "measured_boot_policy_name", fallback="accept-all")
+
+        # process_verify_attestation must have been called with mb_policy_name
+        mock_pva.assert_called_once()
+        call_kw = mock_pva.call_args.kwargs
+        self.assertEqual(
+            call_kw.get("mb_policy_name"),
+            "my-mb-policy",
+            "mb_policy_name must be forwarded from config to process_verify_attestation",
+        )
+
+    def test_default_policy_name_is_accept_all(self):
+        """
+        When config.get returns the fallback, 'accept-all' is passed through.
+        """
+        handler = self._make_handler()
+
+        # Return the fallback value (simulates missing config key)
+        with (
+            patch("keylime.cloud_verifier_tornado.cloud_verifier_common.process_verify_attestation") as mock_pva,
+            patch("keylime.cloud_verifier_tornado.ima.deserialize_runtime_policy", return_value=None),
+            patch("keylime.cloud_verifier_tornado.config.get", return_value="accept-all"),
+        ):  # fallback
+            mock_pva.return_value = _empty_failure()
+            handler._tpm_verify(dict(self._VALID_DATA))  # pylint: disable=protected-access
+
+        self.assertEqual(mock_pva.call_args.kwargs.get("mb_policy_name"), "accept-all")
+
+
+# ---------------------------------------------------------------------------
+# 2.  invoke_get_quote()
+# ---------------------------------------------------------------------------
+
+
+# A minimal HTTP response object with real (non-mock) attribute types so
+# ``response.status_code != 200`` comparisons work correctly.
+class _FakeHTTPResponse:
+    def __init__(self, results_body: dict):
+        self.status_code: int = 200  # real int
+        self.body: bytes = json.dumps({"results": results_body}).encode()
+
+
+class TestInvokeGetQuoteMbPolicyName(unittest.IsolatedAsyncioTestCase):
+    """
+    Covers keylime/cloud_verifier_tornado.py lines ~2220-2226
+    (the process_quote_response call with mb_policy_name inside invoke_get_quote).
+
+    Uses IsolatedAsyncioTestCase so each test gets a fresh event loop.
+    tornado_requests.request is replaced with an AsyncMock that directly
+    returns a _FakeHTTPResponse, matching the ``response = await res`` pattern
+    in invoke_get_quote.
+    """
+
+    _AGENT = {
+        "agent_id": "test-agent-uuid",
+        "ip": "127.0.0.1",
+        "port": 9002,
+        "supported_version": "2.5",
+        "ssl_context": None,
+        "pending_event": None,
+        "provide_V": False,
+    }
+
+    _RESULTS = {
+        "quote": "r/1RDR4AYAC...",
+        "hash_alg": "sha256",
+        "enc_alg": "rsa2048",
+        "sign_alg": "rsassa",
+        "pubkey": "",
+    }
+
+    async def _run_invoke_get_quote(self, config_policy_name: str) -> MagicMock:
+        """
+        Run invoke_get_quote with heavy mocking and return the mock for
+        process_quote_response so callers can assert on it.
+        """
+        # AsyncMock so that ``res = tornado_requests.request(...)`` returns a
+        # coroutine whose await result is _FakeHTTPResponse.
+        mock_request = AsyncMock(return_value=_FakeHTTPResponse(self._RESULTS))
+        mock_pqr = MagicMock(return_value=_empty_failure())
+
+        with (
+            patch("keylime.cloud_verifier_tornado.tornado_requests.request", mock_request),
+            patch(
+                "keylime.cloud_verifier_tornado.cloud_verifier_common.prepare_get_quote",
+                return_value={"nonce": "abc", "mask": "0x0", "ima_ml_entry": 0},
+            ),
+            patch("keylime.cloud_verifier_tornado.cloud_verifier_common.process_quote_response", mock_pqr),
+            patch("keylime.cloud_verifier_tornado.ima.deserialize_runtime_policy", return_value=None),
+            patch("keylime.cloud_verifier_tornado.get_AgentAttestStates") as mock_gas,
+            patch("keylime.cloud_verifier_tornado.asyncio.ensure_future", side_effect=lambda coro: coro.close()),
+            patch("keylime.cloud_verifier_tornado.store_attestation_state"),
+            patch("keylime.cloud_verifier_tornado.shutdown.is_shutting_down", return_value=False),
+            patch("keylime.cloud_verifier_tornado.rmc", None),
+            patch("keylime.cloud_verifier_tornado.config.get", return_value=config_policy_name),
+        ):
+            mock_gas.return_value.get_by_agent_id.return_value = MagicMock()
+            await cvt.invoke_get_quote(
+                dict(self._AGENT),
+                mb_policy="{}",
+                runtime_policy="{}",
+                need_pubkey=False,
+            )
+
+        return mock_pqr
+
+    async def test_mb_policy_name_forwarded_to_process_quote_response(self):
+        """
+        invoke_get_quote reads measured_boot_policy_name from config and
+        forwards it to process_quote_response as the mb_policy_name kwarg.
+        """
+        mock_pqr = await self._run_invoke_get_quote("example-policy")
+
+        mock_pqr.assert_called_once()
+        self.assertEqual(
+            mock_pqr.call_args.kwargs.get("mb_policy_name"),
+            "example-policy",
+            "mb_policy_name must be forwarded from config to process_quote_response",
+        )
+
+    async def test_default_policy_name_fallback(self):
+        """
+        When config returns the fallback, 'accept-all' reaches process_quote_response.
+        """
+        mock_pqr = await self._run_invoke_get_quote("accept-all")
+
+        mock_pqr.assert_called_once()
+        self.assertEqual(
+            mock_pqr.call_args.kwargs.get("mb_policy_name"),
+            "accept-all",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_tpm_check_pcrs.py
+++ b/test/test_tpm_check_pcrs.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for tpm_main.mb_pcrs_to_check().
+
+Tests the intersection of MEASUREDBOOT_PCRS with the active policy's
+get_relevant_pcrs() set, which prevents false failures for PCRs extended
+at runtime (e.g. PCR 11 by systemd-pcrphase).
+"""
+
+import unittest
+from typing import FrozenSet
+from unittest.mock import patch
+
+# Importing example registers the "example" policy (and accept-all / reject-all
+# are registered at module load time in policies.py itself).
+import keylime.mba.elchecking.example  # noqa: F401 – side-effect import
+from keylime.mba.elchecking import policies as mb_policies
+from keylime.mba.elchecking import tests as mb_tests
+from keylime.tpm.tpm_main import mb_pcrs_to_check
+
+# A small, deterministic stand-in for config.MEASUREDBOOT_PCRS.
+# Includes PCR 11 to exercise filtering of runtime-extended PCRs.
+_TEST_MB_PCRS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 14]
+
+
+class TestMbPcrsToCheck(unittest.TestCase):
+    """Tests for mb_pcrs_to_check()."""
+
+    def _run(self, policy_name: str) -> set[int]:
+        with patch("keylime.tpm.tpm_main.config.MEASUREDBOOT_PCRS", _TEST_MB_PCRS):
+            return mb_pcrs_to_check(policy_name)
+
+    def test_accept_all_returns_full_set(self) -> None:
+        """AcceptAll.get_relevant_pcrs() is empty → no filtering."""
+        self.assertEqual(self._run("accept-all"), set(_TEST_MB_PCRS))
+
+    def test_reject_all_returns_full_set(self) -> None:
+        """RejectAll.get_relevant_pcrs() is empty → no filtering."""
+        self.assertEqual(self._run("reject-all"), set(_TEST_MB_PCRS))
+
+    def test_example_policy_excludes_pcr11(self) -> None:
+        """Example policy only cares about PCRs 0-9 and 14; PCR 11 must be excluded."""
+        result = self._run("example")
+        self.assertNotIn(11, result, "PCR 11 should be excluded by the example policy")
+        # All PCRs the example policy declares as relevant that are also in
+        # _TEST_MB_PCRS must be present.
+        example_policy = mb_policies.get_policy("example")
+        assert example_policy is not None
+        example_pcrs = example_policy.get_relevant_pcrs()
+        self.assertEqual(result, set(_TEST_MB_PCRS) & example_pcrs)
+
+    def test_unknown_policy_name_returns_full_set(self) -> None:
+        """An unregistered policy name falls back to the full MEASUREDBOOT_PCRS."""
+        self.assertEqual(self._run("no-such-policy"), set(_TEST_MB_PCRS))
+
+    def test_custom_policy_with_single_pcr(self) -> None:
+        """A policy that declares only PCR 0 as relevant limits the set to {0}."""
+
+        class _SinglePCR(mb_policies.Policy):
+            def get_relevant_pcrs(self) -> FrozenSet[int]:
+                return frozenset({0})
+
+            def refstate_to_test(self, refstate: mb_policies.RefState) -> mb_tests.Test:  # pragma: no cover
+                raise NotImplementedError
+
+        mb_policies.register("_test_single_pcr", _SinglePCR())
+        try:
+            result = self._run("_test_single_pcr")
+            self.assertEqual(result, {0})
+        finally:
+            # Clean up the temporary test registration.
+            mb_policies._registry.pop("_test_single_pcr", None)

--- a/test/test_tpm_check_pcrs.py
+++ b/test/test_tpm_check_pcrs.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for tpm_main.mb_pcrs_to_check().
+
+Tests the intersection of MEASUREDBOOT_PCRS with the active policy's
+get_relevant_pcrs() set, which prevents false failures for PCRs extended
+at runtime (e.g. PCR 11 by systemd-pcrphase).
+"""
+
+import unittest
+from typing import FrozenSet
+from unittest.mock import patch
+
+# Importing example registers the "example" policy (and accept-all / reject-all
+# are registered at module load time in policies.py itself).
+import keylime.mba.elchecking.example  # noqa: F401  # pylint: disable=unused-import
+from keylime.mba.elchecking import policies as mb_policies
+from keylime.mba.elchecking import tests as mb_tests
+from keylime.tpm.tpm_main import Tpm
+
+# A small, deterministic stand-in for config.MEASUREDBOOT_PCRS.
+# Includes PCR 11 to exercise filtering of runtime-extended PCRs.
+_TEST_MB_PCRS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 14]
+
+
+class TestMbPcrsToCheck(unittest.TestCase):
+    """Tests for mb_pcrs_to_check()."""
+
+    def _run(self, policy_name: str) -> set[int]:
+        with patch("keylime.tpm.tpm_main.config.MEASUREDBOOT_PCRS", _TEST_MB_PCRS):
+            return Tpm.mb_pcrs_to_check(policy_name)
+
+    def test_accept_all_returns_full_set(self) -> None:
+        """AcceptAll.get_relevant_pcrs() is empty → no filtering."""
+        self.assertEqual(self._run("accept-all"), set(_TEST_MB_PCRS))
+
+    def test_reject_all_returns_full_set(self) -> None:
+        """RejectAll.get_relevant_pcrs() is empty → no filtering."""
+        self.assertEqual(self._run("reject-all"), set(_TEST_MB_PCRS))
+
+    def test_example_policy_excludes_pcr11(self) -> None:
+        """Example policy only cares about PCRs 0-9 and 14; PCR 11 must be excluded."""
+        result = self._run("example")
+        self.assertNotIn(11, result, "PCR 11 should be excluded by the example policy")
+        # All PCRs the example policy declares as relevant that are also in
+        # _TEST_MB_PCRS must be present.
+        example_policy = mb_policies.get_policy("example")
+        assert example_policy is not None
+        example_pcrs = example_policy.get_relevant_pcrs()
+        self.assertEqual(result, set(_TEST_MB_PCRS) & example_pcrs)
+
+    def test_unknown_policy_name_returns_full_set(self) -> None:
+        """An unregistered policy name falls back to the full MEASUREDBOOT_PCRS."""
+        self.assertEqual(self._run("no-such-policy"), set(_TEST_MB_PCRS))
+
+    def test_custom_policy_with_single_pcr(self) -> None:
+        """A policy that declares only PCR 0 as relevant limits the set to {0}."""
+
+        class _SinglePCR(mb_policies.Policy):
+            def get_relevant_pcrs(self) -> FrozenSet[int]:
+                return frozenset({0})
+
+            def refstate_to_test(self, refstate: mb_policies.RefState) -> mb_tests.Test:  # pragma: no cover
+                raise NotImplementedError
+
+        mb_policies.register("_test_single_pcr", _SinglePCR())
+        try:
+            result = self._run("_test_single_pcr")
+            self.assertEqual(result, {0})
+        finally:
+            # Clean up the temporary test registration.
+            mb_policies.unregister("_test_single_pcr")


### PR DESCRIPTION

# PR Title 
Use only policy's relevant PCRs for tpm event log verification

## Type of Change
*(Select all that apply)*
- [ ] Bug fix (non-breaking change)
- [X] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Change Description

Use only policy's relevant PCRs for tpm event log verification

Intersect MEASUREDBOOT_PCRS with the active policy's get_relevant_pcrs() set for the PCR replay check. PCRs outside the policy's set may have runtime extensions not in the event log (e.g. PCR 11 from systemd-pcrphase).

This is backwards compatible: policies that return all PCRs (or an empty set) behave as before.

## Documentation Updates Required
*(Check all that apply)*
- [X] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [ ] No docs needed (requires maintainer approval)

## Checklist
- [X] Code follows project style guidelines
- [X] Unit/integration tests added/updated
- [X] Documentation updated (per above section)
- [X] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [X] All tests pass (local & CI)

## Additional Context
*(Optional: follow-up tasks, special considerations)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Measured-boot verification now respects a configured measured-boot policy name and limits PCR replay/validation to only those PCRs the active policy marks relevant; if the active policy is absent or reports no relevant PCRs, all configured measured-boot PCRs are validated. Verification and attestation flows accept an explicit measured-boot policy name to control this.

* **Documentation**
  * User guide clarifies PCR replay validation behavior and the empty-policy edge case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->