### PR TITLE
docs: Fix verifier REST API docs and add undocumented endpoints

### DIFF
--- a/docs/rest_apis/2_1/verifier.rst
+++ b/docs/rest_apis/2_1/verifier.rst
@@ -292,19 +292,11 @@ Verifier
     :>json list[string] runtimepolicy names: List of names of the runtime policies.
 
 
-.. http:delete::  /v2.1/allowlist/{runtime_policy_name:string}
+.. http:delete::  /v2.1/allowlists/{runtime_policy_name:string}
 
     Delete IMA policy `runtime_policy_name`.
 
-    **Example response**:
-
-    .. sourcecode:: json
-
-        {
-          "code": 200,
-          "status": "Success",
-          "results": {}
-        }
+    Returns HTTP 204 with empty body on success.
 
     :>json int code: HTTP status code
     :>json string status: Status as string

--- a/docs/rest_apis/2_2/verifier.rst
+++ b/docs/rest_apis/2_2/verifier.rst
@@ -295,19 +295,11 @@ Verifier
     :>json list[string] runtimepolicy names: List of names of the runtime policies.
 
 
-.. http:delete::  /v2.2/allowlist/{runtime_policy_name:string}
+.. http:delete::  /v2.2/allowlists/{runtime_policy_name:string}
 
     Delete IMA policy `runtime_policy_name`.
 
-    **Example response**:
-
-    .. sourcecode:: json
-
-        {
-          "code": 200,
-          "status": "Success",
-          "results": {}
-        }
+    Returns HTTP 204 with empty body on success.
 
     :>json int code: HTTP status code
     :>json string status: Status as string

--- a/docs/rest_apis/2_3/verifier.rst
+++ b/docs/rest_apis/2_3/verifier.rst
@@ -276,19 +276,11 @@ Verifier
     :>json list[string] runtimepolicy names: List of names of the runtime policies.
 
 
-.. http:delete::  /v2.3/allowlist/{runtime_policy_name:string}
+.. http:delete::  /v2.3/allowlists/{runtime_policy_name:string}
 
     Delete IMA policy `runtime_policy_name`.
 
-    **Example response**:
-
-    .. sourcecode:: json
-
-        {
-          "code": 200,
-          "status": "Success",
-          "results": {}
-        }
+    Returns HTTP 204 with empty body on success.
 
     :>json int code: HTTP status code
     :>json string status: Status as string

--- a/docs/rest_apis/2_4/verifier.rst
+++ b/docs/rest_apis/2_4/verifier.rst
@@ -276,19 +276,11 @@ Verifier
     :>json list[string] runtimepolicy names: List of names of the runtime policies.
 
 
-.. http:delete::  /v2.4/allowlist/{runtime_policy_name:string}
+.. http:delete::  /v2.4/allowlists/{runtime_policy_name:string}
 
     Delete IMA policy `runtime_policy_name`.
 
-    **Example response**:
-
-    .. sourcecode:: json
-
-        {
-          "code": 200,
-          "status": "Success",
-          "results": {}
-        }
+    Returns HTTP 204 with empty body on success.
 
     :>json int code: HTTP status code
     :>json string status: Status as string

--- a/docs/rest_apis/2_5/verifier.rst
+++ b/docs/rest_apis/2_5/verifier.rst
@@ -1,6 +1,30 @@
 Verifier
 ~~~~~~~~
 
+.. http:get::  /v2.5/agents/
+
+    Get ordered list of agents enrolled in the Verifier.
+
+    **Example response**:
+
+    .. sourcecode:: json
+
+        {
+          "code": 200,
+          "status": "Success",
+          "results": {
+            "uuids": [
+              "d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
+            ]
+          }
+        }
+
+    :>json int code: HTTP status code
+    :>json string status: Status as string
+    :>json object results: Results as a JSON object
+    :>json list uuids: List of enrolled agent UUIDs
+
+
 .. http:get::  /v2.5/agents/{agent_id:UUID}
 
     Get status of agent `agent_id` from Verifier
@@ -276,23 +300,11 @@ Verifier
     :>json list[string] runtimepolicy names: List of names of the runtime policies.
 
 
-.. http:delete::  /v2.5/allowlist/{runtime_policy_name:string}
+.. http:delete::  /v2.5/allowlists/{runtime_policy_name:string}
 
     Delete IMA policy `runtime_policy_name`.
 
-    **Example response**:
-
-    .. sourcecode:: json
-
-        {
-          "code": 200,
-          "status": "Success",
-          "results": {}
-        }
-
-    :>json int code: HTTP status code
-    :>json string status: Status as string
-    :>json object results: Results as a JSON object (empty)
+    Returns HTTP 204 with empty body on success.
 
 
 .. http:get::  /v2.5/verify/identity
@@ -331,9 +343,9 @@ Verifier
     :<json int valid: A boolean 1 for valid, 0 for invalid identity.
 
 
-.. http:get::  /v2.5/mbpolicies/{policy_name:string}
+.. http:get::  /v2.5/mbpolicies/[policy_name:string]
 
-    Get the measured boot policy named `policy_name`
+    If `policy_name` is provided, get the named measured boot policy from the Verifier.
 
     **Example response**:
 
@@ -343,13 +355,75 @@ Verifier
           "code": 200,
           "status": "Success",
           "results": {
+            "name": "my-mb-policy",
+            "mb_policy": "{...}"
           }
         }
 
     :>json int code: HTTP status code
     :>json string status: Status as string
     :>json object results: Results as a JSON object
-    :<json int valid: A boolean 1 for valid, 0 for invalid identity.
+    :>json string name: Name of the requested measured boot policy.
+    :>json string mb_policy: Measured boot policy JSON object.
+
+
+    Otherwise, retrieve list of names of the measured boot policies.
+
+    **Example response**:
+
+    .. sourcecode:: json
+
+        {
+          "code": 200,
+          "status": "Success",
+          "results": {
+            "mbpolicy names": [
+                "mbpolicyname1",
+                "mbpolicyname2"
+            ]
+          }
+        }
+
+    :>json int code: HTTP status code
+    :>json string status: Status as string
+    :>json object results: Results as a JSON object
+    :>json list[string] mbpolicy names: List of names of the measured boot policies.
+
+
+.. http:post::  /v2.5/mbpolicies/{policy_name:string}
+
+    Add new named measured boot policy `policy_name` to Verifier.
+
+    **Example request**:
+
+    .. sourcecode:: json
+
+        {
+          "mb_policy": "{...}"
+        }
+
+    :<json string mb_policy: Measured boot reference state policy JSON object.
+
+    **Example response**:
+
+    .. sourcecode:: json
+
+        {
+          "code": 200,
+          "status": "Success",
+          "results": {}
+        }
+
+    :>json int code: HTTP status code
+    :>json string status: Status as string
+    :>json object results: Results as a JSON object (empty)
+
+
+.. http:delete::  /v2.5/mbpolicies/{policy_name:string}
+
+    Delete measured boot policy `policy_name`.
+
+    Returns HTTP 204 with empty body on success.
 
 .. http:post::  /v2.5/verify/evidence
 


### PR DESCRIPTION
## Type of Change
*(Select all that apply)*
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ x] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
none

## Change Description

### Concise Summary
Fix incorrect and missing verifier REST API documentation 

### Technical Details
 
  The verifier REST API documentation had several inaccuracies and missing endpoints compared to the actual implementation:                     
   
  - Wrong endpoint path: DELETE /v{2.1-2.5}/allowlist/{name} used singular allowlist instead of the correct plural allowlists                   
  - Wrong response code: DELETE allowlists was documented as returning HTTP 200 with a JSON body, but the implementation returns HTTP 204 with
  an empty body                                                                                                                                 
  - Missing endpoints in v2.5: GET /agents/, POST /mbpolicies/{name}, and DELETE /mbpolicies/{name} were not documented at all
  - Incorrect mbpolicies GET docs: GET /mbpolicies/ supports both listing all policies and fetching a specific one; only the single-policy      
  variant was documented, and its response fields were wrong 

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ x] Needs ReadTheDocs updates
- [ ] No docs needed (requires maintainer approval)

## Verification Process
  1. Compare documented endpoints against route definitions in keylime/verifier.py                                                              
  2. Build the RST docs locally and verify they render correctly
  3. Test the actual API responses against documented status codes and response bodies 

## Checklist
- [ x] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [ x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [ ] All tests pass (local & CI)

## Additional Context
*(Optional: follow-up tasks, special considerations)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated runtime policy deletion endpoints for API versions v2.1–v2.5 to use the pluralized path and document successful deletion as HTTP 204 with an empty response body.
  * Added a v2.5 endpoint for retrieving an ordered list of enrolled agent UUIDs.
  * Expanded v2.5 measured-boot policy management with optional policy-name queries and endpoints for creating and deleting policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->