### PR TITLE
shared_data: Ignore SIGTERM and SIGINT on Manager and parent processes

### DIFF
--- a/keylime/shared_data.py
+++ b/keylime/shared_data.py
@@ -8,13 +8,26 @@ import atexit
 import multiprocessing as mp
 import multiprocessing.process
 import os
+import signal
 import threading
 import time
+from multiprocessing.managers import SyncManager
 from typing import Any, Dict, List, Optional
 
 from keylime import keylime_logging
 
 logger = keylime_logging.init_logging("shared_data")
+
+
+def _manager_ignore_signals() -> None:
+    """Ignore SIGTERM and SIGINT in the Manager's server process.
+
+    Called as the ``initializer`` for ``SyncManager.start()`` so that
+    the Manager survives process-group signals (systemd SIGTERM, Ctrl+C)
+    and stays available while workers drain in-flight work.
+    """
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 
 class FlatDictView:
@@ -127,7 +140,20 @@ class SharedDataManager:
         # Use explicit context to ensure fork compatibility
         # The Manager must be started BEFORE any fork() calls
         ctx = mp.get_context("fork")
-        self._manager = ctx.Manager()
+        # Use SyncManager directly (instead of the ctx.Manager() shortcut)
+        # so we can pass an initializer that makes the Manager's server
+        # process ignore SIGTERM and SIGINT.  Without this, systemd's
+        # cgroup-wide SIGTERM (or Ctrl+C SIGINT in foreground) kills the
+        # Manager before workers finish draining, causing
+        # ConnectionResetError in proxy objects.  The Manager is still
+        # cleanable via IPC shutdown message, process.kill(), or systemd
+        # SIGKILL escalation.
+        # Cannot use 'with' context manager here: the Manager must outlive
+        # __init__ and persist for the lifetime of SharedDataManager.
+        self._manager = SyncManager(ctx=ctx)
+        self._manager.start(  # pylint: disable=consider-using-with
+            initializer=_manager_ignore_signals,
+        )
 
         # CRITICAL FIX: Use a SINGLE flat dict instead of nested dicts
         # Nested DictProxy objects have synchronization issues

--- a/keylime/web/base/server.py
+++ b/keylime/web/base/server.py
@@ -376,11 +376,29 @@ class Server(ABC):
 
         self._pre_fork()
 
+        # Ignore SIGTERM/SIGINT in the parent so it stays in tornado's
+        # monitor loop (os.wait) until all children have drained and
+        # exited cleanly.  Once all children exit, tornado calls
+        # sys.exit(0) which triggers atexit → SharedDataManager.cleanup()
+        # → Manager shutdown via IPC.  Without this, the default signal
+        # disposition kills the parent immediately (no atexit), leaving
+        # the Manager process orphaned.
+        # Children inherit SIG_IGN but override it in
+        # _install_signal_handlers() before entering the event loop.
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+
         # with StatsCollector():
         # num = manager.Value('i', 0)
         task_id = tornado.process.fork_processes(self.worker_count)
         # num.value = num.value + 1
         # print(num.value)
+
+        # Restore default signal disposition in children so they don't
+        # silently ignore SIGTERM/SIGINT before _install_signal_handlers()
+        # replaces these with asyncio-based handlers in start_single().
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
 
         # Remove the Manager's server process from multiprocessing's child
         # tracking so Python's atexit handler does not try to join() it in

--- a/test/test_verifier_server.py
+++ b/test/test_verifier_server.py
@@ -300,10 +300,15 @@ class TestVerifierServerEngineDisposal(unittest.TestCase):
         assert match is not None
         method_body = match.group(0)
 
+        # Strip comment lines to avoid false matches from mentions
+        # in comments (e.g. "# ... before start_single()").
+        code_lines = [line for line in method_body.splitlines() if not line.lstrip().startswith("#")]
+        code_body = "\n".join(code_lines)
+
         # Extract the order of operations
-        fork_index = method_body.find("fork_processes")
-        post_fork_index = method_body.find("_post_fork")
-        start_single_index = method_body.find("start_single()")
+        fork_index = code_body.find("fork_processes")
+        post_fork_index = code_body.find("_post_fork")
+        start_single_index = code_body.find("start_single()")
 
         # All should be present
         self.assertNotEqual(fork_index, -1, "fork_processes call not found")


### PR DESCRIPTION
# shared_data: Ignore SIGTERM and SIGINT on Manager and parent processes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Tests (adding or updating tests)
- [ ] CI/CD changes
- [ ] Other (please describe)

## Related Issues

Resolves: #1882

## Change Description

### Concise Summary

When systemd stops the verifier (or registrar), SIGTERM is delivered to the entire process group — including the multiprocessing Manager's server process that hosts the shared policy cache. The Manager dies immediately, but worker processes still have in-flight `process_agent()` coroutines that need the cache, causing `ConnectionResetError` in proxy objects. The same race occurs with SIGINT (Ctrl+C) when running the daemon in the foreground.

### Technical Details

**Motivation:** Two problems cause the Manager to die before workers finish draining:

1. The `SharedDataManager` creates its Manager via `ctx.Manager()`, a shortcut for `SyncManager().start()` without arguments. The Manager's server process inherits default signal handling and dies on SIGTERM/SIGINT before workers finish.

2. In the new server architecture (`web/base/server.py`), the parent process has no signal handler — `tornado.process.fork_processes()` puts it in a monitor loop (`os.wait`), and the default SIGTERM disposition kills it immediately without running atexit handlers. This means `SharedDataManager.cleanup()` never calls `manager.shutdown()`, leaving the Manager orphaned.

**Fix (two parts):**

1. **Manager process** (`shared_data.py`): Replace `ctx.Manager()` with explicit `SyncManager(ctx=ctx)` + `start(initializer=_manager_ignore_signals)`, where `_manager_ignore_signals()` installs `SIG_IGN` for both SIGTERM and SIGINT. The Manager survives process-group signals and stays available while workers drain.

2. **Parent process** (`web/base/server.py`): Install `SIG_IGN` for SIGTERM and SIGINT in the parent before `fork_processes()`, so it stays in tornado's monitor loop until all children have drained and exited cleanly. Once all children exit, tornado calls `sys.exit(0)`, triggering atexit → `SharedDataManager.cleanup()` → Manager shutdown via IPC. Children inherit `SIG_IGN` but restore `SIG_DFL` immediately after `fork_processes()` returns, before any post-fork initialization. This ensures children are terminable during the brief window before `_install_signal_handlers()` replaces the default handlers with asyncio-based ones in `start_single()`.

**Shutdown flow after fix:**

1. systemd sends SIGTERM to the cgroup
2. Manager ignores SIGTERM — stays alive for IPC
3. Parent ignores SIGTERM — stays in `os.wait()` loop
4. Children restore SIG_DFL immediately after fork, then install asyncio handlers → drain in-flight work → exit cleanly
5. Tornado's monitor loop sees all children exited → calls `sys.exit(0)`
6. Parent's atexit runs → `SharedDataManager.cleanup()` → `manager.shutdown()` via IPC
7. Manager receives IPC shutdown message → exits cleanly

**Why this is safe — the Manager is always cleaned up via:**

1. **Normal shutdown:** `manager.shutdown()` sends an IPC `'shutdown'` message (not a signal) via the atexit handler, and the Manager exits cleanly.
2. **Fallback:** Python's `_finalize_manager` escalates: IPC shutdown → `process.terminate()` (SIGTERM) → `process.kill()` (SIGKILL, cannot be ignored).
3. **Last resort:** systemd sends SIGKILL to the entire cgroup after `TimeoutStopSec`, which also cannot be ignored.

**Side effects:** None. The Manager's IPC protocol is unchanged. Only the OS-level signal dispositions for SIGTERM and SIGINT are affected in the Manager's server process and the parent process.

**Alternatives considered:**

- Setting `SIG_IGN` in the parent before creating the Manager and restoring after — works for `fork` context but briefly leaves the parent unable to handle SIGTERM.
- Changing systemd's `KillMode` — deployment config change, not a code fix.
- Catching `ConnectionResetError` in workers during shutdown — defensive but doesn't solve the root cause (cache data is lost).
- Raising `SystemExit(0)` in the parent's signal handler — exits the parent before children finish draining, causing the Manager to be shut down too early.

## Documentation Updates Required

- [ ] Configuration file changes
- [ ] User guide updates
- [ ] API documentation
- [ ] Man pages
- [x] No documentation changes needed

## Verification Process

1. **Environment:** Verifier running with multiple workers and agents in PULL mode.
2. **Procedure:** Send SIGTERM (or SIGINT via Ctrl+C) to the verifier service while attestation is in progress.
3. **Expected result (before fix):** `ConnectionResetError` tracebacks in worker logs when in-flight `process_agent()` accesses the shared policy cache, or Manager process orphaned until systemd SIGKILL timeout.
4. **Expected result (after fix):** Clean shutdown — workers drain in-flight work, parent waits for all children to exit, then atexit shuts down the Manager via IPC.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] I have written clear commit messages
- [ ] I have updated CHANGELOG if applicable
- [x] All new and existing tests pass

## Additional Context

> This PR was generated with the assistance of Claude Opus 4.6 (Anthropic).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved process manager initialization to better handle termination signals in multi-process environments.
* Enhanced shutdown stability by preventing signal interruption of critical parent-child process flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->