### PR TITLE
Fix timezone handling in Unix timestamp conversion

### DIFF
--- a/keylime/models/base/types/timestamp.py
+++ b/keylime/models/base/types/timestamp.py
@@ -36,7 +36,7 @@ class Timestamp(ModelType):
 
         if not ts:
             try:
-                ts = datetime.fromtimestamp(float(value))
+                ts = datetime.fromtimestamp(float(value), tz=timezone.utc)
             except ValueError:
                 pass
 
@@ -49,7 +49,7 @@ class Timestamp(ModelType):
         return self._load_datetime(ts)
 
     def _load_float(self, value: float) -> datetime:
-        ts = datetime.fromtimestamp(value)
+        ts = datetime.fromtimestamp(value, tz=timezone.utc)
         return self._load_datetime(ts)
 
     def _load_int(self, value: int) -> datetime:

--- a/test/test_timestamp.py
+++ b/test/test_timestamp.py
@@ -177,6 +177,20 @@ class TestTimestampLoadNumeric(unittest.TestCase):
         self.assertEqual(result.month, 1)
         self.assertEqual(result.day, 1)
 
+    def test_load_int_has_utc_timezone(self):
+        """Test that Unix timestamp conversion results in UTC timezone"""
+        ts = Timestamp()
+        unix_int = 1705314645  # Jan 15, 2024 10:30:45 UTC
+
+        result = ts._load_int(unix_int)  # pylint: disable=protected-access
+
+        # This will fail if fromtimestamp() doesn't specify tz=timezone.utc
+        self.assertEqual(result.tzinfo, timezone.utc)
+        # Also verify the time is correct in UTC
+        self.assertEqual(result.hour, 10)
+        self.assertEqual(result.minute, 30)
+        self.assertEqual(result.second, 45)
+
 
 class TestTimestampCast(unittest.TestCase):
     """Test cases for Timestamp.cast() method"""


### PR DESCRIPTION
## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [x] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Change Description

### Concise Summary
Fix datetime.fromtimestamp() calls to explicitly use UTC timezone instead of relying on system local timezone. Without the tz parameter, fromtimestamp() returns timestamps in the local timezone, causing incorrect datetime values on systems with non-UTC timezone settings.

Changes:
- Add tz=timezone.utc parameter to fromtimestamp() calls in _load_str() and _load_float() methods
- Add test_load_int_has_utc_timezone test that reliably validates UTC timezone handling by checking both tzinfo and time components

### Technical Details
 
  Analysis of the Test Failure

  The test test_load_int_zero (line 170-178 in test_timestamp.py:176) is failing because it expects Unix timestamp 0 to convert to January 1, 1970
   at 00:00:00 UTC (the Unix epoch), but it's getting year 1969 instead of 1970.

  Root Cause

  The issue is in the _load_float() and _load_int() methods in timestamp.py:51-56:

  def _load_float(self, value: float) -> datetime:
      ts = datetime.fromtimestamp(value)
      return self._load_datetime(ts)

  def _load_int(self, value: int) -> datetime:
      return self._load_float(float(value))

  The problem is that datetime.fromtimestamp() without specifying a timezone uses the system's local timezone, not UTC.

  When the test runs:
  1. _load_int(0) calls _load_float(0.0)
  2. _load_float(0.0) calls datetime.fromtimestamp(0.0) - this interprets 0 as seconds since epoch in the local timezone
  3. If the system is in a timezone behind UTC (like EST/UTC-5), fromtimestamp(0) returns December 31, 1969, 19:00:00 (local time)
  4. Then _load_datetime() converts this to UTC, but since it's a naive datetime, it just adds UTC timezone without converting, resulting in 1969

  The Fix

  The fix is to explicitly specify tz=timezone.utc when calling fromtimestamp():

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. Describe test environment
2. Step-by-step validation procedure
3. Expected vs actual results

New test case added.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [ ] Documentation updated (per above section)
- [ ] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [ ] All tests pass (local & CI)
