### PR TITLE
Move SyncManager socket to /var/run/keylime to resolve SELinux AVC denials

### DIFF
--- a/keylime/shared_data.py
+++ b/keylime/shared_data.py
@@ -18,6 +18,23 @@ from keylime import keylime_logging
 
 logger = keylime_logging.init_logging("shared_data")
 
+_RUNTIME_DIR = "/var/run/keylime"
+
+
+def _ensure_runtime_dir() -> None:
+    """Ensure the runtime directory exists with correct permissions.
+
+    Under systemd, ``tmpfiles.d`` creates ``/var/run/keylime/`` at boot.
+    This function provides a fallback for non-systemd execution and
+    validates permissions in either case.
+    """
+    os.makedirs(_RUNTIME_DIR, mode=0o700, exist_ok=True)
+    perms = os.stat(_RUNTIME_DIR).st_mode & 0o777
+    if perms != 0o700 or not os.access(_RUNTIME_DIR, os.W_OK | os.X_OK):
+        msg = f"{_RUNTIME_DIR} is not usable by the current process"
+        logger.error(msg)
+        raise PermissionError(msg)
+
 
 def _manager_ignore_signals() -> None:
     """Ignore SIGTERM and SIGINT in the Manager's server process.
@@ -137,8 +154,20 @@ class SharedDataManager:
         """
         logger.debug("Initializing SharedDataManager")
 
-        # Use explicit context to ensure fork compatibility
-        # The Manager must be started BEFORE any fork() calls
+        # Ensure /var/run/keylime/ exists with correct permissions
+        # before forking the Manager server process.
+        _ensure_runtime_dir()
+        self._socket_path = os.path.join(_RUNTIME_DIR, f"shared_data.{os.getpid()}.sock")
+
+        # Remove stale socket from a previous run (e.g. after a crash).
+        # CPython's SocketListener does not pre-unlink before bind().
+        try:
+            os.unlink(self._socket_path)
+        except (FileNotFoundError, PermissionError):
+            pass
+
+        # Use explicit context to ensure fork compatibility.
+        # The Manager must be started BEFORE any fork() calls.
         ctx = mp.get_context("fork")
         # Use SyncManager directly (instead of the ctx.Manager() shortcut)
         # so we can pass an initializer that makes the Manager's server
@@ -150,7 +179,7 @@ class SharedDataManager:
         # SIGKILL escalation.
         # Cannot use 'with' context manager here: the Manager must outlive
         # __init__ and persist for the lifetime of SharedDataManager.
-        self._manager = SyncManager(ctx=ctx)
+        self._manager = SyncManager(address=self._socket_path, ctx=ctx)
         self._manager.start(  # pylint: disable=consider-using-with
             initializer=_manager_ignore_signals,
         )
@@ -162,8 +191,6 @@ class SharedDataManager:
         self._lock = self._manager.Lock()
         self._initialized_at = time.time()
 
-        # Register handler to reinitialize manager connection after fork
-        # This is needed because Manager uses network connections that don't survive fork
         try:
             self._parent_pid = os.getpid()
             logger.debug("SharedDataManager initialized in process %d", self._parent_pid)
@@ -173,7 +200,10 @@ class SharedDataManager:
         # Ensure cleanup on exit
         atexit.register(self.cleanup)
 
-        logger.info("SharedDataManager initialized successfully")
+        logger.info(
+            "SharedDataManager initialized successfully (socket: %s)",
+            self._socket_path,
+        )
 
     def set_data(self, key: str, value: Any) -> None:
         """Store arbitrary pickleable data by key.
@@ -332,6 +362,18 @@ class SharedDataManager:
             logger.info("SharedDataManager shutdown complete")
         except Exception:
             logger.exception("Error during SharedDataManager shutdown")
+
+        # Remove socket file if it still exists.  The Manager server
+        # process normally unlinks it on exit, but if it was killed
+        # (SIGKILL) the file may be left behind.
+        socket_path = getattr(self, "_socket_path", None)
+        if socket_path:
+            try:
+                os.unlink(socket_path)
+            except FileNotFoundError:
+                pass
+            except OSError as e:
+                logger.debug("Could not remove socket file %s: %s", socket_path, e)
 
     def deregister_child(self) -> None:
         """Remove the Manager's server process from multiprocessing's child tracking.

--- a/services/installer.sh
+++ b/services/installer.sh
@@ -11,7 +11,7 @@ fi
 BASEDIR=$(dirname "$0")
 
 # check keylime scripts directory (same for verifier, agent, registrar)
-KEYLIMEDIR=$(dirname $(whereis keylime_verifier | cut -d " " -f 2))
+KEYLIMEDIR=$(dirname "$(whereis keylime_verifier | cut -d " " -f 2)")
 if [[ $KEYLIMEDIR == "." ]]; then
     echo "Unable to find keylime scripts" 1>&2
     exit 1
@@ -20,8 +20,8 @@ fi
 echo "Using keylime scripts directory: ${KEYLIMEDIR}"
 
 # prepare keylime service files and store them in systemd path
-sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" $BASEDIR/keylime_registrar.service.template > /etc/systemd/system/keylime_registrar.service
-sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" $BASEDIR/keylime_verifier.service.template > /etc/systemd/system/keylime_verifier.service
+sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" "$BASEDIR/keylime_registrar.service.template" > /etc/systemd/system/keylime_registrar.service
+sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" "$BASEDIR/keylime_verifier.service.template" > /etc/systemd/system/keylime_verifier.service
 
 echo "Creating keylime user if it not exists"
 if ! getent passwd keylime >/dev/null; then
@@ -30,22 +30,55 @@ if ! getent passwd keylime >/dev/null; then
             keylime
 fi
 
-echo "Changing files to be owned by the keylime user"
-# Create all directories required if not there
-mkdir -p /var/lib/keylime
-mkdir -p /var/log/keylime
-mkdir -p /var/run/keylime
+# install TPM certificate store to /usr/share/keylime/
+# tmpfiles.d will copy this to /var/lib/keylime/tpm_cert_store
+TPM_CERT_STORE_SRC="$BASEDIR/../tpm_cert_store"
+if [[ ! -d "$TPM_CERT_STORE_SRC" ]]; then
+    echo "Missing TPM certificate store: $TPM_CERT_STORE_SRC" 1>&2
+    exit 1
+fi
 
-chown keylime:keylime -R /etc/keylime
-chown keylime:keylime -R /var/lib/keylime
-chown keylime:keylime -R /var/log/keylime
-chown keylime:keylime -R /var/run/keylime
+mkdir -p /usr/share/keylime
+cp -a "$TPM_CERT_STORE_SRC" /usr/share/keylime/ || exit 1
+
+# install tmpfiles.d config for keylime directories
+mkdir -p /usr/lib/tmpfiles.d
+cp "$BASEDIR/keylime-tmpfiles.conf" /usr/lib/tmpfiles.d/keylime.conf
+
+# apply the tmpfiles.d config immediately to create directories with correct ownership
+if command -v systemd-tmpfiles >/dev/null 2>&1; then
+    systemd-tmpfiles --create keylime.conf
+else
+    echo "Warning: systemd-tmpfiles not found, creating directories manually"
+    # Create essential directories as fallback for non-systemd systems
+    mkdir -p /var/run/keylime /var/lib/keylime \
+        /etc/keylime/ca.conf.d \
+        /etc/keylime/logging.conf.d \
+        /etc/keylime/verifier.conf.d \
+        /etc/keylime/registrar.conf.d \
+        /etc/keylime/tenant.conf.d \
+        /etc/keylime/agent.conf.d
+    chown keylime:keylime /var/run/keylime /var/lib/keylime
+    chmod 700 /var/run/keylime /var/lib/keylime
+    # Mirror tmpfiles.d Z/z semantics: recursively set ownership and
+    # file permissions under /etc/keylime, then fix directories to 0500.
+    chown -R keylime:keylime /etc/keylime
+    find /etc/keylime -type f -exec chmod 400 {} \;
+    find /etc/keylime -type d -exec chmod 500 {} \;
+    # Copy TPM cert store from /usr/share to /var/lib only if the
+    # target does not exist yet (mirrors the tmpfiles.d C directive).
+    # This preserves operator-added EK certificates.
+    if [ -d /usr/share/keylime/tpm_cert_store ] && [ ! -d /var/lib/keylime/tpm_cert_store ]; then
+        cp -r /usr/share/keylime/tpm_cert_store /var/lib/keylime/
+        chown -R keylime:keylime /var/lib/keylime/tpm_cert_store
+        find /var/lib/keylime/tpm_cert_store -type f -exec chmod 400 {} \;
+        chmod 500 /var/lib/keylime/tpm_cert_store
+    fi
+fi
 
 # set permissions
 chmod 664 /etc/systemd/system/keylime_registrar.service
 chmod 664 /etc/systemd/system/keylime_verifier.service
-
-chmod 700 /var/run/keylime
 
 # enable at startup
 systemctl enable keylime_registrar.service

--- a/services/keylime-tmpfiles.conf
+++ b/services/keylime-tmpfiles.conf
@@ -1,0 +1,40 @@
+d /run/keylime 0700 keylime keylime -
+
+d /var/lib/keylime 0700 keylime keylime -
+
+d /etc/keylime 0500 keylime keylime -
+d /etc/keylime/ca.conf.d 0500 keylime keylime -
+d /etc/keylime/logging.conf.d 0500 keylime keylime -
+d /etc/keylime/verifier.conf.d 0500 keylime keylime -
+d /etc/keylime/registrar.conf.d 0500 keylime keylime -
+d /etc/keylime/tenant.conf.d 0500 keylime keylime -
+d /etc/keylime/agent.conf.d 0500 keylime keylime -
+
+# TPM certificate store.
+# Copy the cert store from /usr/share/keylime/tpm_cert_store
+# to /var/lib/keylime/tpm_cert_store.
+# Files inside /var/lib/keylime/tpm_cert_store/ have
+# 0400 permission and are owned by keylime/keylime,
+# while /var/lib/keylime/tpm_cert_store/ itself has
+# permission 0500, also owned by keylime/keylime.
+C /var/lib/keylime/tpm_cert_store 0500 keylime keylime - /usr/share/keylime/tpm_cert_store
+Z /var/lib/keylime/tpm_cert_store 0400 keylime keylime -
+z /var/lib/keylime/tpm_cert_store 0500 keylime keylime -
+# Finally, /var/lib/keylime itself has 0700 permission,
+# and is owned by keylime/keylime.
+z /var/lib/keylime 0700 keylime keylime -
+
+# Keylime configuration in /etc/keylime has permission 0400
+# owned by keylime/keylime, while snippet directories and
+# the actual /etc/keylime directory have permission 0500,
+# also owned by keylime/keylime.
+Z /etc/keylime 0400 keylime keylime -
+# Now fix the directories:
+z /etc/keylime/ca.conf.d 0500 keylime keylime -
+z /etc/keylime/logging.conf.d 0500 keylime keylime -
+z /etc/keylime/verifier.conf.d 0500 keylime keylime -
+z /etc/keylime/registrar.conf.d 0500 keylime keylime -
+z /etc/keylime/tenant.conf.d 0500 keylime keylime -
+z /etc/keylime/agent.conf.d 0500 keylime keylime -
+# And finally, /etc/keylime itself.
+z /etc/keylime 0500 keylime keylime -

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 dbus-python
 # modules required for pylint
 setuptools
+pytest
 # packages required for mypy
 sqlalchemy-stubs
 types-python-dateutil

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,30 @@
+"""Shared pytest fixtures for keylime tests."""
+
+import shutil
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from keylime.shared_data import cleanup_global_shared_memory
+
+
+@pytest.fixture(autouse=True)
+def _shared_data_runtime_dir():
+    """Redirect SharedDataManager sockets to a temporary directory.
+
+    The SyncManager creates Unix domain sockets in /var/run/keylime/,
+    which may not be writable by the test user.  This fixture patches
+    the runtime directory to a per-test temp directory so that tests
+    work in any environment.
+
+    After each test, any global SharedDataManager is shut down to
+    prevent stale managers from referencing deleted temp directories.
+    """
+    tmpdir = tempfile.mkdtemp()
+    with patch("keylime.shared_data._RUNTIME_DIR", tmpdir):
+        yield
+    # Shut down any global SharedDataManager left alive by the test
+    # so the next test starts fresh with a new temp directory.
+    cleanup_global_shared_memory()
+    shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
# Move SyncManager socket to /var/run/keylime to resolve SELinux AVC denials

## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
**See also:** #1883 (SIGTERM fix that enabled clean shutdown)

## Change Description

### Concise Summary
Move SharedDataManager's Unix domain socket from /tmp to /var/run/keylime/ to eliminate SELinux AVC denials during clean shutdown using selinux policy from https://github.com/RedHat-SP-Security/keylime-selinux

After the SIGTERM fix in PR #1883, the SyncManager's server process now shuts down cleanly. During clean shutdown, CPython's SocketListener finalizer calls os.unlink() on the Manager's Unix domain socket. When the socket is in /tmp (the default), SELinux denies the unlink because the socket gets label keylime_tmp_t and keylime_server_t lacks unlink permission for that type.

### Technical Details
 
**Motivation behind the change:**
SELinux AVC denials appear in audit logs during verifier/registrar shutdown:
```
type=AVC msg=audit(...): avc: denied { unlink } for comm="MainProcess" 
name="shared_data.*.sock" scontext=system_u:system_r:keylime_server_t:s0 
tcontext=system_u:object_r:keylime_tmp_t:s0 tclass=sock_file permissive=0
```

**Architectural decisions:**

- Socket relocation: Move from /tmp to /var/run/keylime/ where SELinux policy already grants keylime_server_t full access. Keylime already uses this directory for ZeroMQ IPC sockets (keylime.verifier.ipc).

- PID-based socket naming: Use /var/run/keylime/shared_data.<pid>.sock to avoid collisions between verifier/registrar processes or rapid restarts.

- Pre-unlink pattern: CPython's SocketListener does NOT pre-unlink before bind(), so we explicitly unlink stale sockets before creating the SyncManager.

- Comprehensive tmpfiles.d: Create services/keylime-tmpfiles.conf to manage all keylime directories (/run/keylime, /var/lib/keylime, /etc/keylime and subdirectories) with correct ownership and permissions. Preferred over RuntimeDirectory= because multiple services share /run/keylime/.

- Non-systemd fallback: installer.sh includes manual directory creation for OpenRC/sysvinit systems that lack systemd-tmpfiles.

- Test isolation: test/conftest.py patches _RUNTIME_DIR to temp directories so tests run without root access.

**Unintended side effects:**

- Socket location changes from /tmp/pymp-*/... to /var/run/keylime/shared_data.<pid>.sock (visible in process listings)

- Directory /var/run/keylime/ must exist before services start (handled by tmpfiles.d for systemd, installer.sh fallback for others)

**Alternative approaches considered:**

- SELinux policy update: Would require distribution-specific policy changes

- Keep socket in /tmp: Would require allowing unlink on keylime_tmp_t, which is too permissive for a system-wide temp label

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [x] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. **Test environment:** SELinux enforcing mode, source installation via installer.sh

2. **Step-by-step validation procedure:**
   - Run installer.sh to install tmpfiles.d config and create directories
   - Start keylime_verifier service: `sudo systemctl start keylime_verifier`
   - Verify socket location: `sudo ls -lZ /var/run/keylime/` (should show shared_data.<pid>.sock with keylime_var_run_t label)
   - Stop service: `sudo systemctl stop keylime_verifier`
   - Check for AVC denials: `sudo ausearch -m avc -ts recent | grep keylime`
   - Run test suite: `python -m pytest test/ -p no:cov --ignore=test/test_ca_impl_openssl.py`
   - Run linters: `tox -e pylint,pyright,mypy,black,isort`

3. **Expected vs actual results:**
   - Expected: No AVC denials for sock_file unlink, socket in /var/run/keylime/, all tests and linters pass
   - Actual: No AVC denials observed, socket created in correct location with correct SELinux label, all tests pass (test_mba_parsing ordering issue is pre-existing), all linters pass

## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context
*(Optional: follow-up tasks, special considerations)*

**Code Review:**
This PR was reviewed by the keylime-developer agent which identified:
- Critical: Non-systemd fallback required for source installations on OpenRC/sysvinit
- Critical: TPM cert store source directory must be prepared by installer.sh before tmpfiles.d copies it
- Minor: ca.conf.d directory was missing from tmpfiles.d (fixed)

**Implementation Notes:**
- Follows same directory permission pattern as revocation_notifier.py (lines 217-224)
- Aligns with existing ZeroMQ IPC socket location
- No SELinux policy changes required (keylime_var_run_t already has correct permissions)

**For Package Maintainers:**
- Ensure services/keylime-tmpfiles.conf is installed to /usr/lib/tmpfiles.d/keylime.conf
- Ensure tpm_cert_store is installed to /usr/share/keylime/ before tmpfiles.d config runs
---

*This PR was created with assistance from Claude Opus 4.6*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure runtime directory exists with strict permissions; per-process IPC sockets now use unique paths, stale-socket cleanup on startup, explicit binding, improved shutdown cleanup, and startup logs include socket path.
  * Add systemd-tmpfiles config to create/manage Keylime runtime/data/config directories and provision TPM cert store; installer uses tmpfiles when available and falls back to stricter manual ownership/permission setup.

* **Tests**
  * Added pytest to test requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->