### PR TITLE
Fix PUSH mode agent status tracking across restarts and recovery

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -279,8 +279,13 @@ def process_get_status(agent: VerfierMain) -> Dict[str, Any]:
         # PUSH mode: determine status based on accept_attestations flag and attestation history
         # Agent must have successfully attested at least once to show PASS
         if hasattr(agent, "accept_attestations") and agent.accept_attestations is False:
-            # Timeout has fired - agent is not accepting attestations
-            attestation_status = "FAIL"
+            # Timeout has fired - check if there were prior attestation failures
+            # to avoid downgrading from FAIL to TIMEOUT
+            consecutive_failures = getattr(agent, "consecutive_attestation_failures", None)
+            if consecutive_failures is not None and consecutive_failures > 0:
+                attestation_status = "FAIL"
+            else:
+                attestation_status = "TIMEOUT"
         elif hasattr(agent, "accept_attestations") and agent.accept_attestations is True:
             # Check if there are recent failures (consecutive_attestation_failures > 0)
             # This prevents showing PASS when recent attestations failed but timeout hasn't fired yet

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -6,6 +6,7 @@ import os
 import signal
 import sys
 import threading
+import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -21,6 +22,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.orm.exc import NoResultFound  # pyright: ignore
 
+from keylime import agent_util
 from keylime import api_version as keylime_api_version
 from keylime import (
     cloud_verifier_common,
@@ -2825,11 +2827,50 @@ async def process_agent(
         _exit_operation()
 
 
+def check_push_agent_timeout_on_startup(agent: VerfierMain, current_time: int, timeout_seconds: float) -> bool:
+    """Check if a PUSH mode agent timed out during verifier downtime.
+
+    Returns True if the agent was marked as timed out.
+    """
+    if not agent_util.is_push_mode_agent(agent):
+        return False
+
+    logger.debug(
+        "PUSH mode agent %s: last_received_quote=%s, accept_attestations=%s (type=%s)",
+        agent.agent_id,
+        agent.last_received_quote,
+        agent.accept_attestations,
+        type(agent.accept_attestations).__name__,
+    )
+    if (
+        agent.last_received_quote is not None and agent.last_received_quote > 0 and bool(agent.accept_attestations)
+    ):  # pyright: ignore[reportGeneralTypeIssues]
+        last_quote = int(agent.last_received_quote)  # pyright: ignore[reportArgumentType]
+        time_since_last = current_time - last_quote
+        if time_since_last > timeout_seconds:
+            logger.warning(
+                "PUSH mode agent %s timed out during verifier downtime "
+                "(%.1f seconds since last attestation, threshold: %.1f seconds). "
+                "Setting accept_attestations to False.",
+                agent.agent_id,
+                time_since_last,
+                timeout_seconds,
+            )
+            agent.accept_attestations = False  # pyright: ignore[reportAttributeAccessIssue]
+            return True
+    return False
+
+
 async def activate_agents(agents: List[VerfierMain], verifier_ip: str, verifier_port: int) -> None:
     aas = get_AgentAttestStates()
     for agent in agents:
         agent.verifier_ip = verifier_ip  # pyright: ignore
         agent.verifier_port = verifier_port  # pyright: ignore
+
+        if agent_util.is_push_mode_agent(agent):
+            logger.debug("Skipping PULL activation for PUSH mode agent %s", agent.agent_id)
+            continue
+
         agent_run = _from_db_obj(agent)
         if agent_run["mtls_cert"] and agent_run["mtls_cert"] != "disabled":
             agent_run["ssl_context"] = web_util.generate_agent_tls_context(
@@ -2887,10 +2928,16 @@ def main() -> None:
     VerfierMain.metadata.create_all(engine, checkfirst=True)  # pyright: ignore
     with session_context() as session:
         try:
+            quote_interval = config.getfloat("verifier", "quote_interval", fallback=2.0)
+            timeout_seconds = push_agent_monitor.get_maximum_attestation_interval(quote_interval)
+            current_time = int(time.time())
+
             query_all = session.query(VerfierMain).all()
             for row in query_all:
                 if row.operational_state in states.APPROVED_REACTIVATE_STATES:
                     row.operational_state = states.START  # pyright: ignore
+
+                check_push_agent_timeout_on_startup(row, current_time, timeout_seconds)
             # session.commit() is automatically called by context manager
         except SQLAlchemyError as e:
             logger.error("SQLAlchemy Error: %s", e)
@@ -2947,6 +2994,7 @@ def main() -> None:
             # Cancel all pending attestation timeouts (retries, polls)
             cancel_all_pending_events()
             push_agent_monitor.cancel_all_timeouts()
+            push_timeout_periodic.stop()
 
             # Wait for in-flight operations, then close connections and stop
             async def stop() -> None:
@@ -2985,6 +3033,18 @@ def main() -> None:
         server.start()
         # Reactivate agents
         _background_tasks.append(asyncio.ensure_future(activate_agents(agents, verifier_host, int(verifier_port))))
+
+        # Check PUSH mode agents that may have timed out while the verifier was down
+        tornado.ioloop.IOLoop.current().add_callback(push_agent_monitor.check_push_agent_timeouts)
+
+        # Schedule periodic PUSH agent timeout checks as a safety net
+        quote_interval = config.getfloat("verifier", "quote_interval", fallback=2.0)
+        push_timeout_interval_ms = push_agent_monitor.get_maximum_attestation_interval(quote_interval) * 1000
+        push_timeout_periodic = tornado.ioloop.PeriodicCallback(
+            push_agent_monitor.check_push_agent_timeouts, push_timeout_interval_ms
+        )
+        push_timeout_periodic.start()
+
         tornado.ioloop.IOLoop.current().start()
         logger.debug("Server %s stopped.", task_id)
         sys.exit(0)

--- a/keylime/mba/mba.py
+++ b/keylime/mba/mba.py
@@ -49,7 +49,7 @@ MBAgg = Optional[Dict[str, List[str]]]
 # list of all imported modules for MBA.
 # ###########
 
-_mba_imports = []
+_mba_imports: List[Any] = []
 
 # ###########
 # import/load measured boot attestation imports

--- a/keylime/push_agent_monitor.py
+++ b/keylime/push_agent_monitor.py
@@ -4,7 +4,7 @@ This module implements event-driven timeout detection for PUSH mode agents.
 Instead of polling the database continuously, it schedules individual timeout
 callbacks when attestations are received. When an agent exceeds the timeout
 threshold, its accept_attestations flag is set to False, which causes
-attestation_status to show as "FAIL".
+attestation_status to show as "TIMEOUT" (or "FAIL" if there were prior attestation failures).
 
 Integration points:
 - Call schedule_agent_timeout(agent_id) when a PUSH mode attestation is received
@@ -248,7 +248,9 @@ def check_push_agent_timeouts() -> None:
             timed_out_count = 0
             for agent in push_agents:
                 # Skip agents that have never received an attestation
-                if agent.last_received_quote is None:
+                if (
+                    agent.last_received_quote is None or agent.last_received_quote <= 0
+                ):  # pyright: ignore[reportGeneralTypeIssues]
                     logger.debug("Agent %s has never received an attestation, skipping timeout check", agent.agent_id)
                     continue
 

--- a/keylime/verification/tpm_engine.py
+++ b/keylime/verification/tpm_engine.py
@@ -739,12 +739,28 @@ class TPMEngine(VerificationEngine):
             # The fresh agent is used for reading policies but updates must go to the original
             self.attestation.agent.attestation_count += 1
 
-            # Reset consecutive failures counter on success
-            self.attestation.agent.consecutive_attestation_failures = 0
+            # Handle state transitions differently for PUSH vs PULL mode:
+            # - TIMEOUT → PASS: agent resumes accepting attestations
+            # - Clearing failure count requires no prior failures or auto_recover_attestation_failures=True
+            if agent_util.is_push_mode_agent(self.attestation.agent):
+                had_failures = (self.attestation.agent.consecutive_attestation_failures or 0) > 0
 
-            # Re-enable attestations on successful attestation
-            # This allows PUSH mode agents to recover from timeout-induced FAIL status
-            self.attestation.agent.accept_attestations = True
+                self.attestation.agent.accept_attestations = True
+
+                if not had_failures:
+                    self.attestation.agent.consecutive_attestation_failures = 0
+                elif config.getboolean("verifier", "auto_recover_attestation_failures", fallback=False):
+                    self.attestation.agent.consecutive_attestation_failures = 0
+                else:
+                    logger.info(
+                        "Agent %s passed attestation but has prior failures (count=%d). "
+                        "FAIL to PASS auto-recovery is disabled. Re-add agent to clear.",
+                        self.attestation.agent.agent_id,
+                        self.attestation.agent.consecutive_attestation_failures,
+                    )
+            else:
+                self.attestation.agent.consecutive_attestation_failures = 0
+                self.attestation.agent.accept_attestations = True
 
             # Update operational state to GET_QUOTE if not already set
             # This ensures the agent shows as actively attesting in status queries
@@ -780,10 +796,13 @@ class TPMEngine(VerificationEngine):
                 self.agent.accept_attestations = False
                 # Invalidate authentication session on attestation failure in pull mode
                 AuthSession.delete_active_session_for_agent(self.agent_id)
-            # In push mode, token remains valid and agent can retry.
-            # Token is NOT extended on failed attestations (extension only happens for successful attestations above).
-            # Agent will get 503 Service Unavailable if it retries too quickly (due to attestation_interval check).
-            # When token expires, agent will get 401 and must re-authenticate.
+            elif agent_util.is_push_mode_agent(self.attestation.agent):
+                # PUSH mode: re-enable attestations and update timestamp to clear timeout state.
+                # The agent is actively communicating even though verification failed.
+                # Status will show FAIL (not TIMEOUT) because consecutive_attestation_failures > 0.
+                self.attestation.agent.accept_attestations = True
+                self.attestation.agent.last_received_quote = int(time.time())
+                push_agent_monitor.schedule_agent_timeout(self.attestation.agent.agent_id)
 
         self.attestation.refresh_metadata()  # type: ignore[no-untyped-call]
         self._determine_failure_reason(failure)

--- a/keylime/web/verifier_server.py
+++ b/keylime/web/verifier_server.py
@@ -1,9 +1,11 @@
 import asyncio
+import time
 from typing import List, Optional
 
 from sqlalchemy.exc import SQLAlchemyError
 
 from keylime import (
+    agent_util,
     cloud_verifier_common,
     cloud_verifier_tornado,
     config,
@@ -126,9 +128,28 @@ class VerifierServer(Server):
                     # Reset agents in APPROVED_REACTIVATE_STATES to START state
                     # This matches the old architecture (cloud_verifier_tornado.py:2332-2338)
                     query_all = session.query(VerfierMain).all()
+                    now = int(time.time())
+                    quote_interval = config.getfloat("verifier", "quote_interval", fallback=2.0)
+                    timeout_threshold = push_agent_monitor.get_maximum_attestation_interval(quote_interval)
+
                     for row in query_all:
                         if row.operational_state in states.APPROVED_REACTIVATE_STATES:
                             row.operational_state = states.START  # type: ignore
+
+                        if (
+                            agent_util.is_push_mode_agent(row)
+                            and row.last_received_quote is not None
+                            and row.last_received_quote > 0  # pyright: ignore[reportGeneralTypeIssues]
+                        ):
+                            elapsed = now - int(row.last_received_quote)  # pyright: ignore[reportArgumentType]
+                            if elapsed > timeout_threshold:
+                                logger.info(
+                                    "PUSH agent %s last attested %ds ago (threshold: %ds), marking as timed out",
+                                    row.agent_id,
+                                    elapsed,
+                                    int(timeout_threshold),
+                                )
+                                row.accept_attestations = False  # type: ignore
 
                     # Log remaining agents
                     num = session.query(VerfierMain).count()

--- a/templates/2.6/mapping.json
+++ b/templates/2.6/mapping.json
@@ -5,7 +5,8 @@
         "verifier": {
             "add": {
                 "shutdown_drain_timeout": "10",
-                "max_workers": "16"
+                "max_workers": "16",
+                "auto_recover_attestation_failures": "False"
             }
         },
         "registrar": {

--- a/templates/2.6/verifier.j2
+++ b/templates/2.6/verifier.j2
@@ -325,6 +325,16 @@ session_lifetime = {{ verifier.session_lifetime }}
 # as long as they continue attesting within the session_lifetime window.
 # Default: true
 extend_token_on_attestation = {{ verifier.extend_token_on_attestation }}
+#
+# Whether to allow PUSH mode agents to automatically recover from attestation
+# failures (FAIL → PASS transition) when a subsequent attestation succeeds.
+# When disabled (default), agents that previously failed attestation remain in
+# FAIL status even after a successful attestation; an operator must re-add the
+# agent to clear the failure state. This keeps unexpected changes visible.
+# Note: TIMEOUT → PASS recovery (for connectivity issues) is always allowed
+# regardless of this setting.
+# Default: false
+auto_recover_attestation_failures = {{ verifier.auto_recover_attestation_failures }}
 
 # Maximum time in seconds to wait for in-flight attestation operations to
 # complete during shutdown. The verifier will wait up to this long for active

--- a/test/test-requirements.txt
+++ b/test/test-requirements.txt
@@ -3,3 +3,7 @@
 coverage==4.5.2
 green==4.0.2  # Python 3.12+ requires this.
 pytest-asyncio==0.10.0
+# Runtime dependencies are needed at test discovery time because
+# importing keylime modules triggers deep import chains that load
+# packages like pyasn1 and jsonschema at module level.
+-r ../requirements.txt

--- a/test/test_cloud_verifier_common.py
+++ b/test/test_cloud_verifier_common.py
@@ -872,23 +872,23 @@ class TestProcessGetStatus(unittest.TestCase):
         )
 
     def test_push_mode_agent_fail_when_not_accepting(self):
-        """Test PUSH mode agent shows FAIL when accept_attestations=False."""
+        """Test PUSH mode agent shows TIMEOUT when accept_attestations=False."""
         # Create PUSH mode agent with accept_attestations=False
         agent = self._create_mock_agent(
             operational_state=states.GET_QUOTE,
             ip=None,
             port=None,
-            accept_attestations=False,  # Timed out or failed
+            accept_attestations=False,  # Timed out
             attestation_count=1,
         )
 
         status = cloud_verifier_common.process_get_status(agent)
 
-        # Should be FAIL because accept_attestations=False
+        # Should be TIMEOUT because accept_attestations=False (agent stopped sending attestations)
         self.assertEqual(
             status["attestation_status"],
-            "FAIL",
-            "PUSH mode agent should show FAIL when accept_attestations=False",
+            "TIMEOUT",
+            "PUSH mode agent should show TIMEOUT when accept_attestations=False",
         )
 
     def test_push_mode_agent_fail_with_consecutive_failures(self):
@@ -975,6 +975,39 @@ class TestProcessGetStatus(unittest.TestCase):
             "FAIL",
             "PULL mode agent should show FAIL in FAILED state",
         )
+
+
+    def test_push_mode_agent_fail_when_timed_out_with_failures(self):
+        """Test PUSH agent shows FAIL (not TIMEOUT) when timed out with prior failures."""
+        agent = self._create_mock_agent(
+            operational_state=states.GET_QUOTE,
+            ip=None,
+            port=None,
+            accept_attestations=False,
+            attestation_count=5,
+            consecutive_attestation_failures=3,
+        )
+
+        status = cloud_verifier_common.process_get_status(agent)
+
+        self.assertEqual(
+            status["attestation_status"],
+            "FAIL",
+            "PUSH mode agent with accept_attestations=False and consecutive_failures > 0 should show FAIL",
+        )
+
+    def test_push_mode_agent_pending_without_accept_attestations_attr(self):
+        """Test PUSH agent shows PENDING when accept_attestations attribute is missing."""
+        agent = self._create_mock_agent(
+            operational_state=None,
+            ip=None,
+            port=None,
+        )
+        del agent.accept_attestations
+
+        status = cloud_verifier_common.process_get_status(agent)
+
+        self.assertEqual(status["attestation_status"], "PENDING")
 
 
 if __name__ == "__main__":

--- a/test/test_cloud_verifier_common.py
+++ b/test/test_cloud_verifier_common.py
@@ -976,7 +976,6 @@ class TestProcessGetStatus(unittest.TestCase):
             "PULL mode agent should show FAIL in FAILED state",
         )
 
-
     def test_push_mode_agent_fail_when_timed_out_with_failures(self):
         """Test PUSH agent shows FAIL (not TIMEOUT) when timed out with prior failures."""
         agent = self._create_mock_agent(

--- a/test/test_cloud_verifier_tornado.py
+++ b/test/test_cloud_verifier_tornado.py
@@ -187,5 +187,107 @@ class TestCompleteDeletionIfTerminated(unittest.TestCase):
         cloud_verifier_tornado._complete_deletion_if_terminated("agent-123")
 
 
+class TestCheckPushAgentTimeoutOnStartup(unittest.TestCase):
+    """Tests for check_push_agent_timeout_on_startup()."""
+
+    def _make_agent(
+        self,
+        agent_id="agent-1",
+        operational_state=None,
+        ip=None,
+        port=None,
+        accept_attestations=True,
+        last_received_quote=None,
+    ):
+        agent = MagicMock()
+        agent.agent_id = agent_id
+        agent.operational_state = operational_state
+        agent.ip = ip
+        agent.port = port
+        agent.accept_attestations = accept_attestations
+        agent.last_received_quote = last_received_quote
+        return agent
+
+    def test_pull_agent_ignored(self):
+        """PULL mode agents are not checked for timeout."""
+        agent = self._make_agent(ip="10.0.0.1", port=9002, operational_state=7)
+        result = cloud_verifier_tornado.check_push_agent_timeout_on_startup(agent, 1000, 10.0)
+        self.assertFalse(result)
+
+    def test_push_agent_timed_out(self):
+        """PUSH agent with old last_received_quote is marked timed out."""
+        agent = self._make_agent(last_received_quote=900, accept_attestations=True)
+        result = cloud_verifier_tornado.check_push_agent_timeout_on_startup(agent, 1000, 10.0)
+        self.assertTrue(result)
+        self.assertFalse(agent.accept_attestations)
+
+    def test_push_agent_still_healthy(self):
+        """PUSH agent with recent last_received_quote is not marked timed out."""
+        agent = self._make_agent(last_received_quote=995, accept_attestations=True)
+        result = cloud_verifier_tornado.check_push_agent_timeout_on_startup(agent, 1000, 10.0)
+        self.assertFalse(result)
+        self.assertTrue(agent.accept_attestations)
+
+    def test_push_agent_no_quote_yet(self):
+        """PUSH agent with no last_received_quote is not marked timed out."""
+        agent = self._make_agent(last_received_quote=None, accept_attestations=True)
+        result = cloud_verifier_tornado.check_push_agent_timeout_on_startup(agent, 1000, 10.0)
+        self.assertFalse(result)
+
+    def test_push_agent_sentinel_zero_not_timed_out(self):
+        """PUSH agent with sentinel last_received_quote=0 is not marked timed out."""
+        agent = self._make_agent(last_received_quote=0, accept_attestations=True)
+        result = cloud_verifier_tornado.check_push_agent_timeout_on_startup(agent, 1000, 10.0)
+        self.assertFalse(result)
+        self.assertTrue(agent.accept_attestations)
+
+    def test_push_agent_already_timed_out(self):
+        """PUSH agent already marked as timed out (accept_attestations=False) is not changed."""
+        agent = self._make_agent(last_received_quote=900, accept_attestations=False)
+        result = cloud_verifier_tornado.check_push_agent_timeout_on_startup(agent, 1000, 10.0)
+        self.assertFalse(result)
+        self.assertFalse(agent.accept_attestations)
+
+
+class TestActivateAgentsSkipsPushMode(unittest.IsolatedAsyncioTestCase):
+    """Tests for activate_agents() PUSH mode skip behavior."""
+
+    @patch("keylime.cloud_verifier_tornado.get_AgentAttestStates")
+    @patch("keylime.cloud_verifier_tornado._from_db_obj")
+    @patch("keylime.cloud_verifier_tornado.agent_util.is_push_mode_agent")
+    async def test_push_agents_skipped_pull_agents_activated(self, mock_is_push, mock_from_db, _mock_get_aas):
+        """PUSH mode agents should be skipped during PULL activation."""
+        push_agent = MagicMock()
+        push_agent.agent_id = "push-agent"
+
+        pull_agent = MagicMock()
+        pull_agent.agent_id = "pull-agent"
+        pull_agent.operational_state = None
+        pull_agent.boottime = None
+
+        mock_is_push.side_effect = lambda a: a.agent_id == "push-agent"
+        mock_from_db.return_value = {"mtls_cert": None, "agent_id": "pull-agent"}
+
+        await cloud_verifier_tornado.activate_agents([push_agent, pull_agent], "127.0.0.1", 8881)
+
+        mock_from_db.assert_called_once_with(pull_agent)
+
+    @patch("keylime.cloud_verifier_tornado.get_AgentAttestStates")
+    @patch("keylime.cloud_verifier_tornado._from_db_obj")
+    @patch("keylime.cloud_verifier_tornado.agent_util.is_push_mode_agent")
+    async def test_all_push_agents_skipped(self, mock_is_push, mock_from_db, _mock_get_aas):
+        """When all agents are PUSH mode, none should be activated."""
+        agent1 = MagicMock()
+        agent1.agent_id = "push-1"
+        agent2 = MagicMock()
+        agent2.agent_id = "push-2"
+
+        mock_is_push.return_value = True
+
+        await cloud_verifier_tornado.activate_agents([agent1, agent2], "127.0.0.1", 8881)
+
+        mock_from_db.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_evidence_model.py
+++ b/test/test_evidence_model.py
@@ -189,8 +189,7 @@ class TestEvidenceItemModel(unittest.TestCase):
         evidence2 = EvidenceItem.empty()
         evidence2.evidence_class = "certification"
 
-        with patch.object(evidence1, "refresh_metadata"), \
-             patch.object(evidence2, "refresh_metadata"):
+        with patch.object(evidence1, "refresh_metadata"), patch.object(evidence2, "refresh_metadata"):
             evidence1.generate_challenge(128)
             evidence2.generate_challenge(128)
 

--- a/test/test_push_agent_monitor.py
+++ b/test/test_push_agent_monitor.py
@@ -194,6 +194,30 @@ class TestPushAgentMonitor(unittest.TestCase):
     @patch("keylime.push_agent_monitor.config")
     @patch("keylime.cloud_verifier_tornado.session_context")
     @patch("keylime.push_agent_monitor.time.time")
+    def test_check_push_agent_timeouts_sentinel_zero_not_timed_out(self, mock_time, mock_session_context, mock_config):
+        """Test that agents with sentinel last_received_quote=0 are not marked as timed out."""
+        mock_config.getfloat.return_value = 2.0
+        mock_session_context.return_value.__enter__.return_value = self.session
+        mock_session_context.return_value.__exit__.return_value = None
+        mock_time.return_value = self.current_time
+
+        self._create_push_agent(
+            agent_id="sentinel-zero-agent",
+            accept_attestations=True,
+            last_received_quote=0,
+            operational_state=None,
+        )
+
+        check_push_agent_timeouts()
+
+        agent = self.session.query(VerfierMain).filter_by(agent_id="sentinel-zero-agent").first()
+        self.assertIsNotNone(agent)
+        assert agent is not None  # Type narrowing for pyright
+        self.assertTrue(agent.accept_attestations)
+
+    @patch("keylime.push_agent_monitor.config")
+    @patch("keylime.cloud_verifier_tornado.session_context")
+    @patch("keylime.push_agent_monitor.time.time")
     def test_check_push_agent_timeouts_already_failed_agent(self, mock_time, mock_session_context, mock_config):
         """Test that already-failed agents are not updated again (to prevent log spam)."""
         # Configure mocks

--- a/test/test_tpm_engine.py
+++ b/test/test_tpm_engine.py
@@ -212,6 +212,7 @@ class TestTPMEngineProcessResults(unittest.TestCase):
 
         # Simulate agent that has timed out (accept_attestations=False)
         self.mock_agent.accept_attestations = False
+        self.mock_agent.consecutive_attestation_failures = 0
 
         # Mock _extend_auth_token
         with patch.object(self.engine, "_extend_auth_token"):
@@ -240,6 +241,196 @@ class TestTPMEngineProcessResults(unittest.TestCase):
         mock_schedule_timeout.assert_called_once_with("test-agent-123")
 
         # Evaluation should be set to pass
+        self.assertEqual(self.mock_attestation.evaluation, "pass")
+
+    @patch("keylime.verification.tpm_engine.config.get")
+    @patch("keylime.verification.tpm_engine.agent_util.is_push_mode_agent")
+    @patch("keylime.verification.tpm_engine.push_agent_monitor.schedule_agent_timeout")
+    @patch("keylime.verification.tpm_engine.config.getboolean")
+    def test_process_results_push_failure_clears_timeout(
+        self, mock_getboolean, mock_schedule_timeout, mock_is_push_mode, mock_config_get
+    ):
+        """Failed attestation from PUSH agent should clear timeout state (TIMEOUT -> FAIL)"""
+        mock_config_get.return_value = "push"
+        mock_getboolean.return_value = True
+        mock_is_push_mode.return_value = True
+
+        self.mock_agent.accept_attestations = False
+        self.mock_agent.consecutive_attestation_failures = 0
+
+        failure = Failure(Component.QUOTE_VALIDATION)
+        failure.add_event("test_failure", "Test failure", True)
+
+        with patch.object(self.engine, "_select_ima_log_item", return_value=None):
+            with patch.object(self.engine, "_determine_failure_reason"):
+                with patch.object(type(self.engine), "attest_state", new_callable=PropertyMock, return_value=None):
+                    with patch.object(
+                        type(self.engine), "failure_reason", new_callable=PropertyMock, return_value=None
+                    ):
+                        self.engine._process_results(failure)
+
+        self.assertTrue(
+            self.mock_agent.accept_attestations,
+            "Failed attestation from PUSH agent should re-enable accept_attestations to clear timeout state",
+        )
+        self.assertEqual(self.mock_agent.consecutive_attestation_failures, 1)
+        mock_schedule_timeout.assert_called_once_with("test-agent-123")
+        self.assertEqual(self.mock_attestation.evaluation, "fail")
+
+    @patch("keylime.verification.tpm_engine.config.getboolean")
+    @patch("keylime.verification.tpm_engine.agent_util.is_push_mode_agent")
+    @patch("keylime.verification.tpm_engine.push_agent_monitor.schedule_agent_timeout")
+    def test_process_results_push_fail_to_pass_blocked_by_default(
+        self, _mock_schedule_timeout, mock_is_push_mode, mock_getboolean
+    ):
+        """PUSH mode: FAIL → PASS should be blocked by default (auto_recover_attestation_failures=False)"""
+
+        def getboolean_side_effect(_section, key, fallback=None):
+            if key == "auto_recover_attestation_failures":
+                return False
+            if key == "extend_token_on_attestation":
+                return True
+            return fallback
+
+        mock_getboolean.side_effect = getboolean_side_effect
+        mock_is_push_mode.return_value = True
+
+        self.mock_agent.accept_attestations = True
+        self.mock_agent.consecutive_attestation_failures = 3
+
+        with patch.object(self.engine, "_extend_auth_token"):
+            with patch.object(self.engine, "_select_ima_log_item", return_value=None):
+                with patch.object(self.engine, "_determine_failure_reason"):
+                    with patch.object(type(self.engine), "attest_state", new_callable=PropertyMock, return_value=None):
+                        with patch.object(
+                            type(self.engine), "failure_reason", new_callable=PropertyMock, return_value=None
+                        ):
+                            self.engine._process_results(None)
+
+        self.assertTrue(self.mock_agent.accept_attestations)
+        self.assertEqual(
+            self.mock_agent.consecutive_attestation_failures,
+            3,
+            "FAIL → PASS should be blocked: consecutive_attestation_failures must not be reset",
+        )
+        self.assertEqual(self.mock_agent.attestation_count, 1)
+        self.assertEqual(self.mock_attestation.evaluation, "pass")
+
+    @patch("keylime.verification.tpm_engine.config.getboolean")
+    @patch("keylime.verification.tpm_engine.agent_util.is_push_mode_agent")
+    @patch("keylime.verification.tpm_engine.push_agent_monitor.schedule_agent_timeout")
+    def test_process_results_push_fail_to_pass_allowed_when_configured(
+        self, _mock_schedule_timeout, mock_is_push_mode, mock_getboolean
+    ):
+        """PUSH mode: FAIL → PASS should be allowed when auto_recover_attestation_failures=True"""
+
+        def getboolean_side_effect(_section, key, fallback=None):
+            if key == "auto_recover_attestation_failures":
+                return True
+            if key == "extend_token_on_attestation":
+                return True
+            return fallback
+
+        mock_getboolean.side_effect = getboolean_side_effect
+        mock_is_push_mode.return_value = True
+
+        self.mock_agent.accept_attestations = True
+        self.mock_agent.consecutive_attestation_failures = 3
+
+        with patch.object(self.engine, "_extend_auth_token"):
+            with patch.object(self.engine, "_select_ima_log_item", return_value=None):
+                with patch.object(self.engine, "_determine_failure_reason"):
+                    with patch.object(type(self.engine), "attest_state", new_callable=PropertyMock, return_value=None):
+                        with patch.object(
+                            type(self.engine), "failure_reason", new_callable=PropertyMock, return_value=None
+                        ):
+                            self.engine._process_results(None)
+
+        self.assertTrue(self.mock_agent.accept_attestations)
+        self.assertEqual(
+            self.mock_agent.consecutive_attestation_failures,
+            0,
+            "FAIL → PASS should be allowed: consecutive_attestation_failures must be reset when configured",
+        )
+        self.assertEqual(self.mock_agent.attestation_count, 1)
+        self.assertEqual(self.mock_attestation.evaluation, "pass")
+
+    @patch("keylime.verification.tpm_engine.config.getboolean")
+    @patch("keylime.verification.tpm_engine.agent_util.is_push_mode_agent")
+    @patch("keylime.verification.tpm_engine.push_agent_monitor.schedule_agent_timeout")
+    def test_process_results_push_fail_timeout_pass_blocked_by_default(
+        self, _mock_schedule_timeout, mock_is_push_mode, mock_getboolean
+    ):
+        """PUSH mode: FAIL → TIMEOUT → PASS should be blocked by default (no bypass via timeout)"""
+
+        def getboolean_side_effect(_section, key, fallback=None):
+            if key == "auto_recover_attestation_failures":
+                return False
+            if key == "extend_token_on_attestation":
+                return True
+            return fallback
+
+        mock_getboolean.side_effect = getboolean_side_effect
+        mock_is_push_mode.return_value = True
+
+        self.mock_agent.accept_attestations = False
+        self.mock_agent.consecutive_attestation_failures = 3
+
+        with patch.object(self.engine, "_extend_auth_token"):
+            with patch.object(self.engine, "_select_ima_log_item", return_value=None):
+                with patch.object(self.engine, "_determine_failure_reason"):
+                    with patch.object(type(self.engine), "attest_state", new_callable=PropertyMock, return_value=None):
+                        with patch.object(
+                            type(self.engine), "failure_reason", new_callable=PropertyMock, return_value=None
+                        ):
+                            self.engine._process_results(None)
+
+        self.assertTrue(self.mock_agent.accept_attestations)
+        self.assertEqual(
+            self.mock_agent.consecutive_attestation_failures,
+            3,
+            "FAIL → TIMEOUT → PASS must not bypass auto_recover_attestation_failures=False",
+        )
+        self.assertEqual(self.mock_agent.attestation_count, 1)
+        self.assertEqual(self.mock_attestation.evaluation, "pass")
+
+    @patch("keylime.verification.tpm_engine.config.getboolean")
+    @patch("keylime.verification.tpm_engine.agent_util.is_push_mode_agent")
+    @patch("keylime.verification.tpm_engine.push_agent_monitor.schedule_agent_timeout")
+    def test_process_results_push_fail_timeout_pass_allowed_when_configured(
+        self, _mock_schedule_timeout, mock_is_push_mode, mock_getboolean
+    ):
+        """PUSH mode: FAIL → TIMEOUT → PASS should be allowed when auto_recover_attestation_failures=True"""
+
+        def getboolean_side_effect(_section, key, fallback=None):
+            if key == "auto_recover_attestation_failures":
+                return True
+            if key == "extend_token_on_attestation":
+                return True
+            return fallback
+
+        mock_getboolean.side_effect = getboolean_side_effect
+        mock_is_push_mode.return_value = True
+
+        self.mock_agent.accept_attestations = False
+        self.mock_agent.consecutive_attestation_failures = 3
+
+        with patch.object(self.engine, "_extend_auth_token"):
+            with patch.object(self.engine, "_select_ima_log_item", return_value=None):
+                with patch.object(self.engine, "_determine_failure_reason"):
+                    with patch.object(type(self.engine), "attest_state", new_callable=PropertyMock, return_value=None):
+                        with patch.object(
+                            type(self.engine), "failure_reason", new_callable=PropertyMock, return_value=None
+                        ):
+                            self.engine._process_results(None)
+
+        self.assertTrue(self.mock_agent.accept_attestations)
+        self.assertEqual(
+            self.mock_agent.consecutive_attestation_failures,
+            0,
+            "FAIL → TIMEOUT → PASS should clear failures when auto_recover_attestation_failures=True",
+        )
+        self.assertEqual(self.mock_agent.attestation_count, 1)
         self.assertEqual(self.mock_attestation.evaluation, "pass")
 
 

--- a/test/test_verifier_server.py
+++ b/test/test_verifier_server.py
@@ -105,6 +105,123 @@ class TestVerifierServerPrepareAgents(unittest.TestCase):
         # Verify query was called
         mock_session.query.return_value.count.assert_called()
 
+    @patch("keylime.web.verifier_server.push_agent_monitor")
+    @patch("keylime.web.verifier_server.agent_util")
+    @patch("keylime.web.verifier_server.config")
+    @patch("keylime.web.verifier_server.make_engine")
+    @patch("keylime.web.verifier_server.SessionManager")
+    def test_prepare_agents_sentinel_zero_not_timed_out(
+        self, mock_session_manager, mock_make_engine, mock_config, mock_agent_util, mock_push_monitor
+    ):
+        """Test that PUSH agents with sentinel last_received_quote=0 are not marked timed out."""
+        mock_engine = MagicMock()
+        mock_make_engine.return_value = mock_engine
+
+        mock_config.getfloat.return_value = 2.0
+        mock_push_monitor.get_maximum_attestation_interval.return_value = 10.0
+
+        mock_agent = MagicMock()
+        mock_agent.agent_id = "push-agent-sentinel"
+        mock_agent.operational_state = None
+        mock_agent.last_received_quote = 0
+        mock_agent.accept_attestations = True
+        mock_agent_util.is_push_mode_agent.return_value = True
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.all.return_value = [mock_agent]
+        mock_session.query.return_value.count.return_value = 1
+
+        mock_context = MagicMock()
+        mock_context.__enter__.return_value = mock_session
+        mock_context.__exit__.return_value = None
+
+        mock_sm = MagicMock()
+        mock_sm.session_context.return_value = mock_context
+        mock_session_manager.return_value = mock_sm
+
+        server = VerifierServer.__new__(VerifierServer)
+        server._prepare_agents_on_startup()  # pylint: disable=protected-access
+
+        self.assertTrue(mock_agent.accept_attestations)
+
+    @patch("keylime.web.verifier_server.push_agent_monitor")
+    @patch("keylime.web.verifier_server.agent_util")
+    @patch("keylime.web.verifier_server.config")
+    @patch("keylime.web.verifier_server.make_engine")
+    @patch("keylime.web.verifier_server.SessionManager")
+    def test_prepare_agents_push_agent_timed_out_during_downtime(
+        self, mock_session_manager, mock_make_engine, mock_config, mock_agent_util, mock_push_monitor
+    ):
+        """Test that PUSH agents that timed out during verifier downtime are marked."""
+        mock_engine = MagicMock()
+        mock_make_engine.return_value = mock_engine
+
+        mock_config.getfloat.return_value = 2.0
+        mock_push_monitor.get_maximum_attestation_interval.return_value = 10.0
+
+        mock_agent = MagicMock()
+        mock_agent.agent_id = "push-agent-stale"
+        mock_agent.operational_state = None
+        mock_agent.last_received_quote = 1000
+        mock_agent.accept_attestations = True
+        mock_agent_util.is_push_mode_agent.return_value = True
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.all.return_value = [mock_agent]
+        mock_session.query.return_value.count.return_value = 1
+
+        mock_context = MagicMock()
+        mock_context.__enter__.return_value = mock_session
+        mock_context.__exit__.return_value = None
+
+        mock_sm = MagicMock()
+        mock_sm.session_context.return_value = mock_context
+        mock_session_manager.return_value = mock_sm
+
+        server = VerifierServer.__new__(VerifierServer)
+        server._prepare_agents_on_startup()  # pylint: disable=protected-access
+
+        self.assertFalse(mock_agent.accept_attestations)
+
+    @patch("keylime.web.verifier_server.push_agent_monitor")
+    @patch("keylime.web.verifier_server.agent_util")
+    @patch("keylime.web.verifier_server.config")
+    @patch("keylime.web.verifier_server.make_engine")
+    @patch("keylime.web.verifier_server.SessionManager")
+    def test_prepare_agents_push_agent_none_quote_not_timed_out(
+        self, mock_session_manager, mock_make_engine, mock_config, mock_agent_util, mock_push_monitor
+    ):
+        """Test that PUSH agents with last_received_quote=None are not marked timed out."""
+        mock_engine = MagicMock()
+        mock_make_engine.return_value = mock_engine
+
+        mock_config.getfloat.return_value = 2.0
+        mock_push_monitor.get_maximum_attestation_interval.return_value = 10.0
+
+        mock_agent = MagicMock()
+        mock_agent.agent_id = "push-agent-new"
+        mock_agent.operational_state = None
+        mock_agent.last_received_quote = None
+        mock_agent.accept_attestations = True
+        mock_agent_util.is_push_mode_agent.return_value = True
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.all.return_value = [mock_agent]
+        mock_session.query.return_value.count.return_value = 1
+
+        mock_context = MagicMock()
+        mock_context.__enter__.return_value = mock_session
+        mock_context.__exit__.return_value = None
+
+        mock_sm = MagicMock()
+        mock_sm.session_context.return_value = mock_context
+        mock_session_manager.return_value = mock_sm
+
+        server = VerifierServer.__new__(VerifierServer)
+        server._prepare_agents_on_startup()  # pylint: disable=protected-access
+
+        self.assertTrue(mock_agent.accept_attestations)
+
 
 class TestVerifierServerRoutes(unittest.TestCase):
     """Test cases for VerifierServer route configuration."""


### PR DESCRIPTION
# Distinguish TIMEOUT from FAIL for PUSH mode agent attestation status

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [x] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
Resolves: #1888

## Change Description

### Concise Summary
Fix PUSH agent status after verifier restart and recovery

When a PUSH mode agent stops sending attestations and the verifier is restarted, the agent incorrectly shows `attestation_status: "PASS"` instead of reflecting that it has timed out. Additionally, once marked as timed out, the agent cannot recover to `FAIL` or `PASS` status when it resumes sending attestations.

### Technical Details

Three related problems are fixed:

- **Startup timeout detection missing from actual code path.** The verifier entry point (`keylime/cmd/verifier.py`) uses `VerifierServer` from `keylime.web`, which calls `_prepare_agents_on_startup()` in `keylime/web/verifier_server.py`. This method had no logic to detect PUSH agents that timed out while the verifier was down. On restart,
`accept_attestations` remained `True`, so `process_get_status()` reported `"PASS"` even when the agent hadn't attested in hours. The fix checks each PUSH agent's `last_received_quote` against the timeout threshold (`quote_interval * 5`) and sets `accept_attestations = False` if exceeded.

- **No distinction between TIMEOUT and FAIL.** Previously, `process_get_status()` in `cloud_verifier_common.py` returned `"FAIL"` when `accept_attestations` was `False`. This conflated two different conditions: the agent stopped communicating (timeout) vs. the agent is communicating but attestation verification is failing. The fix introduces a `"TIMEOUT"`
status for the former case, while `"FAIL"` is reserved for `consecutive_attestation_failures > 0` with `accept_attestations = True`.

- **PUSH agents stuck in TIMEOUT after resuming attestations.** When a timed-out agent resumed sending attestations, `accept_attestations` was only reset to `True` on *successful* verification (`tpm_engine.py` line 747). If the agent's attestations failed (e.g., IMA mismatch), `accept_attestations` stayed `False` and the status remained `"TIMEOUT"`
indefinitely. The fix resets `accept_attestations = True`, updates `last_received_quote`, and reschedules the timeout in the failure branch of `_process_results()` for PUSH mode agents, since receiving any attestation — even a failing one — proves the agent is communicating.

Equivalent startup logic was also added to `cloud_verifier_tornado.py:main()` for the legacy code path, along with skipping PULL-mode activation for PUSH agents in `activate_agents()`.

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. **Environment:** Fedora 43 with `python3-keylime-7.14.1`, rust-keylime agent in PUSH mode, swtpm.
2. **Startup timeout detection:**
   - Enroll a PUSH mode agent and let it attest successfully (`attestation_status: "PASS"`).
   - Stop the agent and wait longer than the timeout threshold (default: `quote_interval * 5 = 10s`).
   - Restart the verifier.
   - Run `keylime_tenant -c cvstatus -u <agent_id>` and verify `attestation_status: "TIMEOUT"`.
3. **Recovery from timeout:**
   - With the agent in `"TIMEOUT"` state, restart the agent.
   - Verify that `attestation_status` transitions to `"PASS"` (if attestation succeeds) or `"FAIL"` (if verification fails), but no longer stays stuck at `"TIMEOUT"`.
4. **Unit tests:**
   - `pytest test/test_tpm_engine.py test/test_cloud_verifier_common.py test/test_push_agent_monitor.py` — all 49 tests pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context
- The `"TIMEOUT"` status is a new value for `attestation_status` in the API response. Consumers that only expect `"PASS"`, `"FAIL"`, or `"PENDING"` should be updated to handle `"TIMEOUT"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and apply timeouts for PUSH-mode agents at startup and via periodic monitoring.
  * PUSH-mode agents can re-enable and refresh last-attestation timestamps on certain failures.
  * New configuration option to control automatic recovery of attestation failures.

* **Bug Fixes**
  * Treat missing or non-positive last-attestation timestamps as “no attestation” to avoid spurious timeouts.
  
* **Chores**
  * Updated test metadata source and branch for CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->