### PR TITLE
Document verifier wildcard bind address

### DIFF
--- a/docs/man/keylime_verifier.8.rst
+++ b/docs/man/keylime_verifier.8.rst
@@ -34,7 +34,9 @@ All options are under the ``[verifier]`` section.
 Essentials:
 - **mode**: Attestation mode (``pull`` or ``push``). Default: ``pull``
 - **uuid**: Unique identifier for this verifier instance
-- **ip**, **port**: Bind address and HTTP port
+- **ip**, **port**: Bind address and HTTP port. Set ``ip = *`` to listen on all IPv4
+  and IPv6 addresses supported by the host; use a concrete address to limit the
+  verifier to one interface.
 - **registrar_ip**, **registrar_port**: Registrar endpoint
 - **enable_agent_mtls**: Enable mTLS with agents and tenant
 - **tls_dir**: TLS material location

--- a/docs/man/keylime_verifier.8.rst
+++ b/docs/man/keylime_verifier.8.rst
@@ -34,9 +34,10 @@ All options are under the ``[verifier]`` section.
 Essentials:
 - **mode**: Attestation mode (``pull`` or ``push``). Default: ``pull``
 - **uuid**: Unique identifier for this verifier instance
-- **ip**, **port**: Bind address and HTTP port. Set ``ip = *`` to listen on all IPv4
-  and IPv6 addresses supported by the host; use a concrete address to limit the
-  verifier to one interface.
+- **ip**, **port**: Bind address and HTTP port. Use a concrete address to limit
+  the verifier to one interface, ``0.0.0.0`` to listen on all IPv4 interfaces,
+  or ``::`` to listen on all IPv6 interfaces (which also accepts IPv4 on
+  dual-stack hosts).
 - **registrar_ip**, **registrar_port**: Registrar endpoint
 - **enable_agent_mtls**: Enable mTLS with agents and tenant
 - **tls_dir**: TLS material location

--- a/docs/user_guide/configuration.rst
+++ b/docs/user_guide/configuration.rst
@@ -106,6 +106,18 @@ address:
     [verifier]
     ip = 172.30.1.10
 
+For the verifier listener, the ``ip`` option can also be set to ``*`` to bind
+to all IPv4 and IPv6 addresses supported by the host:
+
+.. code-block:: ini
+
+    [verifier]
+    ip = *
+
+This wildcard only controls where the verifier listens for incoming
+connections. Other components still need a concrete verifier address or DNS name
+when they connect to the verifier.
+
 Override configurations via environment variables
 -------------------------------------------------
 

--- a/docs/user_guide/configuration.rst
+++ b/docs/user_guide/configuration.rst
@@ -106,15 +106,23 @@ address:
     [verifier]
     ip = 172.30.1.10
 
-For the verifier listener, the ``ip`` option can also be set to ``*`` to bind
-to all IPv4 and IPv6 addresses supported by the host:
+For the verifier listener, the ``ip`` option can also be set to a wildcard
+address to bind to all interfaces. Use ``0.0.0.0`` for all IPv4 interfaces:
 
 .. code-block:: ini
 
     [verifier]
-    ip = *
+    ip = 0.0.0.0
 
-This wildcard only controls where the verifier listens for incoming
+or ``::`` for all IPv6 interfaces (which on most dual-stack hosts also accepts
+incoming IPv4 connections):
+
+.. code-block:: ini
+
+    [verifier]
+    ip = ::
+
+These wildcard addresses only control where the verifier listens for incoming
 connections. Other components still need a concrete verifier address or DNS name
 when they connect to the verifier.
 

--- a/templates/2.6/verifier.j2
+++ b/templates/2.6/verifier.j2
@@ -8,8 +8,8 @@ version = {{ verifier.version }}
 uuid = {{ verifier.uuid }}
 
 # The binding address and port for the verifier server. Use a specific address
-# to bind one interface, or set ip to "*" to listen on all IPv4 and IPv6
-# addresses supported by the host.
+# to bind one interface, "0.0.0.0" to listen on all IPv4 interfaces, or "::"
+# to listen on all IPv6 interfaces (also accepts IPv4 on dual-stack hosts).
 ip = "{{ verifier.ip }}"
 port = {{ verifier.port }}
 

--- a/templates/2.6/verifier.j2
+++ b/templates/2.6/verifier.j2
@@ -7,7 +7,9 @@ version = {{ verifier.version }}
 # Unique identifier for each verifier instance.
 uuid = {{ verifier.uuid }}
 
-# The binding address and port for the verifier server
+# The binding address and port for the verifier server. Use a specific address
+# to bind one interface, or set ip to "*" to listen on all IPv4 and IPv6
+# addresses supported by the host.
 ip = "{{ verifier.ip }}"
 port = {{ verifier.port }}
 


### PR DESCRIPTION
Resolves #1408.

## Summary
- Document that the verifier `ip` option accepts `*` to bind all supported IPv4 and IPv6 addresses.
- Add the note to the current verifier config template, verifier man page, and configuration guide.
- Clarify that other components still need a concrete verifier address when connecting.

## Validation
- git diff --check
- git diff --check origin/master...HEAD
- targeted rg check for the new verifier wildcard snippets

`python3 -m pytest test/test_config.py -q` could not run locally because pytest is not installed in this checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified verifier IP configuration across user guides, man pages, and templates. Added examples and explicit notes that wildcard bind addresses (e.g., 0.0.0.0 / ::) make the service listen on all supported interfaces, while a concrete IP limits it to a single interface. Clarified this only affects listening interfaces, not which address other components use to connect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->