### PR TITLE
Document attestation status fields in verifier REST API

### DIFF
--- a/docs/rest_apis.rst
+++ b/docs/rest_apis.rst
@@ -85,6 +85,10 @@ API version 2.5 was first implemented in Keylime 7.14.0.
       API version instead of blindly using the agent's latest version
     * Prevents compatibility issues when newer agents communicate with older
       tenants/verifiers
+* Added attestation monitoring fields to `GET /v2.5/agents/{agent_id}` response:
+    * `attestation_status`: Current attestation status (``"PASS"``, ``"FAIL"``, or ``"PENDING"``)
+    * `attestation_period`: Configured attestation interval derived from ``quote_interval``
+    * `maximum_attestation_interval`: Maximum time allowed between attestations in PUSH mode
 
 Changes from v2.3 to v2.4
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/rest_apis/2_1/verifier.rst
+++ b/docs/rest_apis/2_1/verifier.rst
@@ -46,7 +46,10 @@ Verifier
             "last_event_id": "qoute_validation.quote_validation",
             "attestation_count": 240,
             "last_received_quote": 1676644582,
-            "last_successful_attestation": 1676644462
+            "last_successful_attestation": 1676644462,
+            "attestation_status": "PASS",
+            "attestation_period": "2s",
+            "maximum_attestation_interval": "10s"
           }
         }
 
@@ -76,6 +79,9 @@ Verifier
     :>json int attestation_count: Number of quotes received from the agent which have verified successfully.
     :>json int last_received_quote: Timestamp of the last quote received from the agent irrespective of validity. A value of 0 indicates no quotes have been received. May be `null` after upgrading from a previous Keylime version.
     :>json int last_successful_attestation: Timestamp of the last quote received from the agent which verified successfully. A value of 0 indicates no valid quotes have been received. May be `null` after upgrading from a previous Keylime version.
+    :>json string attestation_status: Current attestation status of the agent. Possible values: ``"PASS"`` (agent is successfully attesting), ``"FAIL"`` (agent attestation failed or timed out), ``"PENDING"`` (agent enrolled but not yet attested).
+    :>json string attestation_period: Configured attestation interval (e.g., ``"2s"``). Derived from the ``quote_interval`` verifier configuration option.
+    :>json string maximum_attestation_interval: Maximum time allowed between attestations before the agent is considered timed out in PUSH mode (e.g., ``"10s"``). Typically ``quote_interval * 5`` seconds.
 
 
 .. http:post::  /v2.1/agents/{agent_id:UUID}

--- a/docs/rest_apis/2_1/verifier.rst
+++ b/docs/rest_apis/2_1/verifier.rst
@@ -46,10 +46,7 @@ Verifier
             "last_event_id": "qoute_validation.quote_validation",
             "attestation_count": 240,
             "last_received_quote": 1676644582,
-            "last_successful_attestation": 1676644462,
-            "attestation_status": "PASS",
-            "attestation_period": "2s",
-            "maximum_attestation_interval": "10s"
+            "last_successful_attestation": 1676644462
           }
         }
 
@@ -79,9 +76,6 @@ Verifier
     :>json int attestation_count: Number of quotes received from the agent which have verified successfully.
     :>json int last_received_quote: Timestamp of the last quote received from the agent irrespective of validity. A value of 0 indicates no quotes have been received. May be `null` after upgrading from a previous Keylime version.
     :>json int last_successful_attestation: Timestamp of the last quote received from the agent which verified successfully. A value of 0 indicates no valid quotes have been received. May be `null` after upgrading from a previous Keylime version.
-    :>json string attestation_status: Current attestation status of the agent. Possible values: ``"PASS"`` (agent is successfully attesting), ``"FAIL"`` (agent attestation failed or timed out), ``"PENDING"`` (agent enrolled but not yet attested).
-    :>json string attestation_period: Configured attestation interval (e.g., ``"2s"``). Derived from the ``quote_interval`` verifier configuration option.
-    :>json string maximum_attestation_interval: Maximum time allowed between attestations before the agent is considered timed out in PUSH mode (e.g., ``"10s"``). Typically ``quote_interval * 5`` seconds.
 
 
 .. http:post::  /v2.1/agents/{agent_id:UUID}

--- a/docs/rest_apis/2_5/verifier.rst
+++ b/docs/rest_apis/2_5/verifier.rst
@@ -46,7 +46,10 @@ Verifier
             "last_event_id": "qoute_validation.quote_validation",
             "attestation_count": 240,
             "last_received_quote": 1676644582,
-            "last_successful_attestation": 1676644462
+            "last_successful_attestation": 1676644462,
+            "attestation_status": "PASS",
+            "attestation_period": "2s",
+            "maximum_attestation_interval": "10s"
           }
         }
 
@@ -76,6 +79,9 @@ Verifier
     :>json int attestation_count: Number of quotes received from the agent which have verified successfully.
     :>json int last_received_quote: Timestamp of the last quote received from the agent irrespective of validity. A value of 0 indicates no quotes have been received. May be `null` after upgrading from a previous Keylime version.
     :>json int last_successful_attestation: Timestamp of the last quote received from the agent which verified successfully. A value of 0 indicates no valid quotes have been received. May be `null` after upgrading from a previous Keylime version.
+    :>json string attestation_status: Current attestation status of the agent. Possible values: ``"PASS"`` (agent is successfully attesting), ``"FAIL"`` (agent attestation failed or timed out), ``"PENDING"`` (agent enrolled but not yet attested).
+    :>json string attestation_period: Configured attestation interval (e.g., ``"2s"``). Derived from the ``quote_interval`` verifier configuration option.
+    :>json string maximum_attestation_interval: Maximum time allowed between attestations before the agent is considered timed out in PUSH mode (e.g., ``"10s"``). Typically ``quote_interval * 5`` seconds.
 
 
 .. http:post::  /v2.5/agents/{agent_id:UUID}


### PR DESCRIPTION
# PR Title
  **`Document attestation status fields in verifier REST API`**

  ## Type of Change
  *(Select all that apply)*
  - [ ] Bug fix (non-breaking change)
  - [ ] New feature (non-breaking change)
  - [ ] Breaking change (fix/feature causing existing behavior to change)
  - [x] Documentation update (standalone)
  - [ ] Code refactor (no functional changes)
  - [ ] Test cases (added/modified)
  - [ ] CI/CD changes
  - [ ] Other (please specify: ______)

  ## Related Issues
  **Resolves:** #1893

  ## Change Description

  ### Concise Summary
  Add missing attestation fields to verifier API docs

  Three response fields returned by the verifier `GET /v2.1/agents/{agent_id}` endpoint were added in commit 0b4335d as part of #1818 but were never documented in the REST API reference. This PR closes that gap.

  ### Technical Details

  The verifier endpoint returns `attestation_status`, `attestation_period`, and `maximum_attestation_interval` in production, but users consulting the API documentation would not know these fields exist or what values to expect.

  - **Motivation:** API consumers relying on the documentation have no way to discover these fields or understand their semantics without reading source code.
  - **What changed:** Updated `docs/rest_apis/2_1/verifier.rst` to add the three fields to both the example JSON response and the field description table.
  - **Fields documented:**
    - `attestation_status` (string) — `"PASS"`, `"FAIL"`, or `"PENDING"`
    - `attestation_period` (string) — derived from `quote_interval` config (e.g., `"2s"`)
    - `maximum_attestation_interval` (string) — PUSH mode timeout threshold (e.g., `"10s"`)
  - **No code changes:** this is a documentation-only update; no runtime behavior is affected.

  ## Documentation Updates Required
  *(Check all that apply)*
  - [ ] Updated markdown docs (file path: ______)
  - [ ] Updated code comments/docstrings
  - [x] Needs user guide updates (`docs/`) — `docs/rest_apis/2_1/verifier.rst`
  - [ ] Needs ReadTheDocs updates
  - [ ] No docs needed (requires maintainer approval)

  ## Verification Process
  1. **Environment:** Any system with Sphinx installed, or review the raw RST diff directly.
  2. **Validation:**
     - Build the docs locally: `make -C docs html`
     - Open the generated verifier REST API page and confirm the three new fields appear in both the example response JSON and the field description table.
     - Cross-reference with the actual API response from a running verifier to confirm field names, types, and descriptions match.
  3. **Expected result:** The rendered documentation shows `attestation_status`, `attestation_period`, and `maximum_attestation_interval` with accurate descriptions matching the behavior in `keylime/cloud_verifier_common.py`.

  ## Checklist
  - [x] Code follows project style guidelines
  - [ ] Unit/integration tests added/updated — N/A (documentation only)
  - [x] Documentation updated (per above section)
  - [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/)
  - [ ] CHANGELOG updated (if applicable)
  - [x] All tests pass (local & CI)

  ## Additional Context
  The `attestation_status` field logic is implemented in `keylime/cloud_verifier_common.py` (lines 276–317) and derives its value from a combination of `operational_state`, `last_successful_attestation`, and `attestation_count`. The bulk endpoint (`GET /v2.1/agents?bulk`) also returns these fields via the same code path, but its documentation is not in this
  file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated REST API docs to include new attestation monitoring fields in agent status responses: last_successful_attestation, attestation_status, attestation_period, and maximum_attestation_interval for GET /v2.5/agents/{agent_id}.
  * Added v2.5-to-v3.0 migration notes covering these attestation monitoring fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->