### PR TITLE
verifier: Prevent process_agent() from overwriting TERMINATED state (TOCTOU race)

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -369,6 +369,7 @@ def _complete_deletion_if_terminated(agent_id: str) -> None:
 
     If the agent still exists and is TERMINATED, complete the deletion
     now — there will be no future process_agent() cycle to do it.
+    If the agent is TENANT_FAILED, leave it for the DELETE handler.
     If the agent is already gone, just log and return.
     """
     try:
@@ -379,6 +380,8 @@ def _complete_deletion_if_terminated(agent_id: str) -> None:
             elif agent.operational_state == states.TERMINATED:  # pyright: ignore
                 logger.info("Agent %s was terminated during attestation, completing deletion", agent_id)
                 verifier_db_delete_agent(session, agent_id)
+            elif agent.operational_state == states.TENANT_FAILED:  # pyright: ignore
+                logger.info("Agent %s tenant quote check failed, stopping poll cycle", agent_id)
             else:
                 logger.warning(
                     "Agent %s update matched 0 rows, but agent exists in state %s. Stopping poll cycle.",
@@ -2220,12 +2223,13 @@ async def update_agent_api_version(
                     session.query(VerfierMain)
                     .filter_by(agent_id=agent_id)
                     .filter(VerfierMain.operational_state != states.TERMINATED)  # pyright: ignore
+                    .filter(VerfierMain.operational_state != states.TENANT_FAILED)  # pyright: ignore
                     .update(agent_db)  # pyright: ignore
                 )
                 # session.commit() is automatically called by context manager
 
             if rows == 0:
-                logger.info("Agent %s was terminated during version negotiation, stopping", agent_id)
+                logger.info("Agent %s was terminated or stopped during version negotiation, stopping", agent_id)
                 _complete_deletion_if_terminated(agent_id)
                 return None
 
@@ -2624,6 +2628,7 @@ async def process_agent(
                             session.query(VerfierMain)
                             .filter_by(agent_id=agent["agent_id"])
                             .filter(VerfierMain.operational_state != states.TERMINATED)  # pyright: ignore
+                            .filter(VerfierMain.operational_state != states.TENANT_FAILED)  # pyright: ignore
                             .update(agent)  # type: ignore[arg-type]
                         )
                         # session.commit() is automatically called by context manager
@@ -2640,15 +2645,17 @@ async def process_agent(
                     del agent_db[key]
 
             # Fourth database operation - update agent state.
-            # The TERMINATED filter prevents a TOCTOU race: if a DELETE
-            # handler set TERMINATED between our initial read and this
-            # write, the update matches zero rows and we stop polling
-            # instead of reverting the agent back to an active state.
+            # The TERMINATED/TENANT_FAILED filters prevent a TOCTOU race:
+            # if a DELETE or PUT /stop handler set one of these states
+            # between our initial read and this write, the update matches
+            # zero rows and we stop polling instead of reverting the agent
+            # back to an active state.
             with session_context() as session:
                 rows = (
                     session.query(VerfierMain)
                     .filter_by(agent_id=agent_db["agent_id"])
                     .filter(VerfierMain.operational_state != states.TERMINATED)  # pyright: ignore
+                    .filter(VerfierMain.operational_state != states.TENANT_FAILED)  # pyright: ignore
                     .update(agent_db)  # pyright: ignore
                 )
                 # session.commit() is automatically called by context manager

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -364,6 +364,31 @@ def verifier_db_delete_agent(session: Session, agent_id: str) -> None:
     session.commit()
 
 
+def _complete_deletion_if_terminated(agent_id: str) -> None:
+    """Re-read the agent after a guarded update matched zero rows.
+
+    If the agent still exists and is TERMINATED, complete the deletion
+    now — there will be no future process_agent() cycle to do it.
+    If the agent is already gone, just log and return.
+    """
+    try:
+        with session_context() as session:
+            agent = session.query(VerfierMain).filter_by(agent_id=agent_id).first()
+            if agent is None:
+                logger.info("Agent %s was deleted during attestation, stopping poll cycle", agent_id)
+            elif agent.operational_state == states.TERMINATED:  # pyright: ignore
+                logger.info("Agent %s was terminated during attestation, completing deletion", agent_id)
+                verifier_db_delete_agent(session, agent_id)
+            else:
+                logger.warning(
+                    "Agent %s update matched 0 rows, but agent exists in state %s. Stopping poll cycle.",
+                    agent_id,
+                    agent.operational_state,
+                )
+    except SQLAlchemyError:
+        logger.exception("SQLAlchemy Error completing deletion for agent %s", agent_id)
+
+
 def store_attestation_state(agentAttestState: AgentAttestState) -> None:
     # Only store if IMA log was evaluated
     if agentAttestState.get_ima_pcrs():
@@ -2190,8 +2215,18 @@ async def update_agent_api_version(
                     if key in agent_db:
                         del agent_db[key]
 
-                session.query(VerfierMain).filter_by(agent_id=agent_id).update(agent_db)  # pyright: ignore
+                rows = (
+                    session.query(VerfierMain)
+                    .filter_by(agent_id=agent_id)
+                    .filter(VerfierMain.operational_state != states.TERMINATED)  # pyright: ignore
+                    .update(agent_db)  # pyright: ignore
+                )
                 # session.commit() is automatically called by context manager
+
+            if rows == 0:
+                logger.info("Agent %s was terminated during version negotiation, stopping", agent_id)
+                _complete_deletion_if_terminated(agent_id)
+                return None
 
         else:
             logger.warning("Agent %s did not provide version information", agent_id)
@@ -2584,10 +2619,17 @@ async def process_agent(
                         for key in exclude_db:
                             if key in agent:
                                 del agent[key]
-                        session.query(VerfierMain).filter_by(agent_id=agent["agent_id"]).update(
-                            agent  # type: ignore[arg-type]
+                        rows = (
+                            session.query(VerfierMain)
+                            .filter_by(agent_id=agent["agent_id"])
+                            .filter(VerfierMain.operational_state != states.TERMINATED)  # pyright: ignore
+                            .update(agent)  # type: ignore[arg-type]
                         )
                         # session.commit() is automatically called by context manager
+
+                    if rows == 0:
+                        _complete_deletion_if_terminated(agent["agent_id"])
+                        return
 
         # propagate all state, but remove none DB keys first (using exclude_db)
         try:
@@ -2596,10 +2638,23 @@ async def process_agent(
                 if key in agent_db:
                     del agent_db[key]
 
-            # Fourth database operation - update agent state
+            # Fourth database operation - update agent state.
+            # The TERMINATED filter prevents a TOCTOU race: if a DELETE
+            # handler set TERMINATED between our initial read and this
+            # write, the update matches zero rows and we stop polling
+            # instead of reverting the agent back to an active state.
             with session_context() as session:
-                session.query(VerfierMain).filter_by(agent_id=agent_db["agent_id"]).update(agent_db)  # pyright: ignore
+                rows = (
+                    session.query(VerfierMain)
+                    .filter_by(agent_id=agent_db["agent_id"])
+                    .filter(VerfierMain.operational_state != states.TERMINATED)  # pyright: ignore
+                    .update(agent_db)  # pyright: ignore
+                )
                 # session.commit() is automatically called by context manager
+
+            if rows == 0:
+                _complete_deletion_if_terminated(agent["agent_id"])
+                return
         except SQLAlchemyError as e:
             logger.error("SQLAlchemy Error for agent ID %s: %s", agent["agent_id"], e)
 

--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -1151,9 +1151,10 @@ class AgentsHandler(BaseHandler):
                         if mode == "pull":
                             # Prepare SSLContext for mTLS connections
                             agent_data["ssl_context"] = None
-                            if agent_data["mtls_cert"] and agent_data["mtls_cert"] != "disabled":
+                            mtls_cert = agent_data["mtls_cert"]
+                            if agent_mtls_cert_enabled and isinstance(mtls_cert, str) and mtls_cert != "disabled":
                                 agent_data["ssl_context"] = web_util.generate_agent_tls_context(
-                                    "verifier", agent_data["mtls_cert"], logger=logger
+                                    "verifier", mtls_cert, logger=logger
                                 )
 
                             if agent_data["ssl_context"] is None:

--- a/test/test_cloud_verifier_tornado.py
+++ b/test/test_cloud_verifier_tornado.py
@@ -146,8 +146,26 @@ class TestCompleteDeletionIfTerminated(unittest.TestCase):
     @patch("keylime.cloud_verifier_tornado.logger")
     @patch("keylime.cloud_verifier_tornado.verifier_db_delete_agent")
     @patch("keylime.cloud_verifier_tornado.session_context")
+    def test_noop_when_agent_tenant_failed(self, mock_session_ctx, mock_delete, mock_logger):
+        """Does not delete when agent is in TENANT_FAILED state."""
+        mock_session = MagicMock()
+        mock_agent = MagicMock()
+        mock_agent.operational_state = 10  # states.TENANT_FAILED
+        mock_session.query.return_value.filter_by.return_value.first.return_value = mock_agent
+        mock_session_ctx.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        cloud_verifier_tornado._complete_deletion_if_terminated("agent-123")
+
+        mock_delete.assert_not_called()
+        mock_logger.info.assert_called_once()
+        self.assertIn("tenant quote check failed", mock_logger.info.call_args[0][0])
+
+    @patch("keylime.cloud_verifier_tornado.logger")
+    @patch("keylime.cloud_verifier_tornado.verifier_db_delete_agent")
+    @patch("keylime.cloud_verifier_tornado.session_context")
     def test_warns_when_agent_in_unexpected_state(self, mock_session_ctx, mock_delete, mock_logger):
-        """Logs warning and does not delete when agent exists in a non-TERMINATED state."""
+        """Logs warning and does not delete when agent exists in an unexpected state."""
         mock_session = MagicMock()
         mock_agent = MagicMock()
         mock_agent.operational_state = 3  # states.GET_QUOTE

--- a/test/test_cloud_verifier_tornado.py
+++ b/test/test_cloud_verifier_tornado.py
@@ -10,6 +10,8 @@ Tests cover:
 import unittest
 from unittest.mock import MagicMock, patch
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from keylime import cloud_verifier_tornado
 
 
@@ -108,6 +110,63 @@ class TestStoreAttestationState(unittest.TestCase):
 
         # Verify no attempt to set attributes on None
         mock_session.add.assert_not_called()
+
+
+class TestCompleteDeletionIfTerminated(unittest.TestCase):
+    """Test _complete_deletion_if_terminated helper."""
+
+    @patch("keylime.cloud_verifier_tornado.verifier_db_delete_agent")
+    @patch("keylime.cloud_verifier_tornado.session_context")
+    def test_deletes_when_agent_is_terminated(self, mock_session_ctx, mock_delete):
+        """Completes deletion when agent exists and is TERMINATED."""
+        mock_session = MagicMock()
+        mock_agent = MagicMock()
+        mock_agent.operational_state = 8  # states.TERMINATED
+        mock_session.query.return_value.filter_by.return_value.first.return_value = mock_agent
+        mock_session_ctx.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        cloud_verifier_tornado._complete_deletion_if_terminated("agent-123")
+
+        mock_delete.assert_called_once_with(mock_session, "agent-123")
+
+    @patch("keylime.cloud_verifier_tornado.verifier_db_delete_agent")
+    @patch("keylime.cloud_verifier_tornado.session_context")
+    def test_noop_when_agent_already_deleted(self, mock_session_ctx, mock_delete):
+        """Logs and returns when agent no longer exists in DB."""
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter_by.return_value.first.return_value = None
+        mock_session_ctx.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        cloud_verifier_tornado._complete_deletion_if_terminated("agent-123")
+
+        mock_delete.assert_not_called()
+
+    @patch("keylime.cloud_verifier_tornado.logger")
+    @patch("keylime.cloud_verifier_tornado.verifier_db_delete_agent")
+    @patch("keylime.cloud_verifier_tornado.session_context")
+    def test_warns_when_agent_in_unexpected_state(self, mock_session_ctx, mock_delete, mock_logger):
+        """Logs warning and does not delete when agent exists in a non-TERMINATED state."""
+        mock_session = MagicMock()
+        mock_agent = MagicMock()
+        mock_agent.operational_state = 3  # states.GET_QUOTE
+        mock_session.query.return_value.filter_by.return_value.first.return_value = mock_agent
+        mock_session_ctx.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        cloud_verifier_tornado._complete_deletion_if_terminated("agent-123")
+
+        mock_delete.assert_not_called()
+        mock_logger.warning.assert_called_once()
+
+    @patch("keylime.cloud_verifier_tornado.session_context")
+    def test_handles_sqlalchemy_error(self, mock_session_ctx):
+        """Logs and does not raise on SQLAlchemyError."""
+        mock_session_ctx.return_value.__enter__ = MagicMock(side_effect=SQLAlchemyError("connection lost"))
+        mock_session_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        cloud_verifier_tornado._complete_deletion_if_terminated("agent-123")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# verifier: Prevent process_agent() from overwriting TERMINATED/TENANT_FAILED state (TOCTOU race)

## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [x] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
Closes keylime/keylime#1900

## Change Description

### Concise Summary
Fix TOCTOU race where `process_agent()` overwrites TERMINATED or TENANT_FAILED state set by a concurrent DELETE or PUT /stop handler, causing the agent to continue attesting indefinitely.

### Technical Details

**Problem:**

When a DELETE request arrives during an in-flight attestation cycle, the
DELETE handler correctly sets `operational_state = TERMINATED` in the
database and returns 202. However, the in-flight `process_agent()`
coroutine can overwrite TERMINATED back to an active state (e.g.
`GET_QUOTE`) because the DB writes in `process_agent()` are
unconditional.

The same race applies to `TENANT_FAILED`: if `PUT /stop` sets
`TENANT_FAILED` between the initial read and the DB write,
`process_agent()` overwrites it back to an active state, and the
stop is permanently lost.

The race window:

1. `process_agent()` reads `stored_agent` from DB — sees `GET_QUOTE`
2. TERMINATED/TENANT_FAILED check passes (state is still active)
3. DELETE/PUT handler executes — sets terminal state in DB, returns
4. `process_agent()` writes the in-memory agent dict (with
   `operational_state = GET_QUOTE`) back to DB — **overwrites
   the terminal state**
5. Schedules next poll — attestation continues indefinitely

This was observed in CI: after DELETE returned 202, the agent briefly
showed "Terminated" but then reverted to "Get Quote" with
`attestation_count` increasing on each poll. The tenant timed out after
5 retries.

**Fix:**

Add `WHERE operational_state NOT IN (TERMINATED, TENANT_FAILED)` filters
to the three DB update queries that write the agent dict back to the
database:

1. The main state-propagation write (runs every attestation cycle)
2. The failure-state write (FAILED/INVALID_QUOTE path)
3. The version-negotiation write in `update_agent_api_version()`

If the update matches zero rows, the agent was terminated or stopped
concurrently. A new helper `_complete_deletion_if_terminated()` re-reads
the agent to determine the appropriate action:

- **TERMINATED**: completes the deletion immediately (no future
  `process_agent()` cycle will be scheduled to do it)
- **TENANT_FAILED**: leaves the agent for the DELETE handler to clean up
- **Already deleted**: logs and returns
- **Unexpected state**: logs a warning and stops polling

**Pyright fix (separate commit):**

Narrowed `agent_data["mtls_cert"]` with `isinstance(mtls_cert, str)`
before passing to `generate_agent_tls_context()`, fixing a
`reportArgumentType` error. The function's internal `enable_agent_mtls`
check already provides the config-level guard.

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. Start verifier with a single pull-mode agent and software TPM
2. Wait for successful attestation cycles (`operational_state` = `Get Quote`)
3. Issue `keylime_tenant -c update` (which internally does DELETE + POST)
4. Verify the DELETE returns 202, agent transitions to Terminated, and
   the in-flight attestation does NOT revert the state back to Get Quote
5. Verify `keylime_tenant -c cvstatus` returns 404 (agent deleted)
6. Verify no `AssertionError` in verifier logs
7. Run unit tests: `python -m pytest test/test_cloud_verifier_tornado.py`

## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context
- This is a follow-up to the earlier race condition fix (preventing
  re-deletion of TERMINATED agents). That fix addressed the DELETE
  handler's behavior; this fix addresses the complementary problem on
  the `process_agent()` side.
- The `WHERE` filter makes the check-and-write atomic at the SQL level,
  eliminating the TOCTOU window entirely.
- The TENANT_FAILED guard addresses the same structural race for
  `PUT /stop` — without it, a concurrent stop request would be
  silently overwritten by the next attestation cycle.

> This PR description was generated with the assistance of Claude Opus 4.6 (Anthropic).