### PR TITLE
server: Add max_workers config to cap worker process count

### DIFF
--- a/docs/man/keylime_registrar.8.rst
+++ b/docs/man/keylime_registrar.8.rst
@@ -53,6 +53,10 @@ Essential configuration options:
 **database_pool_sz_ovfl**
    Pool size, overflow (non-sqlite)
 
+**max_workers**
+   Maximum worker processes; actual count is ``min(cpu_count, max_workers)``
+   (``0`` = no limit, default ``16``)
+
 **auto_migrate_db**
    Apply DB migrations on startup
 
@@ -128,7 +132,7 @@ NOTES
 
 - HTTPS is required for routes unless explicitly allowed insecure by the service.
 - With ``tls_dir = default``, start the verifier before the registrar so the shared CA/certs exist in ``$KEYLIME_DIR/cv_ca``.
-- The service forks worker processes (default: CPU count).
+- The service forks worker processes (default: CPU count, capped by ``max_workers``).
 - Registrar and verifier may run on the same host or on separate hosts.
 
 SEE ALSO

--- a/docs/man/keylime_verifier.8.rst
+++ b/docs/man/keylime_verifier.8.rst
@@ -52,6 +52,7 @@ Essentials:
 - **database_pool_sz_ovfl**: Pool size, overflow (non-sqlite)
 - **auto_migrate_db**: Apply DB migrations on startup
 - **num_workers**: Number of worker processes (``0`` = CPU count)
+- **max_workers**: Maximum worker processes; actual count is ``min(cpu_count, max_workers)`` (``0`` = no limit, default ``16``)
 - **exponential_backoff**, **retry_interval**, **max_retries**: Retry behavior for agent comm
 - **quote_interval**: Time between integrity checks (seconds)
 - **max_upload_size**: Upload size limit (bytes)

--- a/docs/user_guide/configuration.rst
+++ b/docs/user_guide/configuration.rst
@@ -369,6 +369,10 @@ Common Options (Both Models)
       - ``0``
       - 2.0
       - ``KEYLIME_VERIFIER_NUM_WORKERS``
+    * - ``max_workers``
+      - ``16``
+      - 2.6
+      - ``KEYLIME_VERIFIER_MAX_WORKERS``
     * - ``max_upload_size``
       - ``104857600``
       - 2.0
@@ -613,6 +617,10 @@ Registrar Configuration (``/etc/keylime/registrar.conf``)
       - ``5,10``
       - 2.0
       - ``KEYLIME_REGISTRAR_DATABASE_POOL_SZ_OVFL``
+    * - ``max_workers``
+      - ``16``
+      - 2.6
+      - ``KEYLIME_REGISTRAR_MAX_WORKERS``
     * - ``auto_migrate_db``
       - ``True``
       - 2.0

--- a/keylime/web/base/server.py
+++ b/keylime/web/base/server.py
@@ -210,6 +210,7 @@ class Server(ABC):
         self.__max_upload_size: Optional[int] = 104857600  # 100MiB
         self.__ssl_ctx: Optional["SSLContext"] = None
         self.__worker_count: Optional[int] = 0
+        self.__max_workers: Optional[int] = 0
 
         # Override defaults with values given by the implementing class
         self._setup()
@@ -563,6 +564,18 @@ class Server(ABC):
 
         self._set_option("max_upload_size", **kwargs)
 
+    def _set_max_workers(self, **kwargs: Any) -> None:
+        """Sets the maximum number of worker processes to fork.
+
+        The actual worker count will be min(cpu_count, max_workers).
+        A value of 0 means no limit (use all CPUs).
+        """
+
+        if "from_config" in kwargs:
+            kwargs.update({"from_config": (kwargs["from_config"], int)})
+
+        self._set_option("max_workers", **kwargs)
+
     def _set_ssl_ctx(self, **kwargs: Any) -> None:
         """Sets the values used to secure TLS sessions. See https://docs.python.org/3/library/ssl.html#ssl.SSLContext"""
 
@@ -725,13 +738,19 @@ class Server(ABC):
         return self.__ssl_ctx
 
     @property
-    def worker_count(self) -> int:
-        # pylint: disable=no-else-return
+    def max_workers(self) -> Optional[int]:
+        return self.__max_workers
 
+    @property
+    def worker_count(self) -> int:
         if self.__worker_count == 0 or self.__worker_count is None:
-            return multiprocessing.cpu_count()
+            count = multiprocessing.cpu_count()
         else:
-            return self.__worker_count
+            count = self.__worker_count
+
+        if self.__max_workers and self.__max_workers > 0:
+            return min(count, self.__max_workers)
+        return count
 
     @property
     def routes(self) -> list[Route]:

--- a/keylime/web/registrar_server.py
+++ b/keylime/web/registrar_server.py
@@ -12,6 +12,7 @@ class RegistrarServer(Server):
         self._set_http_port(from_config="port")
         self._set_https_port(from_config="tls_port")
         self._set_max_upload_size(from_config="max_upload_size")
+        self._set_max_workers(from_config="max_workers")
         self._set_default_ssl_ctx()
 
     def _routes(self):

--- a/keylime/web/verifier_server.py
+++ b/keylime/web/verifier_server.py
@@ -167,6 +167,7 @@ class VerifierServer(Server):
         self._set_http_port(value=None)  # verifier does not accept insecure connections
         self._set_https_port(from_config="port")
         self._set_max_upload_size(from_config="max_upload_size")
+        self._set_max_workers(from_config="max_workers")
         self._set_default_ssl_ctx()
 
     def _routes(self) -> None:

--- a/templates/2.6/mapping.json
+++ b/templates/2.6/mapping.json
@@ -4,7 +4,13 @@
     "components": {
         "verifier": {
             "add": {
-                "shutdown_drain_timeout": "10"
+                "shutdown_drain_timeout": "10",
+                "max_workers": "16"
+            }
+        },
+        "registrar": {
+            "add": {
+                "max_workers": "16"
             }
         }
     }

--- a/templates/2.6/registrar.j2
+++ b/templates/2.6/registrar.j2
@@ -106,6 +106,14 @@ database_url = {{ registrar.database_url }}
 # (https://docs.sqlalchemy.org/en/14/core/pooling.html#api-documentation-available-pool-implementations)
 database_pool_sz_ovfl = {{ registrar.database_pool_sz_ovfl }}
 
+# Maximum number of worker processes. The actual number of workers will be
+# min(cpu_count, max_workers). This prevents creating too many workers on
+# high-core-count systems, which can lead to excessive database connections
+# and resource usage.
+# Set to "0" for no limit (use all CPUs).
+# Default: 16
+max_workers = {{ registrar.max_workers }}
+
 # Whether to automatically update the DB schema using alembic
 auto_migrate_db = {{ registrar.auto_migrate_db }}
 

--- a/templates/2.6/verifier.j2
+++ b/templates/2.6/verifier.j2
@@ -165,6 +165,14 @@ auto_migrate_db = {{ verifier.auto_migrate_db }}
 # Set to "0" to create one worker per processor.
 num_workers = {{ verifier.num_workers }}
 
+# Maximum number of worker processes. The actual number of workers will be
+# min(cpu_count, max_workers). This prevents creating too many workers on
+# high-core-count systems, which can lead to excessive database connections
+# and resource usage.
+# Set to "0" for no limit (use all CPUs).
+# Default: 16
+max_workers = {{ verifier.max_workers }}
+
 # Whether or not to use an exponential backoff algorithm for retries.
 exponential_backoff = {{ verifier.exponential_backoff }}
 

--- a/test/test_server_base.py
+++ b/test/test_server_base.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest.mock import patch
+
+from keylime.web.base.server import Server
+
+
+class _StubServer(Server):
+    """Minimal concrete subclass of Server for testing base class properties."""
+
+    def _routes(self):
+        pass
+
+
+class TestWorkerCount(unittest.TestCase):
+    """Tests for Server.worker_count property with max_workers cap."""
+
+    def _make_server(self, worker_count=0, max_workers=0):
+        """Create a Server instance without triggering __init__ (which binds sockets)."""
+        server = _StubServer.__new__(_StubServer)
+        # pylint: disable=attribute-defined-outside-init
+        setattr(server, "_Server__worker_count", worker_count)
+        setattr(server, "_Server__max_workers", max_workers)
+        return server
+
+    @patch("keylime.web.base.server.multiprocessing")
+    def test_defaults_to_cpu_count(self, mock_mp):
+        mock_mp.cpu_count.return_value = 8
+        server = self._make_server()
+        self.assertEqual(server.worker_count, 8)
+
+    @patch("keylime.web.base.server.multiprocessing")
+    def test_capped_by_max_workers(self, mock_mp):
+        mock_mp.cpu_count.return_value = 40
+        server = self._make_server(max_workers=4)
+        self.assertEqual(server.worker_count, 4)
+
+    @patch("keylime.web.base.server.multiprocessing")
+    def test_not_capped_when_below_max(self, mock_mp):
+        mock_mp.cpu_count.return_value = 8
+        server = self._make_server(max_workers=16)
+        self.assertEqual(server.worker_count, 8)
+
+    @patch("keylime.web.base.server.multiprocessing")
+    def test_max_workers_zero_means_no_limit(self, mock_mp):
+        mock_mp.cpu_count.return_value = 64
+        server = self._make_server(max_workers=0)
+        self.assertEqual(server.worker_count, 64)
+
+    def test_explicit_worker_count_also_capped(self):
+        server = self._make_server(worker_count=20, max_workers=8)
+        self.assertEqual(server.worker_count, 8)
+
+    def test_explicit_worker_count_not_capped_when_below_max(self):
+        server = self._make_server(worker_count=4, max_workers=16)
+        self.assertEqual(server.worker_count, 4)
+
+    def test_explicit_worker_count_no_limit(self):
+        server = self._make_server(worker_count=20, max_workers=0)
+        self.assertEqual(server.worker_count, 20)


### PR DESCRIPTION
# server: Add max_workers config to cap worker process count

## Type of Change
*(Select all that apply)*
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
*(If you use an issue tracker, please put references to them)*
**Resolves:** #1896

## Change Description

### Concise Summary
Add max_workers config option to limit worker processes

On high-core-count systems, the verifier and registrar spawn one worker
per CPU. Each worker creates its own database connection pool
(pool_size=5, max_overflow=10 = 15 connections), resulting in 600+
potential MySQL connections on a 40-core system. This exceeds typical
MySQL max_connections limits and wastes resources.

A new `max_workers` configuration option (default: 16) caps the worker
count to `min(cpu_count, max_workers)`, preventing resource exhaustion
while preserving auto-detection on smaller systems.

### Technical Details

- **Motivation:** On systems with many cores (e.g., Ampere Altra with
  40+ cores), the default behavior of spawning one worker per CPU leads
  to database connection exhaustion. Each worker creates a full
  connection pool, and the total number of connections grows linearly
  with CPU count.

- **Architectural decisions:**
  - Added as a new `max_workers` option rather than modifying `num_workers`
    semantics, since the two serve different purposes: `num_workers` sets an
    explicit count, `max_workers` provides a safety cap for auto-detection.
  - Default of 16 balances parallelism with database resource consumption.
    Setting `max_workers = 0` disables the cap.
  - Applied to both verifier and registrar since both use the same `Server`
    base class and fork workers identically.

- **Unintended side effects:** Systems with more than 16 CPUs will now
  default to 16 workers instead of `cpu_count` workers. Systems with
  fewer than 16 CPUs are unaffected.

- **Alternative approaches considered:**
  - *StaticPool (1 connection per worker):* Not safe. Multiple async
    coroutines can hold concurrent DB sessions within a single worker
    when one awaits network I/O and another enters `session_context()`.
  - *NullPool (no connection pooling):* Adds 10-20ms connection overhead
    per query, unacceptable for attestation latency.
  - *Dynamic pool_size reduction per worker:* Harder to configure and
    less intuitive for operators.

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [x] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [ ] No docs needed (requires maintainer approval)

## Verification Process
1. **Unit tests:** Run `python -m pytest test/test_server_base.py -v`.
   Verifies `worker_count` property behavior: defaults to `cpu_count`,
   capped by `max_workers`, uncapped when `max_workers=0`, explicit
   `worker_count` also capped.
2. **Code quality:** Run `tox -e pylint,pyright,mypy,black,isort`. All
   checks pass (only pre-existing pyright error in
   `cloud_verifier_tornado.py:1131`).
3. **Documentation:** Run `cd docs && make html`. Verify `max_workers`
   appears in the configuration table and man pages.
4. **Manual verification on high-core-count system:** Set
   `max_workers = 4` in `verifier.conf`, start the verifier, and confirm
   the log line shows `with 4 worker processes...` instead of the full
   CPU count.

## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context
- The existing `num_workers` config option in `verifier.conf` is not
  read by the `Server` class — it is only used by legacy code in
  `cloud_verifier_tornado.py:main()` which is no longer the active
  startup path. Wiring up `num_workers` to the `Server` class could be
  done as a follow-up.
- Config option added to config version 2.6 (unreleased).

> This PR was generated with the assistance of Claude Opus 4.6 (Anthropic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `max_workers` configuration option for verifier and registrar services to control the maximum number of worker processes (default: 16). Configure via environment variables or configuration files.

* **Documentation**
  * Updated configuration and service documentation with the new `max_workers` setting and its default behavior.
  * Added guidance for workers management and process limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->