### PR TITLE
fix: Validate cert_bits in mk_request when config is absent

### DIFF
--- a/keylime/ca_impl_openssl.py
+++ b/keylime/ca_impl_openssl.py
@@ -134,6 +134,9 @@ def mk_request(bits: int, common_name: str) -> Tuple[CertificateBuilder, RSAPriv
       common_name -- common name in the request
     Returns a X509 request and the private key
     """
+    # RSA key_size must be at least 1024; default to 2048 for invalid values
+    if bits < 1024:
+        bits = 2048
 
     privkey = rsa.generate_private_key(
         public_exponent=65537,


### PR DESCRIPTION
Closes keylime/keylime#1906

## Problem
`config.getint("ca", "cert_bits")` returns `-1` when the `ca.conf` configuration file is not installed. This gets passed to `rsa.generate_private_key(key_size=-1)`, which raises:

```
ValueError: key_size must be at least 1024-bits.
```

## Fix
Add a guard at the start of `mk_request()` to ensure `bits` is at least 1024. If an invalid value is passed, we default to 2048.

## Files Changed
- `keylime/ca_impl_openssl.py` — 3 lines

## Testing
The fix was verified by inspecting the code path. A follow-up with a targeted test fixture would further harden this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a minimum RSA key size for generated keys: requests below 1024 bits are automatically raised to 2048 bits to maintain security standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->