### PR TITLE
fix: guard systemd service installation in installer.sh

### DIFF
--- a/services/installer.sh
+++ b/services/installer.sh
@@ -20,8 +20,12 @@ fi
 echo "Using keylime scripts directory: ${KEYLIMEDIR}"
 
 # prepare keylime service files and store them in systemd path
-sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" "$BASEDIR/keylime_registrar.service.template" > /etc/systemd/system/keylime_registrar.service
-sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" "$BASEDIR/keylime_verifier.service.template" > /etc/systemd/system/keylime_verifier.service
+if command -v systemctl >/dev/null 2>&1; then
+    sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" "$BASEDIR/keylime_registrar.service.template" > /etc/systemd/system/keylime_registrar.service
+    sed "s|KEYLIMEDIR|$KEYLIMEDIR|g" "$BASEDIR/keylime_verifier.service.template" > /etc/systemd/system/keylime_verifier.service
+else
+    echo "systemd not detected, skipping service file installation"
+fi
 
 echo "Creating keylime user if it not exists"
 if ! getent passwd keylime >/dev/null; then
@@ -76,10 +80,12 @@ else
     fi
 fi
 
-# set permissions
-chmod 664 /etc/systemd/system/keylime_registrar.service
-chmod 664 /etc/systemd/system/keylime_verifier.service
+# set permissions for systemd service files
+if command -v systemctl >/dev/null 2>&1; then
+    chmod 664 /etc/systemd/system/keylime_registrar.service
+    chmod 664 /etc/systemd/system/keylime_verifier.service
 
-# enable at startup
-systemctl enable keylime_registrar.service
-systemctl enable keylime_verifier.service
+    # enable at startup
+    systemctl enable keylime_registrar.service
+    systemctl enable keylime_verifier.service
+fi


### PR DESCRIPTION
## Summary

Guard systemd-specific operations in `services/installer.sh` with a `command -v systemctl` check to support non-systemd systems (OpenRC, sysvinit).

## Changes

- Lines 22-24: Service file creation (`sed` commands) now guarded
- Lines 66-67: `systemctl enable` calls now guarded  
- Permissions (`chmod 664`) also guarded since service files may not exist on non-systemd

When systemd is absent, the script will:
- Skip service file installation
- Skip `systemctl enable` calls
- Continue with all other installation steps (user creation, TPM certs, tmpfiles.d, etc.)

## Closes

Closes #1887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced installer with conditional systemd service setup: it now detects `systemctl`, installs and enables the registrar and verifier services when supported, and preserves the existing non-systemd fallback behavior when `systemctl` isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->