### PR TITLE
fix: wire request_timeout from verifier.conf into new VerifierServer path

### DIFF
--- a/keylime/web/verifier_server.py
+++ b/keylime/web/verifier_server.py
@@ -42,6 +42,14 @@ class VerifierServer(Server):
 
     def _pre_fork(self) -> None:
         """Query agents from database before forking (only needed for PULL mode)."""
+        # Wire request_timeout from config into the module-level dict so agents
+        # pick up the configured value instead of DEFAULT_TIMEOUT.
+        # This mirrors the initialization done in cloud_verifier_tornado.main().
+        from keylime.config import DEFAULT_TIMEOUT
+        cloud_verifier_tornado.exclude_db["request_timeout"] = config.getfloat(
+            "verifier", "request_timeout", fallback=DEFAULT_TIMEOUT
+        )
+
         logger.info("start_multi() called with operating_mode: %s", self.operating_mode)
         self._all_agents = []
         if self.operating_mode == "pull":


### PR DESCRIPTION
Closes #1871

When using the new server architecture (keylime/cmd/verifier.py -> VerifierServer), the configured request_timeout value from verifier.conf was never applied to pull-mode agents. All agents used DEFAULT_TIMEOUT (60s) regardless of configuration.

The fix wires the request_timeout from config into exclude_db in VerifierServer._pre_fork(), mirroring the initialization done in cloud_verifier_tornado.main() which is dead code for the new server path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where configured request timeout settings were not being properly applied to agents during server initialization, ensuring timeout configurations are now consistently enforced across all agent connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/keylime/keylime/pull/1917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->