### PR TITLE
Fix test compatibility across Python and cryptography library versions

### DIFF
--- a/test/test_shutdown.py
+++ b/test/test_shutdown.py
@@ -13,8 +13,14 @@ class TestShutdownFlag(unittest.TestCase):
     """Test the process-wide shutdown flag."""
 
     def setUp(self) -> None:
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
         # Reset the module-level event before each test
         shutdown._shutdown_event = asyncio.Event()
+
+    def tearDown(self) -> None:
+        asyncio.set_event_loop(None)
+        self.loop.close()
 
     def test_initial_state_not_shutting_down(self) -> None:
         self.assertFalse(shutdown.is_shutting_down())
@@ -33,6 +39,8 @@ class TestOperationTracking(unittest.TestCase):
     """Test _enter_operation / _exit_operation and drain logic."""
 
     def setUp(self) -> None:
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
         # Import here so we can reset module globals
         from keylime import cloud_verifier_tornado as cvt
 
@@ -47,6 +55,8 @@ class TestOperationTracking(unittest.TestCase):
     def tearDown(self) -> None:
         self.cvt._active_operations = self._saved_active
         self.cvt._operations_drained = self._saved_event
+        asyncio.set_event_loop(None)
+        self.loop.close()
 
     def test_initial_state_is_drained(self) -> None:
         self.assertEqual(self.cvt.get_active_operations(), 0)
@@ -78,12 +88,8 @@ class TestOperationTracking(unittest.TestCase):
         self.assertTrue(self.cvt._operations_drained.is_set())
 
     def test_wait_for_drain_returns_true_when_already_drained(self) -> None:
-        loop = asyncio.new_event_loop()
-        try:
-            result = loop.run_until_complete(self.cvt.wait_for_drain(1.0))
-            self.assertTrue(result)
-        finally:
-            loop.close()
+        result = self.loop.run_until_complete(self.cvt.wait_for_drain(1.0))
+        self.assertTrue(result)
 
     def test_wait_for_drain_returns_true_after_exit(self) -> None:
         self.cvt._enter_operation()
@@ -96,23 +102,14 @@ class TestOperationTracking(unittest.TestCase):
             asyncio.ensure_future(_exit_soon())
             return await self.cvt.wait_for_drain(2.0)
 
-        loop = asyncio.new_event_loop()
-        try:
-            result = loop.run_until_complete(_drain_after_delay())
-            self.assertTrue(result)
-            self.assertEqual(self.cvt.get_active_operations(), 0)
-        finally:
-            loop.close()
+        result = self.loop.run_until_complete(_drain_after_delay())
+        self.assertTrue(result)
+        self.assertEqual(self.cvt.get_active_operations(), 0)
 
     def test_wait_for_drain_returns_false_on_timeout(self) -> None:
         self.cvt._enter_operation()
-
-        loop = asyncio.new_event_loop()
-        try:
-            result = loop.run_until_complete(self.cvt.wait_for_drain(0.1))
-            self.assertFalse(result)
-        finally:
-            loop.close()
+        result = self.loop.run_until_complete(self.cvt.wait_for_drain(0.1))
+        self.assertFalse(result)
 
 
 class TestPendingEventRegistry(unittest.TestCase):

--- a/test/test_tpm2_objects.py
+++ b/test/test_tpm2_objects.py
@@ -301,7 +301,8 @@ class TestEccPublicKeySecurityValidation(unittest.TestCase):
         # The cryptography library should reject this point as not being on the curve
         with self.assertRaises(ValueError) as cm:
             pubkey_parms_from_tpm2b_public(tpm2b_public)
-        self.assertIn("not on the curve", str(cm.exception).lower())
+        err = str(cm.exception).lower()
+        self.assertTrue("not on the curve" in err or "invalid ec key" in err)
 
     def test_point_at_infinity_validation(self):
         """Test that the point at infinity (0, 0) is rejected (Security Check #2)"""
@@ -314,7 +315,8 @@ class TestEccPublicKeySecurityValidation(unittest.TestCase):
         # The cryptography library should reject the point at infinity
         with self.assertRaises(ValueError) as cm:
             pubkey_parms_from_tpm2b_public(tpm2b_public)
-        self.assertIn("not on the curve", str(cm.exception).lower())
+        err = str(cm.exception).lower()
+        self.assertTrue("not on the curve" in err or "invalid ec key" in err)
 
     def test_valid_point_accepted(self):
         """Test that a valid point on the curve is accepted"""
@@ -413,7 +415,8 @@ class TestEccPublicKeySecurityValidation(unittest.TestCase):
         tpm2b_public_invalid = self.create_ecc_tpm2b_public(1, 1, TPM_ECC_NIST_P521)
         with self.assertRaises(ValueError) as cm:
             pubkey_parms_from_tpm2b_public(tpm2b_public_invalid)
-        self.assertIn("not on the curve", str(cm.exception).lower())
+        err = str(cm.exception).lower()
+        self.assertTrue("not on the curve" in err or "invalid ec key" in err)
 
 
 class TestEccMarshaling(unittest.TestCase):


### PR DESCRIPTION
  ## Type of Change
  - [x] Bug fix (non-breaking change)
  - [x] Test cases (added/modified)

  ## Related Issues
  None.

  ## Change Description

  ### Concise Summary
  Fix tests that fail with older asyncio and cryptography versions

  ### Technical Details

  **asyncio.Event() loop binding (`test_shutdown.py`):**
  `asyncio.Event()` can bind to the current event loop at creation time on older Python releases. The shutdown tests were
  creating events in `setUp` bound to one loop, then running them from a different loop created inside individual test methods,
   causing `RuntimeError`. The fix creates a single explicit event loop in `setUp`/`tearDown` and reuses it across all async
  tests in the class.

  **ECC error messages (`test_tpm2_objects.py`):**
  The `cryptography` library changed its error message for invalid EC points when EC support was migrated from Python/CFFI to
  Rust in version 42.0.0. Older versions raise `"Invalid EC key."` while newer versions raise `"Invalid EC key. Point is not on
   the curve specified."` The tests were asserting only the newer message. The fix accepts both.

  ## Documentation Updates Required
  - [x] No docs needed (requires maintainer approval)

  ## Verification Process
  1. Run the affected tests: `pytest test/test_shutdown.py test/test_tpm2_objects.py`
  2. All tests should pass on both cryptography <42.0.0 (CFFI backend) and >=42.0.0 (Rust backend)

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Unit/integration tests added/updated
  - [x] Documentation updated (per above section)
  - [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message
  article](https://chris.beams.io/posts/git-commit/)
  - [ ] CHANGELOG updated (if applicable)
  - [x] All tests pass (local & CI)

  ## Additional Context
  The `test_coordinate_exceeds_field_prime_rejected` test at `test_tpm2_objects.py:398` also references `"not on the curve"`
  but does **not** need updating -- keylime's own coordinate bounds check catches the input before the cryptography library is
  reached, so the library's error message is never hit in that test.

