### PR TITLE
fix: correct [A-z] regex in DM-IMA grammar STRING token

### DIFF
--- a/keylime/ima/dm_grammar.py
+++ b/keylime/ima/dm_grammar.py
@@ -153,7 +153,7 @@ snapshot_snapshot_overflowed: "snapshot_overflowed=" yes_no
 // generic rules
 ?yes_no: "y" -> yes | "n" -> no
 optional_string: STRING? 
-STRING: /([A-z]|[0-9]|\-|\:)+/
+STRING: /[A-Za-z0-9\-\:\_\.+@#]+/
 NUMBER: INT
 version_nb: INT "." INT "." INT
 

--- a/test/test_ima_dm.py
+++ b/test/test_ima_dm.py
@@ -308,6 +308,43 @@ class TestImaDM(unittest.TestCase):
         failure = validator.validate(ima_buf.digest, ima_buf.name, ima_buf.data)
         self.assertIn("ima.validation.dm.dm_device_rename.new_uuid_invalid", failure.get_event_ids())
 
+    def _make_linear_load_data(self, name, uuid=""):
+        return (
+            f"dm_version=4.45.0;name={name},uuid={uuid},"
+            f"major=253,minor=0,minor_count=1,num_targets=1;"
+            f"target_index=0,target_begin=0,target_len=4268032,"
+            f"target_name=linear,target_version=1.4.0,"
+            f"device_name=254:2,start=0;"
+        )
+
+    def test_string_token_accepts_dm_whitelist_chars(self):
+        valid_names = [
+            "test_device",
+            "my.device",
+            "vol+1",
+            "dev@host",
+            "pool#1",
+            "my.dev_1+tag@host#2",
+        ]
+        for name in valid_names:
+            with self.subTest(name=name):
+                data = self._make_linear_load_data(name)
+                result: ima_dm.LoadEvent = cast(ima_dm.LoadEvent, ima_dm.parse(data, "dm_table_load"))
+                self.assertEqual(result.device_metadata.name, name)
+
+    def test_string_token_rejects_non_whitelist_chars(self):
+        invalid_names = [
+            "test\\device",
+            "test[0]",
+            "test^dev",
+            "test`dev",
+        ]
+        for name in invalid_names:
+            with self.subTest(name=name):
+                data = self._make_linear_load_data(name)
+                with self.assertRaises(Exception):
+                    ima_dm.parse(data, "dm_table_load")
+
     def test_matching_func(self):
         for entry in [None, False, True, "test", 123]:
             self.assertTrue(ima_dm._check_attr(entry, None))


### PR DESCRIPTION
## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [x] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
**Resolves:** keylime/keylime#1913

## Change Description

### Concise Summary
Fix `[A-z]` regex in DM-IMA grammar STRING token to match the device-mapper name whitelist

### Technical Details

- The `STRING` token in `keylime/ima/dm_grammar.py` used `[A-z]`, a well-known regex anti-pattern that matches ASCII 65-122, including six unintended characters between `Z` (90) and `a` (97): `[`, `\`, `]`, `^`, `_`, and `` ` ``
- Of those six, `_` is a legitimate character in DM names/UUIDs, but the other five (`[`, `\`, `]`, `^`, `` ` ``) should not be accepted
- The fix replaces the regex with an explicit character class matching the device-mapper name whitelist (`0-9, A-Z, a-z, #+-.:=@_` per the `dmsetup` manpage): `[A-Za-z0-9\-\:\_\.+@#]`
- This is a defensive code quality fix; the current architecture constrains exploitability (device-mapper creation requires `CAP_SYS_ADMIN`, unknown devices fail verification via `no_matching_policy`)

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. Verify the regex change: `grep 'STRING' keylime/ima/dm_grammar.py` shows `[A-Za-z0-9\-\:\_\.+@#]`
2. Run DM-IMA tests: `python -m pytest test/test_ima_dm.py -v`
3. New tests verify that all DM whitelist characters (`_`, `.`, `+`, `@`, `#`) are accepted and that previously-accepted non-whitelist characters (`\`, `[`, `^`, `` ` ``) are rejected

## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [ ] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context
None.

> This PR was generated with the assistance of Claude Opus 4.6 (Anthropic).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded character set recognition in the IMA grammar parser to support additional characters including underscores, dots, plus signs, at symbols, and hash marks in string tokens. This allows the system to properly parse and process a wider range of valid input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->