### PR TITLE
fix: Suppress false-positive type checker errors in types.py

### DIFF
--- a/keylime/types.py
+++ b/keylime/types.py
@@ -15,7 +15,9 @@ except ImportError:
     # fall back to older version
     try:
         # The following only exists with python-cryptography v37.0.x
-        from cryptography.hazmat.primitives.asymmetric.types import CERTIFICATE_PRIVATE_KEY_TYPES
+        from cryptography.hazmat.primitives.asymmetric.types import (  # type: ignore[attr-defined,no-redef]  # isort: skip
+            CERTIFICATE_PRIVATE_KEY_TYPES,  # pyright: ignore[reportAttributeAccessIssue]
+        )
     except ImportError:
         pass
 


### PR DESCRIPTION
## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues

N/A

## Change Description

### Concise Summary

Suppress false-positive type checker errors for compatibility import

The `CERTIFICATE_PRIVATE_KEY_TYPES` fallback import in `keylime/types.py` triggers mypy and pyright errors when checked against newer versions of the cryptography library. This change adds targeted suppression directives.

### Technical Details

The fallback import exists for compatibility with cryptography v37.0.x-v39.x, where `CertificateIssuerPrivateKeyTypes` did not yet exist. In v40.0+, the old name `CERTIFICATE_PRIVATE_KEY_TYPES` was removed. Type checkers analyze against the installed (newer) version and report:

- mypy: `attr-defined` (symbol doesn't exist) and `no-redef` (already defined on line 7)
- pyright: `reportAttributeAccessIssue` (unknown import symbol)

These are false positives because the import is guarded by `try/except ImportError`, so the missing attribute is handled gracefully at runtime.

The three suppression directives are ordered deliberately:
- `# type: ignore[attr-defined,no-redef]` must come first on the `from` line (mypy only reads `type: ignore` if it is the first directive comment)
- `# isort: skip` follows on the same line to prevent isort from reformatting the multi-line import, which would move the `type: ignore` to the item line where mypy cannot see it
- `# pyright: ignore[reportAttributeAccessIssue]` goes on the item line where pyright reports the issue

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. Run `tox -e mypy,pyright,isort,black,pylint`
2. All five checks pass with no errors

## Checklist
- [x] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [ ] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context

No functional changes — this is a static analysis fix only.

> This PR was created with the assistance of Claude Opus 4.6 (Anthropic).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code organization and compatibility handling for cryptography library imports to ensure stability across different versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->