### PR TITLE
DB: increase evidence_items.agent_id column length

### DIFF
--- a/keylime/migrations/versions/a59cc9366774_fix_evidence_items_agent_id_length.py
+++ b/keylime/migrations/versions/a59cc9366774_fix_evidence_items_agent_id_length.py
@@ -1,0 +1,71 @@
+"""Fix evidence_items.agent_id column length for PostgreSQL, MySQL and MariaDB
+
+Revision ID: a59cc9366774
+Revises: 5a8b2c3d4e6f
+Create Date: 2026-06-29 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a59cc9366774"
+down_revision = "5a8b2c3d4e6f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()[f"upgrade_{engine_name}"]()
+
+
+def downgrade(engine_name):
+    globals()[f"downgrade_{engine_name}"]()
+
+
+def upgrade_registrar():
+    pass
+
+
+def downgrade_registrar():
+    pass
+
+
+def upgrade_cloud_verifier():
+    bind = op.get_bind()
+    if bind.dialect.name == "mysql":
+        # MySQL and MariaDB both block ALTER COLUMN on FK-referenced columns
+        # (error 1832), and batch recreate fails too because FK names must be
+        # unique database-wide (error 121). The portable fix is to drop the FK,
+        # widen the column, then restore the FK. The FK name is looked up from
+        # information_schema rather than hardcoded.
+        result = bind.execute(
+            sa.text(
+                "SELECT CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE"
+                " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'evidence_items'"
+                " AND COLUMN_NAME = 'agent_id' AND REFERENCED_TABLE_NAME IS NOT NULL"
+                " LIMIT 1"
+            )
+        )
+        fk_name = result.scalar()
+        if fk_name:
+            bind.execute(sa.text(f"ALTER TABLE evidence_items DROP FOREIGN KEY `{fk_name}`"))
+        bind.execute(sa.text("ALTER TABLE evidence_items MODIFY agent_id VARCHAR(80) NOT NULL"))
+        if fk_name:
+            bind.execute(
+                sa.text(
+                    f"ALTER TABLE evidence_items ADD CONSTRAINT `{fk_name}`"
+                    " FOREIGN KEY (agent_id, attestation_index)"
+                    " REFERENCES attestations (agent_id, `index`)"
+                )
+            )
+    else:
+        with op.batch_alter_table("evidence_items") as batch_op:
+            batch_op.alter_column(
+                "agent_id", existing_type=sa.String(length=20), type_=sa.String(length=80), existing_nullable=False
+            )
+
+
+def downgrade_cloud_verifier():
+    pass


### PR DESCRIPTION
## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
**Resolves:** #1921

## Change Description

### Concise Summary
Fix `evidence_items.agent_id` column too small for PostgreSQL, MySQL, and MariaDB

The push-attestation migration (`870c218abd9a`) defined `evidence_items.agent_id`
as `varchar(20)`, which is too small for any valid agent ID. Standard UUIDs are
36 characters and `hash_ek` agent IDs are 64 characters. PostgreSQL enforces
`VARCHAR` length limits (unlike SQLite), causing `StringDataRightTruncation` on
every evidence INSERT, breaking push-mode attestation entirely.

### Technical Details

- **Root cause:** `evidence_items.agent_id` was declared as `String(20)` in migration
  `870c218abd9a`, likely a copy-paste error from the adjacent `evidence_class` column.
  The column should be `String(80)` to match `attestations.agent_id` and
  `verifiermain.agent_id`.

- **Why only non-SQLite backends:** SQLite does not enforce `VARCHAR` length limits,
  so the bug was invisible in SQLite-based deployments.

- **MySQL and MariaDB constraints:** Both block inline `ALTER COLUMN` on
  FK-referenced columns (error 1832). Additionally, Alembic's batch table recreate
  fails because FK constraint names must be unique database-wide, so the temp table
  cannot be created with the same FK name as the original (error 121). MariaDB
  additionally does not honor `FOREIGN_KEY_CHECKS=0` for `ALTER TABLE` column
  modifications, unlike MySQL.

- **Fix:** A corrective Alembic migration (`a59cc9366774`) widens the column from
  `varchar(20)` to `varchar(80)`. For MySQL and MariaDB, the migration queries the
  actual FK constraint name from `information_schema`, drops it, widens the column,
  then restores the FK. For PostgreSQL and SQLite the standard `batch_alter_table`
  path is used. The original migration is left unchanged since it has already been
  published and applied by existing deployments.

- **Downgrade:** Intentionally a no-op, consistent with other column-widening
  migrations in this project (e.g. `160f932fde5b`, `8da20383f6e1`).

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. Deploy verifier + registrar with a **PostgreSQL**, **MySQL**, or **MariaDB**
   database backend.
2. Register an agent using a `hash_ek`-style UUID (64 characters) and add it to
   the verifier with push mode enabled.
3. Start the push-model agent and observe verifier logs — before this fix, every
   evidence submission returns HTTP 500 with a `StringDataRightTruncation` (PostgreSQL)
   or `OperationalError` (MySQL/MariaDB) on the `evidence_items` INSERT.
4. After applying this migration (`alembic upgrade head`), repeat steps 2–3 and
   confirm the verifier processes evidence submissions successfully and attestation
   completes without errors.

## Checklist
- [x] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context

> This PR was created with the assistance of Claude Sonnet 4.6 (Anthropic).
