### PR TITLE
fix: handle concurrent agent deletion in verifier GET handler

### DIFF
--- a/keylime/cloud_verifier_tornado.py
+++ b/keylime/cloud_verifier_tornado.py
@@ -18,7 +18,7 @@ import tornado.netutil
 import tornado.process
 import tornado.web
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import InvalidRequestError, SQLAlchemyError
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.orm.exc import NoResultFound  # pyright: ignore
 
@@ -614,7 +614,17 @@ class AgentsHandler(BaseHandler):
                 if agent is not None:
                     # Refresh agent from database to ensure we have the latest consecutive_attestation_failures
                     # This is critical for PUSH mode status detection when failures occur
-                    session.refresh(agent)
+                    try:
+                        session.refresh(agent, attribute_names=["consecutive_attestation_failures"])
+                    except InvalidRequestError:
+                        # The attestation loop concurrently deleted the agent (TERMINATED → deleted)
+                        # between the initial query and the refresh. Return 404 to the caller.
+                        web_util.echo_json_response(self.req_handler, 404, "agent id not found")
+                        logger.info(
+                            "GET returning 404 response. agent %s was deleted during request processing.",
+                            agent_id,
+                        )
+                        return
                     response = cloud_verifier_common.process_get_status(agent)
                     web_util.echo_json_response(self.req_handler, 200, "Success", response)
                 else:
@@ -658,9 +668,18 @@ class AgentsHandler(BaseHandler):
 
                     json_response = {}
                     for agent in agent_list:
+                        aid = agent.agent_id
                         # Refresh agent from database to ensure fresh consecutive_attestation_failures
-                        session.refresh(agent)
-                        json_response[agent.agent_id] = cloud_verifier_common.process_get_status(agent)
+                        try:
+                            session.refresh(agent, attribute_names=["consecutive_attestation_failures"])
+                        except InvalidRequestError:
+                            # Agent was concurrently deleted during iteration; skip it.
+                            logger.debug(
+                                "Agent %s was deleted during bulk GET request processing, skipping.",
+                                aid,
+                            )
+                            continue
+                        json_response[aid] = cloud_verifier_common.process_get_status(agent)
 
                     web_util.echo_json_response(self.req_handler, 200, "Success", json_response)
                 else:

--- a/test/test_cloud_verifier_tornado.py
+++ b/test/test_cloud_verifier_tornado.py
@@ -3,14 +3,17 @@
 Tests cover:
 1. _register_pending_event / _cancel_pending_event helpers
 2. store_attestation_state graceful handling when agent is deleted
+3. AgentsHandler.get() race condition: session.refresh() raises InvalidRequestError
+   when the attestation loop deletes the agent between query and refresh
 """
 
 # pylint: disable=protected-access
 
 import unittest
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import InvalidRequestError, SQLAlchemyError
 
 from keylime import cloud_verifier_tornado
 
@@ -287,6 +290,166 @@ class TestActivateAgentsSkipsPushMode(unittest.IsolatedAsyncioTestCase):
         await cloud_verifier_tornado.activate_agents([agent1, agent2], "127.0.0.1", 8881)
 
         mock_from_db.assert_not_called()
+
+
+def _make_agents_handler(agent_id: str):
+    """Build a bare AgentsHandler instance without Tornado infrastructure.
+
+    Bypasses tornado.web.RequestHandler.__init__ and sets only the attributes
+    the GET handler path under test actually touches.
+    """
+    handler = object.__new__(cloud_verifier_tornado.AgentsHandler)
+    req = MagicMock()
+    req.uri = f"/v2.1/agents/{agent_id}"
+    handler._req_handler_override = req
+    handler.request = req
+    return handler
+
+
+class TestGetHandlerRaceCondition(unittest.TestCase):
+    """Verify that AgentsHandler.get() handles the concurrent-deletion race.
+
+    The race: the attestation loop deletes a TERMINATED agent between the
+    initial query (one_or_none) and the subsequent session.refresh(). SQLAlchemy
+    raises InvalidRequestError("Could not refresh instance '...'") in that case.
+    The handler must return 404 instead of propagating a 500.
+    """
+
+    AGENT_ID = "d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
+
+    def _run_get(self, session_mock):
+        """Wire up validate_input and session_context, invoke handler.get()."""
+        handler = _make_agents_handler(self.AGENT_ID)
+
+        # Provide REST params the same way __validate_input would
+        validate_return = ({"agents": self.AGENT_ID, "api_version": "2.1"}, self.AGENT_ID)
+
+        @contextmanager
+        def fake_session_ctx():
+            yield session_mock
+
+        with (
+            patch.object(
+                cloud_verifier_tornado.AgentsHandler,
+                "_AgentsHandler__validate_input",
+                return_value=validate_return,
+            ),
+            patch("keylime.cloud_verifier_tornado.session_context", fake_session_ctx),
+            patch("keylime.cloud_verifier_tornado.web_util.echo_json_response") as mock_echo,
+        ):
+            handler.get()
+            return mock_echo
+
+    def test_returns_404_when_refresh_raises_invalid_request_error(self):
+        """GET returns 404 (not 500) when session.refresh raises InvalidRequestError."""
+        mock_session = MagicMock()
+        mock_agent = MagicMock()
+        # Query finds the agent — it still existed at query time
+        mock_session.query.return_value.options.return_value.options.return_value.filter_by.return_value.one_or_none.return_value = (
+            mock_agent
+        )
+        # Refresh raises — agent was deleted between query and refresh
+        mock_session.refresh.side_effect = InvalidRequestError("Could not refresh instance")
+
+        mock_echo = self._run_get(mock_session)
+
+        mock_echo.assert_called_once()
+        args = mock_echo.call_args[0]
+        self.assertEqual(args[1], 404)
+        self.assertIn("not found", args[2])
+        # Verify attribute_names is passed to avoid expiring eagerly-loaded relationships
+        mock_session.refresh.assert_called_once_with(mock_agent, attribute_names=["consecutive_attestation_failures"])
+
+    def test_returns_200_when_no_race(self):
+        """GET returns 200 normally when session.refresh succeeds."""
+        mock_session = MagicMock()
+        mock_agent = MagicMock()
+        mock_session.query.return_value.options.return_value.options.return_value.filter_by.return_value.one_or_none.return_value = (
+            mock_agent
+        )
+        mock_session.refresh.return_value = None  # success
+
+        with patch("keylime.cloud_verifier_tornado.cloud_verifier_common.process_get_status", return_value={}):
+            mock_echo = self._run_get(mock_session)
+
+        mock_echo.assert_called_once()
+        args = mock_echo.call_args[0]
+        self.assertEqual(args[1], 200)
+
+    def test_returns_404_when_agent_not_found(self):
+        """GET returns 404 when agent is not in DB at query time."""
+        mock_session = MagicMock()
+        mock_session.query.return_value.options.return_value.options.return_value.filter_by.return_value.one_or_none.return_value = (
+            None
+        )
+
+        mock_echo = self._run_get(mock_session)
+
+        mock_echo.assert_called_once()
+        args = mock_echo.call_args[0]
+        self.assertEqual(args[1], 404)
+        # refresh must NOT have been called — agent was already None
+        mock_session.refresh.assert_not_called()
+
+
+class TestBulkGetHandlerRaceCondition(unittest.TestCase):
+    """Verify bulk GET skips deleted agents rather than crashing."""
+
+    AGENT_IDS = ["agent-aaa", "agent-bbb", "agent-ccc"]
+
+    def _run_bulk_get(self, session_mock):
+        handler = _make_agents_handler("")
+
+        # No agent_id → bulk listing path; "bulk" key triggers the for-loop
+        validate_return = ({"agents": "", "api_version": "2.1", "bulk": ""}, "")
+
+        @contextmanager
+        def fake_session_ctx():
+            yield session_mock
+
+        with (
+            patch.object(
+                cloud_verifier_tornado.AgentsHandler,
+                "_AgentsHandler__validate_input",
+                return_value=validate_return,
+            ),
+            patch("keylime.cloud_verifier_tornado.session_context", fake_session_ctx),
+            patch("keylime.cloud_verifier_tornado.web_util.echo_json_response") as mock_echo,
+            patch(
+                "keylime.cloud_verifier_tornado.cloud_verifier_common.process_get_status",
+                side_effect=lambda a: {"agent_id": a.agent_id},
+            ),
+        ):
+            handler.get()
+            return mock_echo
+
+    def test_bulk_get_skips_deleted_agent_includes_rest(self):
+        """Bulk GET omits the concurrently-deleted agent but includes the others."""
+        agents = []
+        for aid in self.AGENT_IDS:
+            a = MagicMock()
+            a.agent_id = aid
+            agents.append(a)
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.options.return_value.options.return_value.all.return_value = agents
+
+        # Middle agent is deleted between query and refresh
+        def refresh_side_effect(agent, attribute_names=None):  # pylint: disable=unused-argument
+            if agent.agent_id == "agent-bbb":
+                raise InvalidRequestError("Could not refresh instance")
+
+        mock_session.refresh.side_effect = refresh_side_effect
+
+        mock_echo = self._run_bulk_get(mock_session)
+
+        mock_echo.assert_called_once()
+        args = mock_echo.call_args[0]
+        self.assertEqual(args[1], 200)
+        result = args[3]
+        self.assertIn("agent-aaa", result)
+        self.assertNotIn("agent-bbb", result)  # deleted agent is skipped
+        self.assertIn("agent-ccc", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# fix: handle concurrent agent deletion in verifier GET handler

## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [x] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
**Resolves:** #1924

## Change Description

### Concise Summary

Wrap `session.refresh(agent)` in the verifier GET handler with a
`try/except InvalidRequestError` to handle the race condition where
the attestation loop concurrently deletes a TERMINATED agent between
the initial query and the refresh call.

### Technical Details

The verifier GET handler queries for an agent with `one_or_none()`,
finds it, then calls `session.refresh(agent)` to ensure it has the
latest state. However, the attestation loop runs as an interleaved
coroutine on the same Tornado IOLoop and can delete the agent record
(when it transitions to TERMINATED and the attestation cycle completes)
between these two operations. When this happens, SQLAlchemy raises
`InvalidRequestError("Could not refresh instance '...'")`, which
propagates as an unhandled exception, causing the verifier to return
a 500 response with an empty body. The tenant then crashes parsing
the empty response with `ValueError: Unable to convert response to
JSON format`.

Commit 476ea2f previously hardened the DELETE handler against a
related race, but the GET handler was left vulnerable.

This fix:

- Catches `InvalidRequestError` specifically (not the broader
  `SQLAlchemyError`) to avoid masking genuine database errors such as
  connectivity failures or deadlocks, which should still produce 500
- For the single-agent GET: returns 404 — the agent the caller was
  polling is gone, which is the correct semantic
- For the bulk GET: skips the concurrently-deleted agent with
  `continue` and returns the rest of the listing — a 404 for a bulk
  response because one agent disappeared mid-iteration would be wrong

The `InvalidRequestError` exception was verified against SQLAlchemy
2.0 source: `session.refresh()` raises it (and only it) when the
SELECT for the primary key returns no rows. `StaleDataError` is only
raised by the version-ID validator (optimistic locking, not used on
`VerfierMain`), and `NoResultFound` is only raised by `.one()`, not
by `refresh()`.

## Documentation Updates Required
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process

1. **Environment:** Python unit tests, no hardware TPM required
2. **Unit tests** added to `test/test_cloud_verifier_tornado.py`:
   - `TestGetHandlerRaceCondition::test_returns_404_when_refresh_raises_invalid_request_error`
     — mocks `session.refresh()` to raise `InvalidRequestError` and
     asserts the handler returns HTTP 404
   - `TestGetHandlerRaceCondition::test_returns_200_when_no_race`
     — verifies the happy path is unaffected
   - `TestGetHandlerRaceCondition::test_returns_404_when_agent_not_found`
     — verifies the pre-existing 404 path is intact and `refresh` is
     not called when the agent was absent at query time
   - `TestBulkGetHandlerRaceCondition::test_bulk_get_skips_deleted_agent_includes_rest`
     — verifies bulk GET omits the deleted agent and returns the rest
3. **Result:** All 23 tests pass (`python -m pytest test/test_cloud_verifier_tornado.py`)

## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context

The functional test `/functional/ek-cert-use-ek_check_script` that
originally exposed this race is not reliably reproducible (timing
dependent), so the fix is covered by unit tests that deterministically
inject the race via mocking.

> This pull request was created with the assistance of Claude Sonnet 4.6 (Anthropic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent listing and lookup behavior when an agent is removed during a request.
  * Single-agent requests now return a not found response instead of failing unexpectedly.
  * Bulk agent results now skip agents that were deleted mid-request, avoiding partial refresh errors.
  * Reduced unnecessary data refreshes for agent status updates, improving request reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->