### PR TITLE
fix: track renamed device by new uuid when match_on is uuid

### DIFF
--- a/keylime/ima/ima_dm.py
+++ b/keylime/ima/ima_dm.py
@@ -259,7 +259,7 @@ class DmIMAValidator:
                 )
                 device_state.valid_state = False
             elif match_key == "uuid":
-                self.devices[event.new_name] = self.devices.pop(device_key)
+                self.devices[event.new_uuid] = self.devices.pop(device_key)
 
         return failure
 

--- a/test/test_ima_dm.py
+++ b/test/test_ima_dm.py
@@ -308,6 +308,71 @@ class TestImaDM(unittest.TestCase):
         failure = validator.validate(ima_buf.digest, ima_buf.name, ima_buf.data)
         self.assertIn("ima.validation.dm.dm_device_rename.new_uuid_invalid", failure.get_event_ids())
 
+    def _make_buf_entry(self, payload, event):
+        # Build the (digest, name, data) triple that DmIMAValidator.validate expects,
+        # computing a matching sha256 digest so the data hash check passes.
+        import hashlib
+
+        data = ast.Buffer(payload.encode().hex())
+        name = ast.Name(event)
+        digest = ast.Digest("sha256:" + hashlib.sha256(payload.encode()).hexdigest())
+        return digest, name, data
+
+    def test_device_rename_uuid_match(self):
+        # When matching on uuid, a rename that changes the uuid must keep tracking
+        # the device under its new uuid, otherwise later events for it are lost.
+        policy = {
+            "version": 1,
+            "match_on": "uuid",
+            "rules": {
+                "example": {
+                    "required": False,
+                    "device_resume_required": False,
+                    "device_rename": {"valid_name": "test.*", "valid_uuid": "newuuid"},
+                    "device_remove": {"allow_removal": False},
+                    "allow_clear": False,
+                    "table_load": {
+                        "allow_multiple_loads": False,
+                        "name": "test",
+                        "uuid": "myuuid",
+                        "major": 253,
+                        "minor": 0,
+                        "minor_count": 1,
+                        "num_targets": 1,
+                        "targets": [
+                            {
+                                "target_index": 0,
+                                "target_begin": 0,
+                                "target_len": 4268032,
+                                "target_name": "linear",
+                                "target_version": "1.4.0",
+                                "device_name": "254:2",
+                                "start": 0,
+                            }
+                        ],
+                    },
+                }
+            },
+        }
+        validator = ima_dm.DmIMAValidator(cast(types.Policies, policy))
+
+        load = self._make_linear_load_data("test", uuid="myuuid")
+        failure = validator.validate(*self._make_buf_entry(load, "dm_table_load"))
+        self.assertFalse(failure)
+        self.assertIn("myuuid", validator.devices)
+
+        rename = (
+            "dm_version=4.45.0;name=test,uuid=myuuid,major=253,minor=0,minor_count=1,"
+            "num_targets=1;new_name=test2,new_uuid=newuuid;current_device_capacity=4268032;"
+        )
+        failure = validator.validate(*self._make_buf_entry(rename, "dm_device_rename"))
+        self.assertFalse(failure)
+
+        # The device must now be tracked under its new uuid, not the new name.
+        self.assertNotIn("myuuid", validator.devices)
+        self.assertIn("newuuid", validator.devices)
+        self.assertNotIn("test2", validator.devices)
+
     def _make_linear_load_data(self, name, uuid=""):
         return (
             f"dm_version=4.45.0;name={name},uuid={uuid},"


### PR DESCRIPTION
## Type of Change
- [x] Bug fix (non-breaking change)
- [x] Test cases (added/modified)

## Change Description

When the device mapper IMA policy is configured with `"match_on": "uuid"`, the validator in `keylime/ima/ima_dm.py` keys its tracked device state by the device uuid. On a `dm_device_rename` event that changes the uuid, `validate_device_rename` re-inserted the state under `event.new_name` instead of `event.new_uuid`, so the device could no longer be looked up by its uuid.

The visible effect is that a legitimate uuid-matched device that gets renamed is lost from tracking, and any later event for it (resume, remove, target update, clear) then reports a spurious `*_before_table_load` failure. The name-matching branch just above already uses `new_name` correctly, so this just mirrors that for the uuid branch. It's a one-line change.

I came across this while reading through the dm validation code. The rename path only had coverage for the name-matching case, which is why the uuid variant slipped through.

## Verification Process

Added a regression test (`test_device_rename_uuid_match`) that loads a uuid-matched device, renames it to a new uuid, and asserts the state is tracked under the new uuid. It fails on the current code (device ends up under the new name) and passes with the fix. The full `test/test_ima_dm.py` suite is green (18 tests).

## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [x] All tests pass (local & CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device renaming so UUID-based updates are now stored under the correct identifier.
  * This prevents device entries from being rekeyed incorrectly during rename events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->