### PR TITLE
fix: handle invalid config values for typed server options

### DIFF
--- a/keylime/web/base/server.py
+++ b/keylime/web/base/server.py
@@ -449,9 +449,34 @@ class Server(ABC):
         """Sets config component (i.e., namespace) used to locate config values when setting server options."""
         self.__config_component = component
 
+    _TYPED_CONFIG_GETTERS: dict[type, Callable[..., Any]] = {
+        int: config.getint,
+        float: config.getfloat,
+        bool: config.getboolean,
+    }
+
+    def _get_typed_config_value(self, config_name: str, data_type: type, fallback: Any) -> Any:
+        """Read a typed config value, falling back gracefully on ValueError."""
+        getter = self._TYPED_CONFIG_GETTERS[data_type]
+        try:
+            return getter(self.config_component, config_name, fallback=fallback)  # type: ignore
+        except ValueError:
+            if fallback is None:
+                raise
+            raw_value = config.get(self.config_component, config_name, fallback="<unknown>")  # type: ignore[arg-type]
+            logger.warning(
+                "Cannot parse '%s' as %s for option '%s' (component: %s), using fallback: %s",
+                raw_value,
+                data_type.__name__,
+                config_name,
+                self.config_component,
+                fallback,
+            )
+            return fallback
+
     def _set_option(self, name: str, **kwargs: Any) -> None:
         """Sets server option by name either from given value or by obtaining it from user config. If the value is
-        falsy, uses the given fallback value instead or ``None`` if no fallback is provided. Examples::
+        ``None``, uses the given fallback value instead. Examples::
 
             # Set option using provided value
             self._set_option("bind_interface", value="0.0.0.0")
@@ -487,19 +512,13 @@ class Server(ABC):
             case {"from_config": (config_name, data_type)} if data_type is str:
                 value = config.get(self.config_component, config_name, fallback=fallback)  # type: ignore
 
-            case {"from_config": (config_name, data_type)} if data_type is int:
-                value = config.getint(self.config_component, config_name, fallback=fallback)  # type: ignore
-
-            case {"from_config": (config_name, data_type)} if data_type is float:
-                value = config.getfloat(self.config_component, config_name, fallback=fallback)  # type: ignore
-
-            case {"from_config": (config_name, data_type)} if data_type is bool:
-                value = config.getboolean(self.config_component, config_name, fallback=fallback)  # type: ignore
+            case {"from_config": (config_name, data_type)} if data_type in self._TYPED_CONFIG_GETTERS:
+                value = self._get_typed_config_value(config_name, data_type, fallback)
 
             case _:
                 raise TypeError(f"invalid arguments given when setting option '{name}' for {self.__class__.__name__}")
 
-        setattr(self, attr_name, value or fallback)
+        setattr(self, attr_name, value if value is not None else fallback)
 
     def _set_operating_mode(self, **kwargs: Any) -> None:
         """Sets operating mode of the server (push or pull)."""
@@ -573,6 +592,9 @@ class Server(ABC):
 
         if "from_config" in kwargs:
             kwargs.update({"from_config": (kwargs["from_config"], int)})
+
+        if "fallback" not in kwargs:
+            kwargs.update({"fallback": 0})
 
         self._set_option("max_workers", **kwargs)
 


### PR DESCRIPTION
## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
**Resolves:** #1929

## Change Description

### Concise Summary
Handle invalid typed config values gracefully

When a typed configuration option (int, float, bool) contains an empty or
invalid value, Python's `configparser` raises `ValueError` instead of using
the fallback. This causes the verifier to crash on startup when e.g.
`max_workers` has an empty value after a configuration file upgrade that
did not properly apply the configuration templates.

### Technical Details

The root cause is that `configparser.getint()` only uses the fallback when
the key is *missing* from the config file. When the key exists but has an
empty or non-numeric value, it attempts `int('')` which raises `ValueError`.

This fix:

- Wraps `config.getint()`, `config.getfloat()`, and `config.getboolean()`
  calls in `_set_option()` with try/except `ValueError` blocks, logging a
  warning and falling back to the caller-provided default
- Adds a default fallback of `0` (meaning "use all CPUs") for
  `_set_max_workers()`, following the same pattern already used by
  `_set_max_upload_size()`

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. Set `max_workers =` (empty value) in the verifier configuration
2. Start the verifier
3. Verify it starts successfully with a warning instead of crashing

## Checklist
- [x] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context
*This PR was written with the assistance of AI (Claude Code)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configuration options using typed integer, float, or boolean parsing: invalid values now either raise an error or, if a fallback is provided, emit a warning and use that fallback.
  * Correctly preserves valid falsy values such as `0` and `False` instead of replacing them with fallbacks.
  * Updated max-worker fallback behavior to default to `0` when no fallback is specified, improving consistency when values are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->