### PR TITLE
fix: use check_run.head_sha for PR coverage workflow

### DIFF
--- a/.github/workflows/submit-PR-coverage.yaml
+++ b/.github/workflows/submit-PR-coverage.yaml
@@ -18,8 +18,9 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v3
     - name: Wait for Packit tests to finish and download coverage.xml file
-      run: ./download_packit_coverage.sh
+      run: ./download_packit_coverage.sh --github-sha "$GITHUB_PR_SHA"
       env:
+        GITHUB_PR_SHA: ${{ github.event.check_run.head_sha }}
         MAX_DURATION: 7200
         SLEEP_DELAY: 120
     - name: List downloaded files

--- a/scripts/download_packit_coverage.sh
+++ b/scripts/download_packit_coverage.sh
@@ -3,7 +3,7 @@
 # There are 3 options how to tell this script where to start
 # --artifacts-url - Testing Farm artifacts URL, provided by testing-farm script
 # --testing-farm-log - Log of 'testing-farm request' command from where artifacts URL will be parsed
-# --github-sha - PR merge commit provided by GitHub, here we will try to get artifacts URL using GitHub API
+# --github-sha - PR HEAD commit (check_run.head_sha) provided by GitHub, here we will try to get artifacts URL using GitHub API
 
 if [ "$1" == "--artifacts-url" -a -n "$2" ]; then
     TF_ARTIFACTS_URL="$2"
@@ -97,12 +97,9 @@ if [ -n "${GITHUB_SHA}" -a -z "${TF_ARTIFACTS_URL}" -a -z "${TT_LOG}" ]; then
     echo "Trying to find Testing Farm / Packig CI test results using GitHub API"
 
     echo "Fist I need to find the respective PR commit"
-    GITHUB_API_SHA_URL="${GITHUB_API_COMMIT_URL}/${GITHUB_SHA}"
-
-    # Now we try to parse URL of Testing farm job from GITHUB_API_RUNS_URL page
-    GITHUB_PR_SHA=$( do_GitHub_API_call "${GITHUB_API_SHA_URL}" \
-                                     ".parents[1].sha" \
-                                     "Failed to parse PR commit from ${GITHUB_API_RUNS_URL}, trying again after ${SLEEP_DELAY} seconds..." )
+    # When triggered by check_run event, the SHA passed via --github-sha
+    # is already the PR HEAD commit (check_run.head_sha), so we use it directly
+    GITHUB_PR_SHA="${GITHUB_SHA}"
     echo "GITHUB_PR_SHA=${GITHUB_PR_SHA}"
 
     echo "Now we read check-runs details"


### PR DESCRIPTION
**PR Title: fix: use check_run.head_sha for PR coverage workflow**

---
Type of Change

- [x] Bug fix (non-breaking change)
- [x] CI/CD changes

**Related Issues**

See also: PR #1912 (introduced the check_run trigger change that broke coverage)

**Concise Summary**

Fix PR coverage upload broken by check_run trigger

**Technical Details**

PR #1912 changed the submit-PR-coverage.yaml workflow trigger from pull_request to check_run. However, the GITHUB_SHA environment variable behaves differently for check_run events — it points to the default branch HEAD, not the PR commit.

The download script (download_packit_coverage.sh) assumes GITHUB_SHA is a merge commit and extracts the PR HEAD commit via .parents[1].sha. With the check_run trigger this returns null, causing the script to loop on an invalid API URL (/commits/null/check-runs?...) for 4 hours until the job timeout is reached.

Error observed in CI logs:
```
GITHUB_PR_SHA=null
GITHUB_API_RUNS_URL=https://api.github.com/repos/keylime/keylime/commits/null/check-runs?check_name=testing-farm:fedora-43-x86_64:full
jq: error (at <stdin>:5): null (null) cannot be matched, as it is not a string
...
Error: Maximum job duration exceeded. Terminating
Failed to download "/coverage.tar.gz"
Error: Process completed with exit code 5.
```

Fix:
- Pass `${{ github.event.check_run.head_sha }} `explicitly via `--github-sha `in the workflow. This is the actual PR HEAD commit from the check_run event payload.
- In the download script, use the provided SHA directly as the PR commit instead of extracting .parents[1].sha from a merge commit.

The rest of the flow (check-run lookup, artifacts download, Codecov upload) is unchanged. The --testing-farm-log path used by submit-HEAD-coverage.yaml is not affected.

Documentation Updates Required

- [x] No docs needed (requires maintainer approval)

Verification Process

1. Merge this fix to master (workflow must be on the default branch to take effect for check_run events)
2. Open a PR and trigger /packit test -i full
3. After the testing-farm:fedora-43-x86_64:full check run completes, the submit-PR-coverage workflow should:
  - Resolve GITHUB_PR_SHA to the actual PR commit (not null)
  - Find the Testing Farm artifacts URL via the GitHub API
  - Download coverage.tar.gz successfully
  - Upload all 3 coverage XML files to Codecov
4. Verify that Codecov posts a coverage comment on the PR

Checklist

- [x] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [ ] Commit messages follow Chris Beams' How to Write a Git Commit Message article (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [ ] All tests pass (local & CI)

Additional Context

- Unit/integration tests are not feasible for this change — the check_run trigger workflow can only be tested once merged to the default branch.
- Fork PRs should also work since Packit creates check-runs on the base repo, and fork commits are accessible via refs/pull/N/head during the PR lifecycle. Testing with a fork PR after merge is recommended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request coverage retrieval by using the completed check run’s head commit SHA when downloading Packit coverage.
  * Reduced coverage upload/reporting issues by ensuring artifact discovery targets the correct pull request head commit directly (avoiding mismatches from derived SHA parsing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->