### PR TITLE
mba: add an ordered PCR replay policy for boot logs

### DIFF
--- a/docs/user_guide/use_measured_boot.rst
+++ b/docs/user_guide/use_measured_boot.rst
@@ -62,15 +62,12 @@ an agent node, the following actions will be taken.
 
 .. note::
 
-   The PCR replay in step 3 is restricted to the intersection of ``MEASUREDBOOT_PCRS``
-   (the PCRs Keylime collects) and the set returned by the active policy's
-   ``get_relevant_pcrs()`` method.  PCRs outside that set are excluded from the
-   replay check.  This allows policies to declare that certain PCRs (e.g. PCR 11,
-   which ``systemd-pcrphase`` extends at runtime) are not part of their trust
-   model, preventing spurious verification failures.
-   Policies that return an empty set from ``get_relevant_pcrs()`` (such as the
-   built-in ``accept-all`` and ``reject-all``) apply no restriction, so all
-   ``MEASUREDBOOT_PCRS`` are replayed.
+   The PCR replay in step 3 uses the intersection of ``MEASUREDBOOT_PCRS`` and
+   the active policy's relevant PCR set. PCRs outside that set are excluded.
+   This allows a policy to omit PCR 11 when ``systemd-pcrphase`` extends it at
+   runtime. A policy that returns an empty set applies no restriction, so
+   Keylime uses all ``MEASUREDBOOT_PCRS``. The built-in ``accept-all`` and
+   ``reject-all`` policies use this behavior.
 
 How to use 
 ---------- 
@@ -135,6 +132,56 @@ While an operator can attempt to write its own policy from scratch, it is
 recommended that one just copies `example.py` into `mypolicy.py`, change it as
 required and then just points to this policy for `measured_boot_policy_name` in `verifier.conf`
 for its own use.
+
+Ordered PCR replay policy
+-------------------------
+
+The built-in `ordered-replay` policy pins the expected final PCR values of the
+boot log. The reference values are the outcome of replaying the log in order.
+Keylime does that replay once, in the trusted parser (`tpm2_eventlog`), and
+binds the resulting per-PCR values to the AK-signed quote before the policy
+runs. The policy then compares each reference value against that quote-bound,
+parser-calculated `pcrs` map, so it inherits the parser's handling of special
+cases such as `StartupLocality` and `EV_EFI_HCRTM_EVENT`.
+
+The `pcrs` map uses the same bank and PCR structure as the parsed event log.
+Supported bank names are the ones the verifier can authenticate through a quote:
+
+* `sha1`
+* `sha256`
+* `sha384`
+* `sha512`
+
+PCR values may be JSON integers or full-size hexadecimal strings::
+
+   {
+     "pcrs": {
+       "sha256": {
+         "0": "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+       }
+     }
+   }
+
+Set `measured_boot_policy_name = ordered-replay` to select this policy. The
+reference map must contain exactly one bank, and that bank must match the bank
+in the AK-signed quote. Every reference PCR must also belong to
+``MEASUREDBOOT_PCRS`` and must have an event-log value that Keylime matched
+against the same PCR in the quote. An empty or missing reference state is
+rejected rather than treated as accept-all.
+
+This policy pins the reference state against each quote, so it runs on every
+attestation and during one-shot evidence verification, regardless of the
+``measured_boot_evaluate`` setting. A later quote that presents a different boot
+state is therefore still compared against the reference values.
+
+The guarantee is per-PCR final value equality against the quote. Reordering
+events that extend a single PCR is detected when it changes that PCR's digest
+sequence, and therefore its final value, under the collision resistance of the
+bank's hash. Reordering that leaves the final value unchanged is not
+authenticated. This covers swapping two events with equal digests, or moving an
+``EV_NO_ACTION`` entry that does not extend the PCR. Interleaving of events
+across different PCRs also cannot be distinguished from independent PCR
+endpoints. No policy built on PCR values alone can authenticate that ordering.
 
 Named Measured Boot Policy
 ----------------------------

--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -500,6 +500,9 @@ def process_verify_attestation(
             skip_clock_check=True,
             skip_pcr_check=False,
             skip_data_pcr_check=True,
+            # One-shot verification has no attestation count. Treat it as the first
+            # quote so a 'once' measured-boot policy is evaluated here too.
+            count=0,
         )
         failure.merge(quote_failure)
     except Exception as e:

--- a/keylime/cmd/verifier.py
+++ b/keylime/cmd/verifier.py
@@ -1,6 +1,7 @@
 from keylime import api_version, config, keylime_logging
 from keylime.common.migrations import apply
 from keylime.mba import mba
+from keylime.mba.elchecking import policies
 from keylime.models import da_manager, db_manager
 from keylime.shared_data import initialize_shared_memory
 from keylime.web import VerifierServer
@@ -35,6 +36,13 @@ def main() -> None:
 
     # Explicitly load and initialize measured boot components
     mba.load_imports()
+
+    # A measured boot policy name that is not registered is an operator error. Fail
+    # fast here so a misspelled name cannot silently accept an empty reference state
+    # and let attestation pass at run time.
+    mb_policy_name = config.get("verifier", "measured_boot_policy_name", fallback="accept-all")
+    if policies.get_policy(mb_policy_name) is None:
+        raise ValueError(f"Unknown measured boot policy name configured: {mb_policy_name!r}")
 
     # Prepare to use the cloud_verifier database
     db_manager.make_engine("cloud_verifier")

--- a/keylime/mba/elchecking/elchecker.py
+++ b/keylime/mba/elchecking/elchecker.py
@@ -51,31 +51,27 @@ def bootlog_evaluate(
     mb_measurement_data: tests.Data,
     pcrs_inquote: Set[int],
     agent_id: str,
+    quote_hash_alg: Optional[str] = None,
+    log_bound_pcrs: Optional[Set[int]] = None,
 ) -> Failure:
     """
     Evaluating a measured boot event log against a policy
     :param policy_data: policy definition (aka "refstate") (as a string).
     :param measurement_data: parsed measured boot event log as produced by `parse_bootlog`
-    :param pcrsInQuote: a set of PCRs provided by the quote.
+    :param pcrs_inquote: the PCRs the quote validated.
     :param agent_id: the UUID of the keylime agent sending this data.
+    :param quote_hash_alg: the PCR bank authenticated by the quote.
+    :param log_bound_pcrs: PCRs whose event-log value matched the quote. A PCR the
+        policy relies on must be in this set. A policy that requires this set
+        (ordered-replay) rejects when it is omitted; other policies fall back to
+        pcrs_inquote.
     :returns: list of all failures encountered while evaluating the boot log against the policy.
     """
     failure = Failure(Component.MEASURED_BOOT)
 
-    # no evaluation if the refstate is an empty string
-    if not mb_refstate_str:
-        return failure
-
-    mb_refstate_data = json.loads(mb_refstate_str)
-
-    # no evaluation if the refstate does not load as JSON
-    if not mb_refstate_data:
-        return failure
-
-    # load policy name
+    # Load policy name and policy first, so a malformed reference state is reported
+    # as an invalid operator policy rather than raising.
     mb_policy_name = config.get("verifier", "measured_boot_policy_name", fallback="accept-all")
-
-    # pylint: enable=import-outside-toplevel
     mb_policy = policies.get_policy(mb_policy_name)
 
     # fallback if we cannot find policy
@@ -85,20 +81,96 @@ def bootlog_evaluate(
         mb_policy_name = "reject-all"
         mb_policy = policies.RejectAll()
 
-    # figure out whether the quote contains all quotes to evaluate the policy
-    # if there are any PCRs in the policy that are not in the quote, we canot evaluate.
-    mb_pcrs_policy = mb_policy.get_relevant_pcrs()
-    missing_pcrs = list(mb_pcrs_policy.difference(pcrs_inquote))
+    # Parse the reference state; it may be missing or empty. Malformed JSON is an
+    # operator error, not an agent fault, so report it as invalid_mb_policy.
+    try:
+        mb_refstate_data = json.loads(mb_refstate_str) if mb_refstate_str else None
+    except (TypeError, ValueError) as exn:
+        logger.error("Measured boot reference state for policy %s is not valid JSON: %s", mb_policy_name, str(exn))
+        failure.add_event(
+            "invalid_mb_policy",
+            {"context": "Invalid measured boot reference state", "policy": mb_policy_name, "reason": str(exn)},
+            True,
+        )
+        return failure
+
+    # An empty or missing reference state means different things per policy. A
+    # policy that does not accept it (reject-all, ordered-replay) still runs so the
+    # missing content fails closed. A policy that accepts it but must run on every
+    # quote or needs the log-bound PCR set also runs, so its hooks take effect.
+    # Any other accepting policy (accept-all) passes without further checks.
+    if not mb_refstate_data:
+        if not mb_policy.accepts_empty_refstate():
+            mb_refstate_data = {}
+        elif mb_policy.requires_evaluation_every_quote() or mb_policy.requires_log_bound_pcrs():
+            mb_refstate_data = {}
+        else:
+            return failure
+
     reason = None
-    if len(missing_pcrs) > 0:
-        logger.error("PCRs specified for policy %s not in quote: %s", mb_policy_name, str(missing_pcrs))
-        failure.add_event("missing_pcrs", {"context": "PCRs are missing in quote", "data": missing_pcrs}, True)
-    # evaluate the policy
+
+    # The quote must bind every PCR the policy relies on. A genuinely missing PCR
+    # is reported as missing_pcrs (kept stable for monitoring rules); a reference
+    # state the policy cannot read is reported as invalid_mb_policy.
+    try:
+        relevant_pcrs = mb_policy.get_relevant_pcrs_from_refstate(mb_refstate_data)
+    except Exception as exn:
+        logger.error("Measured boot policy %s cannot read its reference state: %s", mb_policy_name, str(exn))
+        failure.add_event(
+            "invalid_mb_policy",
+            {"context": "Invalid measured boot reference state", "policy": mb_policy_name, "reason": str(exn)},
+            True,
+        )
+        return failure
+
+    # A PCR the policy relies on is bound only if its event-log value matched the
+    # quote. A policy that needs that set (ordered-replay) rejects when a caller
+    # omits it; other policies keep the broad quote-PCR set for compatibility.
+    if log_bound_pcrs is not None:
+        bound_pcrs = log_bound_pcrs
+    elif mb_policy.requires_log_bound_pcrs():
+        logger.error("Measured boot policy %s requires the quote-bound PCR set, which was not provided", mb_policy_name)
+        failure.add_event(
+            "quote_context",
+            {
+                "context": "Quote context does not satisfy measured boot policy",
+                "policy": mb_policy_name,
+                "reason": "the set of quote-bound PCRs was not provided",
+            },
+            True,
+        )
+        return failure
     else:
-        try:
-            reason = mb_policy.evaluate(mb_refstate_data, mb_measurement_data)
-        except Exception as exn:
-            reason = f"policy evaluation failed: {str(exn)}"
+        bound_pcrs = pcrs_inquote
+    missing_pcrs = sorted(relevant_pcrs.difference(bound_pcrs))
+    if missing_pcrs:
+        logger.error("PCRs specified for policy %s not bound to the log by the quote: %s", mb_policy_name, missing_pcrs)
+        failure.add_event("missing_pcrs", {"context": "PCRs are missing in quote", "data": missing_pcrs}, True)
+        return failure
+
+    # The quoted PCR bank must satisfy the policy (bank binding).
+    try:
+        bank_reason = mb_policy.validate_quote_bank(mb_refstate_data, quote_hash_alg)
+    except Exception as exn:
+        bank_reason = f"quote bank validation failed: {str(exn)}"
+
+    if bank_reason:
+        logger.error("Quote context does not satisfy measured boot policy %s: %s", mb_policy_name, bank_reason)
+        failure.add_event(
+            "quote_context",
+            {
+                "context": "Quote context does not satisfy measured boot policy",
+                "policy": mb_policy_name,
+                "reason": bank_reason,
+            },
+            True,
+        )
+        return failure
+
+    try:
+        reason = mb_policy.evaluate(mb_refstate_data, mb_measurement_data)
+    except Exception as exn:
+        reason = f"policy evaluation failed: {str(exn)}"
 
     if reason:
         logger.error(

--- a/keylime/mba/elchecking/policies.py
+++ b/keylime/mba/elchecking/policies.py
@@ -24,6 +24,45 @@ class Policy(metaclass=abc.ABCMeta):
         """Reveal the set of relevant PCR indices"""
         raise NotImplementedError
 
+    def get_relevant_pcrs_from_refstate(self, refstate: RefState) -> typing.FrozenSet[int]:
+        """Reveal relevant PCR indices after reading the reference state."""
+        _ = refstate
+        return self.get_relevant_pcrs()
+
+    def accepts_empty_refstate(self) -> bool:
+        """Whether an empty or missing reference state is a valid configuration.
+
+        ``accept-all`` tolerates an empty reference state; policies that must
+        check content (``ordered-replay``, ``reject-all``) override this so an
+        empty reference state is not silently treated as accept-all.
+        """
+        return True
+
+    def requires_evaluation_every_quote(self) -> bool:
+        """Whether the policy must run on every quote, not just the first one.
+
+        ``measured_boot_evaluate = once`` skips evaluation after the first
+        attestation. A policy that pins the reference state against each quote
+        (``ordered-replay``, ``reject-all``) overrides this so a later quote
+        presenting a different boot state is still compared.
+        """
+        return False
+
+    def requires_log_bound_pcrs(self) -> bool:
+        """Whether the policy needs the set of PCRs the quote bound to the log.
+
+        ``ordered-replay`` compares reference values against PCRs the quote
+        already matched to the event log, so it overrides this. When a caller
+        omits that set, the evaluator rejects instead of falling back to the
+        broad quote-PCR set, which would drop the value-matched requirement.
+        """
+        return False
+
+    def validate_quote_bank(self, refstate: RefState, quote_hash_alg: typing.Optional[str]) -> str:
+        """Return a reason if the quoted PCR bank does not satisfy the policy."""
+        _ = (refstate, quote_hash_alg)
+        return ""
+
     @abc.abstractmethod
     def refstate_to_test(self, refstate: RefState) -> tests.Test:
         """Convert the given RefState into a precise Test"""
@@ -51,8 +90,54 @@ class RejectAll(Policy):
     def get_relevant_pcrs(self) -> typing.FrozenSet[int]:
         return frozenset()
 
+    def accepts_empty_refstate(self) -> bool:
+        return False
+
+    def requires_evaluation_every_quote(self) -> bool:
+        return True
+
     def refstate_to_test(self, refstate: RefState) -> tests.Test:
         return tests.RejectAll("reject all")
+
+
+class OrderedReplay(Policy):
+    """Match reference PCR values against the quote-bound, parser-calculated map."""
+
+    def get_relevant_pcrs(self) -> typing.FrozenSet[int]:
+        return frozenset()
+
+    def accepts_empty_refstate(self) -> bool:
+        return False
+
+    def requires_evaluation_every_quote(self) -> bool:
+        return True
+
+    def requires_log_bound_pcrs(self) -> bool:
+        return True
+
+    @staticmethod
+    def _refstate_to_replay(refstate: RefState) -> tests.OrderedReplay:
+        if not isinstance(refstate, dict):
+            raise Exception(f"expected refstate to be a dict, got {refstate!r}")
+        if "pcrs" not in refstate:
+            raise Exception("refstate lacks pcrs")
+        return tests.OrderedReplay(refstate["pcrs"])
+
+    def get_relevant_pcrs_from_refstate(self, refstate: RefState) -> typing.FrozenSet[int]:
+        replay = self._refstate_to_replay(refstate)
+        return frozenset(pcr for bank in replay.expected.values() for pcr in bank)
+
+    def validate_quote_bank(self, refstate: RefState, quote_hash_alg: typing.Optional[str]) -> str:
+        replay = self._refstate_to_replay(refstate)
+        reference_banks = set(replay.expected)
+        if quote_hash_alg is None:
+            return "the quote hash algorithm is unavailable"
+        if reference_banks != {quote_hash_alg}:
+            return f"reference PCR banks {sorted(reference_banks)} do not match quoted bank {quote_hash_alg}"
+        return ""
+
+    def refstate_to_test(self, refstate: RefState) -> tests.Test:
+        return self._refstate_to_replay(refstate)
 
 
 def _mkreg() -> typing.Dict[str, Policy]:
@@ -74,6 +159,7 @@ def unregister(name: str) -> None:
 
 register("accept-all", AcceptAll())
 register("reject-all", RejectAll())
+register("ordered-replay", OrderedReplay())
 
 
 def get_policy_names() -> typing.List[str]:

--- a/keylime/mba/elchecking/tests.py
+++ b/keylime/mba/elchecking/tests.py
@@ -1,5 +1,6 @@
 import abc
 import re
+import string
 import typing
 
 from keylime.common.algorithms import Hash
@@ -281,6 +282,112 @@ class TupleTest(Test):
             reason = test.why_not(globs, subject_elt)
             if reason:
                 return f"[{idx}] " + reason
+        return ""
+
+
+# Banks the verifier can authenticate end to end through the quote path.
+# This is the set of algorithms mapped in keylime.tpm.tpm_main.Tpm.HASH_ALG_TO_TPM
+# and keylime.tpm.tpm2_objects.HASH_FUNCS. A reference that names any other bank
+# cannot be tied to an AK-signed quote, so the policy rejects it rather than
+# silently trusting a parser-only value.
+QUOTE_AUTHENTICATED_BANKS = frozenset({"sha1", "sha256", "sha384", "sha512"})
+
+
+class OrderedReplay(Test):
+    """Compare reference PCR values against the parser's quote-bound PCR map.
+
+    The reference values are the expected outcome of replaying the boot log in
+    order. The verifier does that replay once, in the trusted parser
+    (``tpm2_eventlog``), and binds the resulting per-PCR values to the AK-signed
+    quote before this test runs. Rather than maintain a second replay here (which
+    would have to track ``StartupLocality``, ``EV_EFI_HCRTM_EVENT`` and the TPM
+    1.2 versus 2.0 rules to stay correct), the test reads that parser-calculated
+    map from the measurement data and checks each reference PCR against it.
+
+    The guarantee is per-PCR final value equality against the quote. Reordering
+    events that extend one PCR is caught only when it changes that PCR's final
+    value, under the collision resistance of the bank's hash. A reorder that
+    leaves the endpoint unchanged, such as swapping two events with equal digests
+    or moving an entry that does not extend the PCR, is not authenticated.
+    Interleaving of events across different PCRs cannot be told apart from
+    independent PCR endpoints either, and no PCR-based policy authenticates it.
+    """
+
+    expected: typing.Dict[str, typing.Dict[int, bytes]]
+
+    def __init__(self, reference_pcrs: Data):
+        super().__init__()
+        if not isinstance(reference_pcrs, dict) or not reference_pcrs:
+            raise Exception("reference PCRs must be a non-empty dict")
+
+        self.expected = {}
+        for alg_name, bank in reference_pcrs.items():
+            if not isinstance(alg_name, str) or not Hash.is_recognized(alg_name):
+                raise Exception(f"unrecognized reference PCR hash algorithm {alg_name!r}")
+            if alg_name not in QUOTE_AUTHENTICATED_BANKS:
+                raise Exception(
+                    f"reference PCR bank {alg_name!r} cannot be authenticated by a quote; "
+                    f"use one of {sorted(QUOTE_AUTHENTICATED_BANKS)}"
+                )
+            if not isinstance(bank, dict) or not bank:
+                raise Exception(f"reference PCR bank {alg_name!r} must be a non-empty dict")
+
+            hash_alg = Hash(alg_name)
+            digest_size = hash_alg.get_size() // 8
+            expected_bank: typing.Dict[int, bytes] = {}
+            for pcr_name, value in bank.items():
+                try:
+                    pcr = int(pcr_name)
+                except (TypeError, ValueError) as exc:
+                    raise Exception(f"reference PCR index {pcr_name!r} is not an integer") from exc
+                if isinstance(pcr_name, bool) or pcr < 0 or pcr > 23:
+                    raise Exception(f"reference PCR index {pcr_name!r} is outside 0..23")
+                if pcr in expected_bank:
+                    raise Exception(f"reference PCR bank {alg_name!r} repeats PCR {pcr}")
+
+                if isinstance(value, int) and not isinstance(value, bool):
+                    try:
+                        expected = value.to_bytes(digest_size, byteorder="big")
+                    except (OverflowError, ValueError) as exc:
+                        raise Exception(f"reference value for {alg_name} PCR {pcr} has the wrong size") from exc
+                elif isinstance(value, str):
+                    value_hex = value[2:] if value.startswith("0x") else value
+                    if len(value_hex) != digest_size * 2 or any(c not in string.hexdigits for c in value_hex):
+                        raise Exception(f"reference value for {alg_name} PCR {pcr} is not a full-size hex digest")
+                    expected = bytes.fromhex(value_hex)
+                else:
+                    raise Exception(f"reference value for {alg_name} PCR {pcr} must be an integer or hex string")
+                expected_bank[pcr] = expected
+            self.expected[alg_name] = expected_bank
+
+    def why_not(self, globs: Globals, subject: Data) -> str:
+        if not isinstance(subject, dict):
+            return "is not a measurement-data dict"
+        log_pcrs = subject.get("pcrs")
+        if not isinstance(log_pcrs, dict):
+            return "measurement data has no parser-calculated pcrs map"
+
+        for alg_name, expected_bank in self.expected.items():
+            hash_alg = Hash(alg_name)
+            digest_size = hash_alg.get_size() // 8
+            log_bank = log_pcrs.get(alg_name)
+            if not isinstance(log_bank, dict):
+                return f"measurement data has no {alg_name} pcrs from the parser"
+            for pcr, expected in expected_bank.items():
+                if str(pcr) in log_bank:
+                    got_value = log_bank[str(pcr)]
+                elif pcr in log_bank:
+                    got_value = log_bank[pcr]
+                else:
+                    return f"{alg_name} PCR {pcr} is absent from the parser-calculated pcrs"
+                if not isinstance(got_value, int) or isinstance(got_value, bool):
+                    return f"{alg_name} PCR {pcr} parser value is not an integer"
+                try:
+                    got = got_value.to_bytes(digest_size, byteorder="big")
+                except (OverflowError, ValueError):
+                    return f"{alg_name} PCR {pcr} parser value does not fit the bank width"
+                if got != expected:
+                    return f"{alg_name} PCR {pcr} is {got.hex()}, expected {expected.hex()}"
         return ""
 
 

--- a/keylime/mba/mba.py
+++ b/keylime/mba/mba.py
@@ -1,5 +1,5 @@
 import importlib
-from inspect import isfunction
+from inspect import Parameter, isfunction, signature
 from typing import Any, Dict, List, Mapping, Optional, Set, Tuple
 
 from keylime import config
@@ -159,18 +159,36 @@ def bootlog_evaluate(
     measurement_data: MBLog,
     pcrsInQuote: Set[int],
     agent_id: str,
+    quote_hash_alg: Optional[str] = None,
+    log_bound_pcrs: Optional[Set[int]] = None,
 ) -> Failure:
     """
     MBA API front-end for evaluating a measured boot event log against a policy.
     :param policy_data: policy definition (aka "mb_policy") (as a string).
     :param measurement_data: parsed measured boot event log as produced by `bootlog_parse`
-    :param pcrsInQuote: a set of PCRs provided by the quote.
+    :param pcrsInQuote: the PCRs the quote validated. Always passed positionally so
+        its meaning never changes for any implementation.
     :param agent_id: the UUID of the keylime agent sending this data.
+    :param quote_hash_alg: the PCR bank authenticated by the quote.
+    :param log_bound_pcrs: PCRs whose event-log value matched the quote.
     :returns: list of all failures encountered while evaluating the boot log against the policy.
     """
     try:
         m = _find_implementation("bootlog_evaluate")
-        return m.bootlog_evaluate(policy_data, measurement_data, pcrsInQuote, agent_id)  # type: ignore[no-any-return]
+        implementation = m.bootlog_evaluate
+        parameters = signature(implementation).parameters
+        accepts_kwargs = any(parameter.kind == Parameter.VAR_KEYWORD for parameter in parameters.values())
+
+        # The positional pcrsInQuote keeps its original meaning for every
+        # implementation. The extra context is passed by keyword only to
+        # implementations that name it (or accept arbitrary keywords), so a
+        # legacy four-argument implementation is never changed.
+        extra: Dict[str, Any] = {}
+        if accepts_kwargs or "quote_hash_alg" in parameters:
+            extra["quote_hash_alg"] = quote_hash_alg
+        if accepts_kwargs or "log_bound_pcrs" in parameters:
+            extra["log_bound_pcrs"] = log_bound_pcrs
+        return implementation(policy_data, measurement_data, pcrsInQuote, agent_id, **extra)  # type: ignore[no-any-return]
     except Exception as e:
         raise ValueError from e
 

--- a/keylime/tpm/tpm_main.py
+++ b/keylime/tpm/tpm_main.py
@@ -391,14 +391,14 @@ class Tpm:
             )
 
     @staticmethod
-    def mb_pcrs_to_check(policy_name: str) -> Set[int]:
+    def mb_pcrs_to_check(policy_name: str, refstate: Optional[mb_policies.RefState] = None) -> Set[int]:
         """Return the set of measured-boot PCRs to replay against the event log.
 
-        Intersects ``config.MEASUREDBOOT_PCRS`` (PCRs Keylime collects) with the
-        set returned by ``policy.get_relevant_pcrs()`` for *policy_name*.  PCRs
-        outside the policy's relevant set are excluded so that runtime extensions
-        not captured in the event log (e.g. PCR 11 from ``systemd-pcrphase``) do
-        not cause spurious verification failures.
+        Intersects ``config.MEASUREDBOOT_PCRS`` with the PCR set derived from the
+        reference state when the policy provides one. PCRs outside that set are
+        excluded so that runtime extensions not captured in the event log (e.g.
+        PCR 11 from ``systemd-pcrphase``) do not cause spurious verification
+        failures.
 
         Policies that return an empty set from ``get_relevant_pcrs()`` (such as
         the built-in ``accept-all`` and ``reject-all``) apply no restriction, so
@@ -407,7 +407,14 @@ class Tpm:
         pcr_set: Set[int] = set(config.MEASUREDBOOT_PCRS)
         policy = mb_policies.get_policy(policy_name)
         if policy is not None:
-            relevant = policy.get_relevant_pcrs()
+            try:
+                if refstate is None:
+                    relevant = policy.get_relevant_pcrs()
+                else:
+                    relevant = policy.get_relevant_pcrs_from_refstate(refstate)
+            except Exception as exn:
+                logger.warning("Could not derive PCRs for measured boot policy %s: %s", policy_name, str(exn))
+                return pcr_set
             if relevant:
                 pcr_set &= relevant
         return pcr_set
@@ -454,6 +461,7 @@ class Tpm:
         failure.merge(mb_failure)
 
         pcrs_in_quote: Set[int] = set()  # PCRs in quote that were already used for some kind of validation
+        mb_log_bound_pcrs: Set[int] = set()  # PCRs whose event-log value matched the quote
 
         pcr_nums = set(pcrs_dict.keys())
 
@@ -493,27 +501,65 @@ class Tpm:
         else:
             logger.info("No IMA verification policy configured for agent '%s'; skipping IMA verification", agent_id)
 
-        if mb_policy is not None:
-            logger.info("Checking measured boot PCRs against log for agent: %s", agent_id)
-        else:
-            logger.info(
-                "No measured boot policy configured for agent '%s'; skipping measured boot verification", agent_id
-            )
-
         # Collect mismatched measured boot PCRs as measured_boot failures
         mb_pcr_failure = Failure(Component.MEASURED_BOOT)
-        # Handle measured boot PCRs only if the parsing worked and policy is valid and non-empty
-        # An empty policy {} is treated as accept-all and should skip validation
+        # Handle measured boot PCRs only if the parsing worked and the policy runs.
+        # An empty policy {} is treated as accept-all for policies that tolerate an
+        # empty reference state; policies that require content (ordered-replay,
+        # reject-all) still run so the missing content surfaces as a failure.
         mb_policy_is_nonempty = False
+        mb_refstate: Optional[mb_policies.RefState] = None
         if mb_policy is not None:
             try:
                 mb_policy_obj = json.loads(mb_policy)
                 mb_policy_is_nonempty = bool(mb_policy_obj)
+                if isinstance(mb_policy_obj, dict):
+                    mb_refstate = mb_policy_obj
             except Exception:
                 pass
 
-        if not mb_failure and mb_policy is not None and mba.policy_is_valid(mb_policy) and mb_policy_is_nonempty:
-            for pcr_num in Tpm.mb_pcrs_to_check(mb_policy_name) & pcr_nums:
+        # An unregistered policy name is an operator misconfiguration. Fail closed
+        # here instead of skipping evaluation, so a misspelled name cannot accept an
+        # empty reference state and let attestation pass. Startup validation catches
+        # this earlier; this guard also covers callers outside the normal path.
+        mb_selected_policy = mb_policies.get_policy(mb_policy_name)
+        if mb_selected_policy is None:
+            logger.error("Unknown measured boot policy name '%s' for agent %s", mb_policy_name, agent_id)
+            failure.add_event(
+                "invalid_mb_policy",
+                {"context": "Unknown measured boot policy", "policy": mb_policy_name},
+                True,
+            )
+            return failure
+
+        mb_requires_content = not mb_selected_policy.accepts_empty_refstate()
+        mb_requires_every_quote = mb_selected_policy.requires_evaluation_every_quote()
+        mb_requires_log_bound = mb_selected_policy.requires_log_bound_pcrs()
+        mb_policy_is_valid_policy = mb_policy is not None and mba.policy_is_valid(mb_policy)
+        # A truthy reference state that is not valid policy is an operator error. It is
+        # reported below as invalid_mb_policy and must not reach the evaluator, whereas a
+        # missing or empty state still enters the evaluator for content-requiring policies.
+        mb_policy_is_malformed = mb_policy is not None and mb_policy.strip() != "" and not mb_policy_is_valid_policy
+        # A policy that requires content, must run on every quote, or needs the
+        # log-bound PCR set (ordered-replay, reject-all) runs even when no reference
+        # state is supplied, so it fails closed instead of being silently skipped.
+        # Other policies only run for a valid, non-empty reference state.
+        mb_should_evaluate = not mb_policy_is_malformed and (
+            mb_requires_content
+            or mb_requires_every_quote
+            or mb_requires_log_bound
+            or (mb_policy_is_valid_policy and mb_policy_is_nonempty)
+        )
+
+        if mb_should_evaluate:
+            logger.info("Checking measured boot PCRs against log for agent: %s", agent_id)
+        else:
+            logger.info(
+                "No measured boot policy to evaluate for agent '%s'; skipping measured boot verification", agent_id
+            )
+
+        if not mb_failure and mb_should_evaluate:
+            for pcr_num in Tpm.mb_pcrs_to_check(mb_policy_name, mb_refstate) & pcr_nums:
                 if not mb_measurement_list:
                     logger.error(
                         "Measured Boot PCR %d in policy, but no measurement list provided by agent %s",
@@ -543,12 +589,14 @@ class Tpm:
                     mb_pcr_failure.add_event(
                         f"invalid_pcr_{pcr_num}",
                         {
-                            "context": "SHA256 boot event log PCR value does not match",
+                            "context": f"{hash_alg.value} boot event log PCR value does not match",
                             "got": pcrs_dict[pcr_num],
                             "expected": val_from_log_hex,
                         },
                         True,
                     )
+                else:
+                    mb_log_bound_pcrs.add(pcr_num)
 
                 if pcr_num in pcr_allowlist and pcrs_dict[pcr_num] not in pcr_allowlist[pcr_num]:
                     logger.error(
@@ -625,7 +673,7 @@ class Tpm:
                 logger.error("Invalid measured boot policy for agent '%s'", agent_id)
                 failure.add_event("invalid_mb_policy", "Invalid measured boot policy", True)
 
-        if not mb_failure and mb_policy_is_nonempty and mba.policy_is_valid(mb_policy):
+        if not mb_failure and mb_should_evaluate:
             mb_evaluate = config.get("verifier", "measured_boot_evaluate", fallback="once")
 
             # Value of measured_boot_evaluate can be only 'once' or 'always'
@@ -635,12 +683,24 @@ class Tpm:
                     "invalid_measured_boot_evaluate", "correct value of measured_boot_evaluate is required", True
                 )
 
-            if mb_evaluate == "always":
-                mb_policy_failure = mba.bootlog_evaluate(mb_policy, mb_measurement_data, pcrs_in_quote, agent_id)
-                failure.merge(mb_policy_failure)
-
-            elif mb_evaluate == "once" and count == 0:
-                mb_policy_failure = mba.bootlog_evaluate(mb_policy, mb_measurement_data, pcrs_in_quote, agent_id)
+            # measured_boot_evaluate is only 'once' or 'always'; there is no
+            # multi-quote 'learn' mode on this path. 'once' evaluates only on the
+            # first quote (count == 0), and the continuous verifier increments
+            # attestation_count itself so that first quote is reached naturally.
+            # One-shot verification is a separate entry point that passes count=0
+            # (see process_verify_attestation), so a 'once' policy runs on its
+            # single quote too. A policy that pins the reference state against
+            # every quote (requires_evaluation_every_quote) runs regardless of
+            # mb_evaluate and count.
+            if mb_evaluate == "always" or mb_requires_every_quote or (mb_evaluate == "once" and count == 0):
+                mb_policy_failure = mba.bootlog_evaluate(
+                    mb_policy,
+                    mb_measurement_data,
+                    pcrs_in_quote,
+                    agent_id,
+                    quote_hash_alg=str(hash_alg),
+                    log_bound_pcrs=mb_log_bound_pcrs,
+                )
                 failure.merge(mb_policy_failure)
 
         return failure

--- a/test/test_ordered_replay_policy.py
+++ b/test/test_ordered_replay_policy.py
@@ -1,0 +1,547 @@
+"""Tests for the built-in ordered-replay measured-boot policy."""
+
+import json
+import types
+import unittest
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+from keylime.common.algorithms import Hash
+from keylime.failure import Component, Failure
+from keylime.mba import mba
+from keylime.mba.elchecking import elchecker, policies
+from keylime.tpm.tpm_main import Tpm
+
+
+def _fold(events: List[Dict[str, Any]], alg: str = "sha256") -> Dict[str, int]:
+    """Model tpm2_eventlog's in-order replay for simple events (test helper only).
+
+    Extends each event's digest into its PCR accumulator in list order, starting
+    from the all-zero seed. This mirrors, for events with no special reset rules,
+    the parser-calculated ``pcrs`` map the policy consumes. It is a test fixture,
+    not the production replay, which lives in tpm2_eventlog.
+    """
+    hash_alg = Hash(alg)
+    acc: Dict[int, bytes] = {}
+    for event in events:
+        if event.get("EventType") == "EV_NO_ACTION":
+            continue
+        pcr = event["PCRIndex"]
+        for digest in event["Digests"]:
+            if digest["AlgorithmId"] != alg:
+                continue
+            cur = acc.get(pcr, hash_alg.get_start_hash())
+            acc[pcr] = hash_alg.hash(cur + bytes.fromhex(digest["Digest"]))
+    return {str(pcr): int.from_bytes(value, byteorder="big") for pcr, value in acc.items()}
+
+
+class TestOrderedReplayPolicy(unittest.TestCase):
+    """The policy pins reference PCR values against the quote-bound parser map."""
+
+    @staticmethod
+    def _event(pcr: int, event_type: str, digest: bytes, algorithm: str = "sha256") -> Dict[str, Any]:
+        return {
+            "PCRIndex": pcr,
+            "EventType": event_type,
+            "Digests": [{"AlgorithmId": algorithm, "Digest": digest.hex()}],
+        }
+
+    def setUp(self) -> None:
+        hash_alg = Hash.SHA256
+        self.scrtm = hash_alg.hash(b"scrtm-version")
+        self.firmware = hash_alg.hash(b"platform-firmware")
+        self.bootloader = hash_alg.hash(b"bootloader")
+
+        self.in_order = [
+            self._event(0, "EV_S_CRTM_VERSION", self.scrtm),
+            self._event(0, "EV_EFI_PLATFORM_FIRMWARE_BLOB", self.firmware),
+            self._event(4, "EV_EFI_BOOT_SERVICES_APPLICATION", self.bootloader),
+        ]
+        # The parser-calculated PCR map that the verifier binds to the quote.
+        self.log_pcrs = {"sha256": _fold(self.in_order)}
+        self.measurement_data = {"events": self.in_order, "pcrs": self.log_pcrs}
+        self.refstate = {"pcrs": {"sha256": dict(self.log_pcrs["sha256"])}}
+
+    @staticmethod
+    def _failure_ids(failure: Failure) -> List[str]:
+        return failure.get_event_ids()
+
+    def _bootlog_evaluate(
+        self,
+        refstate: Dict[str, Any],
+        measurement_data: Dict[str, Any],
+        bound_pcrs: set,
+        quote_hash_alg: str,
+    ) -> Failure:
+        with patch("keylime.mba.elchecking.elchecker.config.get", return_value="ordered-replay"):
+            return elchecker.bootlog_evaluate(
+                json.dumps(refstate),
+                measurement_data,
+                bound_pcrs,
+                "test-agent",
+                quote_hash_alg=quote_hash_alg,
+                log_bound_pcrs=bound_pcrs,
+            )
+
+    # --- policy-level value matching -------------------------------------------------
+
+    def test_accepts_matching_reference(self) -> None:
+        reason = policies.evaluate("ordered-replay", self.refstate, self.measurement_data)
+        self.assertEqual(reason, "")
+
+    def test_accepts_full_size_hex_reference(self) -> None:
+        pcr0 = self.log_pcrs["sha256"]["0"].to_bytes(32, "big")
+        pcr4 = self.log_pcrs["sha256"]["4"].to_bytes(32, "big")
+        refstate = {"pcrs": {"sha256": {"0": "0x" + pcr0.hex(), "4": pcr4.hex()}}}
+        reason = policies.evaluate("ordered-replay", refstate, self.measurement_data)
+        self.assertEqual(reason, "")
+
+    def test_rejects_wrong_reference_value(self) -> None:
+        refstate = {"pcrs": {"sha256": {"0": "00" * 32}}}
+        reason = policies.evaluate("ordered-replay", refstate, self.measurement_data)
+        self.assertIn("sha256 PCR 0 is", reason)
+
+    def test_rejects_pcr_absent_from_parser_map(self) -> None:
+        refstate = {"pcrs": {"sha256": {"5": "00" * 32}}}
+        reason = policies.evaluate("ordered-replay", refstate, self.measurement_data)
+        self.assertIn("PCR 5 is absent", reason)
+
+    def test_rejects_bank_absent_from_parser_map(self) -> None:
+        measurement_data = {"events": self.in_order, "pcrs": {}}
+        reason = policies.evaluate("ordered-replay", self.refstate, measurement_data)
+        self.assertIn("no sha256 pcrs", reason)
+
+    def test_rejects_unauthenticatable_bank(self) -> None:
+        refstate = {"pcrs": {"sm3_256": {"0": "00" * 32}}}
+        with self.assertRaises(Exception) as ctx:
+            policies.evaluate("ordered-replay", refstate, self.measurement_data)
+        self.assertIn("cannot be authenticated by a quote", str(ctx.exception))
+
+    # --- issue #1: parser handles StartupLocality, the policy honors it --------------
+
+    def test_locality_is_not_collapsed(self) -> None:
+        hash_alg = Hash.SHA256
+        digest = hash_alg.hash(b"crtm")
+        # PCR 0 seeded for locality 3 (last byte 0x03), as tpm2_eventlog reports it.
+        loc3_seed = b"\x00" * 31 + b"\x03"
+        loc3_pcr0 = hash_alg.hash(loc3_seed + digest)
+        loc0_pcr0 = hash_alg.hash(hash_alg.get_start_hash() + digest)
+        self.assertNotEqual(loc3_pcr0, loc0_pcr0)
+
+        measurement_data = {"events": [], "pcrs": {"sha256": {"0": int.from_bytes(loc3_pcr0, "big")}}}
+        # A locality-0 reference must not match a locality-3 boot.
+        loc0_ref = {"pcrs": {"sha256": {"0": int.from_bytes(loc0_pcr0, "big")}}}
+        self.assertIn("PCR 0 is", policies.evaluate("ordered-replay", loc0_ref, measurement_data))
+        # The correct locality-3 reference matches.
+        loc3_ref = {"pcrs": {"sha256": {"0": int.from_bytes(loc3_pcr0, "big")}}}
+        self.assertEqual(policies.evaluate("ordered-replay", loc3_ref, measurement_data), "")
+
+    # --- issue #3: per-PCR ordering, not cross-PCR interleaving ----------------------
+
+    def test_same_pcr_reorder_rejected_cross_pcr_reorder_accepted(self) -> None:
+        # Reference pins the in-order state.
+        refstate = self.refstate
+
+        # Cross-PCR permutation: move the PCR 4 event ahead of the PCR 0 events,
+        # keeping each PCR's internal order. The per-PCR endpoints are unchanged,
+        # so the parser map is identical and the reference still matches.
+        cross_pcr = [self.in_order[2], self.in_order[0], self.in_order[1]]
+        cross_data = {"events": cross_pcr, "pcrs": {"sha256": _fold(cross_pcr)}}
+        self.assertEqual(cross_data["pcrs"], self.log_pcrs)
+        self.assertEqual(policies.evaluate("ordered-replay", refstate, cross_data), "")
+
+        # Same-PCR permutation: swap the two PCR 0 events. PCR 0's value changes,
+        # so the reference no longer matches.
+        same_pcr = [self.in_order[1], self.in_order[0], self.in_order[2]]
+        same_data = {"events": same_pcr, "pcrs": {"sha256": _fold(same_pcr)}}
+        self.assertNotEqual(same_data["pcrs"]["sha256"]["0"], self.log_pcrs["sha256"]["0"])
+        self.assertIn("sha256 PCR 0 is", policies.evaluate("ordered-replay", refstate, same_data))
+
+    # --- quote-context binding through elchecker.bootlog_evaluate --------------------
+
+    def test_bootlog_evaluate_accepts_bound_bank_and_pcrs(self) -> None:
+        failure = self._bootlog_evaluate(self.refstate, self.measurement_data, {0, 4}, "sha256")
+        self.assertFalse(failure)
+
+    def test_bootlog_evaluate_reports_unbound_pcr_as_missing_pcrs(self) -> None:
+        hash_alg = Hash.SHA256
+        digest = hash_alg.hash(b"late-boot-event")
+        events = [self._event(5, "EV_ACTION", digest)]
+        measurement_data = {"events": events, "pcrs": {"sha256": _fold(events)}}
+        refstate = {"pcrs": {"sha256": {"5": measurement_data["pcrs"]["sha256"]["5"]}}}
+        failure = self._bootlog_evaluate(refstate, measurement_data, {0}, "sha256")
+        self.assertIn("measured_boot.missing_pcrs", self._failure_ids(failure))
+        self.assertIn("5", failure.events[0].context)
+
+    def test_bootlog_evaluate_rejects_wrong_quote_bank(self) -> None:
+        failure = self._bootlog_evaluate(self.refstate, self.measurement_data, {0, 4}, "sha384")
+        self.assertIn("measured_boot.quote_context", self._failure_ids(failure))
+        self.assertIn("do not match quoted bank sha384", failure.events[0].context)
+
+    def test_bootlog_evaluate_rejects_missing_quote_bank(self) -> None:
+        with patch("keylime.mba.elchecking.elchecker.config.get", return_value="ordered-replay"):
+            failure = elchecker.bootlog_evaluate(
+                json.dumps(self.refstate), self.measurement_data, {0, 4}, "test-agent", log_bound_pcrs={0, 4}
+            )
+        self.assertIn("measured_boot.quote_context", self._failure_ids(failure))
+        self.assertIn("quote hash algorithm is unavailable", failure.events[0].context)
+
+    def test_bootlog_evaluate_rejects_missing_log_bound_pcrs(self) -> None:
+        # ordered-replay needs the quote-bound PCR set; omitting it must not fall back
+        # to the broad quote-PCR set.
+        with patch("keylime.mba.elchecking.elchecker.config.get", return_value="ordered-replay"):
+            failure = elchecker.bootlog_evaluate(
+                json.dumps(self.refstate), self.measurement_data, {0, 4}, "test-agent", quote_hash_alg="sha256"
+            )
+        self.assertIn("measured_boot.quote_context", self._failure_ids(failure))
+        self.assertIn("quote-bound PCRs was not provided", failure.events[0].context)
+
+    def test_bootlog_evaluate_rejects_multiple_reference_banks(self) -> None:
+        sha384 = Hash.SHA384
+        pcr0 = sha384.hash(sha384.get_start_hash() + sha384.hash(b"scrtm-version"))
+        refstate = {
+            "pcrs": {
+                "sha256": self.refstate["pcrs"]["sha256"],
+                "sha384": {"0": int.from_bytes(pcr0, byteorder="big")},
+            }
+        }
+        failure = self._bootlog_evaluate(refstate, self.measurement_data, {0, 4}, "sha256")
+        self.assertIn("measured_boot.quote_context", self._failure_ids(failure))
+        self.assertIn("reference PCR banks", failure.events[0].context)
+
+    # --- issue #2: an empty reference state must not disable the policy ---------------
+
+    def test_bootlog_evaluate_rejects_empty_ordered_replay_refstate(self) -> None:
+        with patch("keylime.mba.elchecking.elchecker.config.get", return_value="ordered-replay"):
+            failure = elchecker.bootlog_evaluate(
+                "{}", self.measurement_data, {0, 4}, "test-agent", quote_hash_alg="sha256"
+            )
+        self.assertIn("measured_boot.invalid_mb_policy", self._failure_ids(failure))
+
+    def test_bootlog_evaluate_rejects_none_refstate(self) -> None:
+        with patch("keylime.mba.elchecking.elchecker.config.get", return_value="ordered-replay"):
+            failure = elchecker.bootlog_evaluate(
+                None, self.measurement_data, {0, 4}, "test-agent", quote_hash_alg="sha256"
+            )
+        self.assertIn("measured_boot.invalid_mb_policy", self._failure_ids(failure))
+
+    def test_bootlog_evaluate_rejects_empty_string_refstate(self) -> None:
+        with patch("keylime.mba.elchecking.elchecker.config.get", return_value="ordered-replay"):
+            failure = elchecker.bootlog_evaluate(
+                "", self.measurement_data, {0, 4}, "test-agent", quote_hash_alg="sha256"
+            )
+        self.assertIn("measured_boot.invalid_mb_policy", self._failure_ids(failure))
+
+    def test_bootlog_evaluate_reports_malformed_json_without_raising(self) -> None:
+        for bad in ("{", "not JSON", "   "):
+            with self.subTest(refstate=bad):
+                with patch("keylime.mba.elchecking.elchecker.config.get", return_value="ordered-replay"):
+                    failure = elchecker.bootlog_evaluate(
+                        bad, self.measurement_data, {0, 4}, "test-agent", quote_hash_alg="sha256", log_bound_pcrs={0, 4}
+                    )
+                self.assertIn("measured_boot.invalid_mb_policy", self._failure_ids(failure))
+
+    def test_bootlog_evaluate_accepts_empty_accept_all_refstate(self) -> None:
+        with patch("keylime.mba.elchecking.elchecker.config.get", return_value="accept-all"):
+            failure = elchecker.bootlog_evaluate(
+                "{}", self.measurement_data, set(), "test-agent", quote_hash_alg="sha256"
+            )
+        self.assertFalse(failure)
+
+    def test_elchecker_runs_custom_every_quote_policy_on_empty_refstate(self) -> None:
+        # A custom policy that accepts an empty reference state but requires
+        # every-quote evaluation must actually run its test through the real
+        # evaluator, not be short-circuited by the empty-state check.
+        class EveryQuoteRuns(policies.Policy):
+            def get_relevant_pcrs(self) -> frozenset:
+                return frozenset()
+
+            def requires_evaluation_every_quote(self) -> bool:
+                return True
+
+            def refstate_to_test(self, refstate: Any) -> Any:
+                return policies.tests.RejectAll("custom policy ran")
+
+        policies.register("every-quote-runs", EveryQuoteRuns())
+        try:
+            with patch("keylime.mba.elchecking.elchecker.config.get", return_value="every-quote-runs"):
+                failure = elchecker.bootlog_evaluate(
+                    "{}", self.measurement_data, {0, 4}, "test-agent", quote_hash_alg="sha256", log_bound_pcrs={0, 4}
+                )
+        finally:
+            policies.unregister("every-quote-runs")
+        self.assertIn("measured_boot.policy_every-quote-runs", self._failure_ids(failure))
+        self.assertIn("custom policy ran", failure.events[0].context)
+
+    def test_elchecker_enforces_log_bound_for_custom_empty_state_policy(self) -> None:
+        # A custom policy that accepts an empty reference state but requires the
+        # log-bound PCR set must reach the check and reject when that set is omitted,
+        # rather than being skipped before its requirement is enforced.
+        class LogBoundRuns(policies.Policy):
+            def get_relevant_pcrs(self) -> frozenset:
+                return frozenset()
+
+            def requires_log_bound_pcrs(self) -> bool:
+                return True
+
+            def refstate_to_test(self, refstate: Any) -> Any:
+                return policies.tests.AcceptAll()
+
+        policies.register("log-bound-runs", LogBoundRuns())
+        try:
+            with patch("keylime.mba.elchecking.elchecker.config.get", return_value="log-bound-runs"):
+                failure = elchecker.bootlog_evaluate(
+                    "{}", self.measurement_data, {0, 4}, "test-agent", quote_hash_alg="sha256"
+                )
+        finally:
+            policies.unregister("log-bound-runs")
+        self.assertIn("measured_boot.quote_context", self._failure_ids(failure))
+        self.assertIn("quote-bound PCRs was not provided", failure.events[0].context)
+
+    def test_check_pcrs_runs_ordered_replay_on_empty_refstate(self) -> None:
+        parser_failure = Failure(Component.MEASURED_BOOT)
+        with (
+            patch(
+                "keylime.tpm.tpm_main.mba.bootlog_parse",
+                return_value=({}, None, self.measurement_data, parser_failure),
+            ),
+            patch("keylime.tpm.tpm_main.mba.policy_is_valid", return_value=True),
+            patch("keylime.tpm.tpm_main.config.get", return_value="once"),
+            patch(
+                "keylime.tpm.tpm_main.mba.bootlog_evaluate",
+                return_value=Failure(Component.MEASURED_BOOT),
+            ) as evaluate,
+        ):
+            Tpm().check_pcrs(
+                agentAttestState=None,
+                tpm_policy={},
+                pcrs_dict={},
+                data=None,
+                ima_measurement_list=None,
+                runtime_policy=None,
+                ima_keyrings=None,
+                mb_measurement_list="boot-log",
+                mb_policy="{}",
+                hash_alg=Hash.SHA256,
+                count=0,
+                mb_policy_name="ordered-replay",
+            )
+        # ordered-replay requires content, so evaluation still runs for an empty {}.
+        evaluate.assert_called_once()
+
+    def _check_pcrs_evaluate_mock(
+        self, mb_policy: Any, count: int, mb_evaluate: str = "once", mb_policy_name: str = "ordered-replay"
+    ) -> Any:
+        parser_failure = Failure(Component.MEASURED_BOOT)
+        with (
+            patch(
+                "keylime.tpm.tpm_main.mba.bootlog_parse",
+                return_value=({}, None, self.measurement_data, parser_failure),
+            ),
+            patch("keylime.tpm.tpm_main.mba.policy_is_valid", return_value=True),
+            patch("keylime.tpm.tpm_main.config.get", return_value=mb_evaluate),
+            patch(
+                "keylime.tpm.tpm_main.mba.bootlog_evaluate",
+                return_value=Failure(Component.MEASURED_BOOT),
+            ) as evaluate,
+        ):
+            Tpm().check_pcrs(
+                agentAttestState=None,
+                tpm_policy={},
+                pcrs_dict={},
+                data=None,
+                ima_measurement_list=None,
+                runtime_policy=None,
+                ima_keyrings=None,
+                mb_measurement_list="boot-log",
+                mb_policy=mb_policy,
+                hash_alg=Hash.SHA256,
+                count=count,
+                mb_policy_name=mb_policy_name,
+            )
+        return evaluate
+
+    def test_check_pcrs_evaluates_ordered_replay_in_one_shot(self) -> None:
+        # One-shot verification uses count == -1; 'once' would otherwise skip it.
+        self._check_pcrs_evaluate_mock("{}", count=-1).assert_called_once()
+
+    def test_check_pcrs_evaluates_ordered_replay_on_later_attestation(self) -> None:
+        # A later quote (count > 0) is still pinned to the reference state.
+        self._check_pcrs_evaluate_mock("{}", count=5).assert_called_once()
+
+    def test_check_pcrs_evaluates_ordered_replay_with_none_mb_policy(self) -> None:
+        self._check_pcrs_evaluate_mock(None, count=0).assert_called_once()
+
+    def test_check_pcrs_evaluates_ordered_replay_with_empty_string_mb_policy(self) -> None:
+        self._check_pcrs_evaluate_mock("", count=0).assert_called_once()
+
+    def test_check_pcrs_runs_every_quote_policy_that_accepts_empty_refstate(self) -> None:
+        # A custom policy that accepts an empty reference state but needs to run on
+        # every quote must not be skipped once (count > 0).
+        class EveryQuoteEmptyOk(policies.Policy):
+            def get_relevant_pcrs(self) -> frozenset:
+                return frozenset()
+
+            def requires_evaluation_every_quote(self) -> bool:
+                return True
+
+            def refstate_to_test(self, refstate: Any) -> Any:
+                return policies.tests.AcceptAll()
+
+        policies.register("every-quote-empty-ok", EveryQuoteEmptyOk())
+        try:
+            evaluate = self._check_pcrs_evaluate_mock("{}", count=5, mb_policy_name="every-quote-empty-ok")
+            evaluate.assert_called_once()
+        finally:
+            policies.unregister("every-quote-empty-ok")
+
+    def test_check_pcrs_reports_malformed_refstate_without_raising(self) -> None:
+        # A malformed non-empty reference string is an operator error: it is flagged
+        # as invalid_mb_policy and the evaluator is not invoked.
+        parser_failure = Failure(Component.MEASURED_BOOT)
+        with (
+            patch(
+                "keylime.tpm.tpm_main.mba.bootlog_parse",
+                return_value=({}, None, self.measurement_data, parser_failure),
+            ),
+            patch("keylime.tpm.tpm_main.mba.policy_is_valid", side_effect=elchecker.policy_is_valid),
+            patch("keylime.tpm.tpm_main.config.get", return_value="once"),
+            patch("keylime.tpm.tpm_main.mba.bootlog_evaluate") as evaluate,
+        ):
+            failure = Tpm().check_pcrs(
+                agentAttestState=None,
+                tpm_policy={},
+                pcrs_dict={},
+                data=None,
+                ima_measurement_list=None,
+                runtime_policy=None,
+                ima_keyrings=None,
+                mb_measurement_list="boot-log",
+                mb_policy="{",
+                hash_alg=Hash.SHA256,
+                count=0,
+                mb_policy_name="ordered-replay",
+            )
+        evaluate.assert_not_called()
+        self.assertTrue(any("invalid_mb_policy" in event_id for event_id in self._failure_ids(failure)))
+
+    def test_check_pcrs_fails_closed_on_unknown_policy_name(self) -> None:
+        # A misspelled or unregistered configured policy name must fail closed even
+        # when the reference state is missing or empty, not skip evaluation.
+        for refstate in (None, "", "{}"):
+            with self.subTest(refstate=refstate):
+                parser_failure = Failure(Component.MEASURED_BOOT)
+                with (
+                    patch(
+                        "keylime.tpm.tpm_main.mba.bootlog_parse",
+                        return_value=({}, None, self.measurement_data, parser_failure),
+                    ),
+                    patch("keylime.tpm.tpm_main.config.get", return_value="once"),
+                    patch("keylime.tpm.tpm_main.mba.bootlog_evaluate") as evaluate,
+                ):
+                    failure = Tpm().check_pcrs(
+                        agentAttestState=None,
+                        tpm_policy={},
+                        pcrs_dict={},
+                        data=None,
+                        ima_measurement_list=None,
+                        runtime_policy=None,
+                        ima_keyrings=None,
+                        mb_measurement_list="boot-log",
+                        mb_policy=refstate,
+                        hash_alg=Hash.SHA256,
+                        count=0,
+                        mb_policy_name="ordered-repay",
+                    )
+                evaluate.assert_not_called()
+                self.assertTrue(failure)
+                self.assertTrue(any("invalid_mb_policy" in event_id for event_id in self._failure_ids(failure)))
+
+    # --- issue #4: legacy PCR-set semantics and the failure-id split -----------------
+
+    def test_check_pcrs_passes_broad_and_log_bound_pcr_sets(self) -> None:
+        measurement_data = {"events": self.in_order, "pcrs": self.log_pcrs}
+        parser_failure = Failure(Component.MEASURED_BOOT)
+        mb_policy = json.dumps({"pcrs": {"sha256": {"0": self.log_pcrs["sha256"]["0"]}}})
+        quote_only_pcr = "ab" * 32
+
+        with (
+            patch(
+                "keylime.tpm.tpm_main.mba.bootlog_parse",
+                return_value=({"0": self.log_pcrs["sha256"]["0"]}, None, measurement_data, parser_failure),
+            ),
+            patch("keylime.tpm.tpm_main.mba.policy_is_valid", return_value=True),
+            patch("keylime.tpm.tpm_main.config.get", return_value="always"),
+            patch(
+                "keylime.tpm.tpm_main.mba.bootlog_evaluate",
+                return_value=Failure(Component.MEASURED_BOOT),
+            ) as evaluate,
+        ):
+            failure = Tpm().check_pcrs(
+                agentAttestState=None,
+                tpm_policy={"23": [quote_only_pcr]},
+                pcrs_dict={0: hex(self.log_pcrs["sha256"]["0"])[2:], 23: quote_only_pcr},
+                data=None,
+                ima_measurement_list=None,
+                runtime_policy=None,
+                ima_keyrings=None,
+                mb_measurement_list="boot-log",
+                mb_policy=mb_policy,
+                hash_alg=Hash.SHA256,
+                count=0,
+                mb_policy_name="ordered-replay",
+            )
+
+        self.assertFalse(failure)
+        # The broad quote set (PCR 0 plus the allowlisted PCR 23) is passed
+        # positionally for legacy implementations; the log-bound set {0} is passed
+        # as the keyword the new implementation reads.
+        evaluate.assert_called_once_with(
+            mb_policy,
+            measurement_data,
+            {0, 23},
+            "<unknown>",
+            quote_hash_alg="sha256",
+            log_bound_pcrs={0},
+        )
+
+    def test_mba_frontend_gives_legacy_implementation_the_broad_pcr_set(self) -> None:
+        expected = Failure(Component.MEASURED_BOOT)
+
+        def legacy_evaluate(policy: str, measurement: object, pcrs: set, agent: str) -> Failure:
+            # Legacy implementations keep the original pcrsInQuote, not log_bound_pcrs.
+            self.assertEqual((policy, measurement, pcrs, agent), ("{}", {}, {0, 23}, "test-agent"))
+            return expected
+
+        implementation = types.SimpleNamespace(bootlog_evaluate=legacy_evaluate)
+        with patch("keylime.mba.mba._find_implementation", return_value=implementation):
+            result = mba.bootlog_evaluate("{}", {}, {0, 23}, "test-agent", quote_hash_alg="sha256", log_bound_pcrs={0})
+        self.assertIs(result, expected)
+
+    def test_mba_frontend_gives_kwargs_implementation_the_broad_pcr_set(self) -> None:
+        # An implementation that accepts **kwargs keeps the broad pcrsInQuote
+        # positionally and receives the extra context by keyword.
+        expected = Failure(Component.MEASURED_BOOT)
+        captured: Dict[str, Any] = {}
+
+        def kwargs_evaluate(policy: str, measurement: object, pcrs: set, agent: str, **kwargs: Any) -> Failure:
+            captured["positional"] = (policy, measurement, pcrs, agent)
+            captured["kwargs"] = kwargs
+            return expected
+
+        implementation = types.SimpleNamespace(bootlog_evaluate=kwargs_evaluate)
+        with patch("keylime.mba.mba._find_implementation", return_value=implementation):
+            result = mba.bootlog_evaluate("{}", {}, {0, 23}, "test-agent", quote_hash_alg="sha256", log_bound_pcrs={0})
+        self.assertIs(result, expected)
+        self.assertEqual(captured["positional"], ("{}", {}, {0, 23}, "test-agent"))
+        self.assertEqual(captured["kwargs"], {"quote_hash_alg": "sha256", "log_bound_pcrs": {0}})
+
+    # --- PCR-boundary restriction ----------------------------------------------------
+
+    def test_refstate_cannot_expand_measured_boot_pcr_boundary(self) -> None:
+        refstate = {"pcrs": {"sha256": {"23": "00" * 32}}}
+        self.assertEqual(Tpm.mb_pcrs_to_check("ordered-replay", refstate), set())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# `feat: add ordered PCR replay measured-boot policy`

## Type of Change
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [x] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
None

## Change Description

### Concise Summary
Add ordered PCR replay measured-boot policy

The policy pins the expected per-PCR values of the boot log. The verifier replays the log once in the trusted parser and binds the resulting per-PCR values to the AK-signed quote, then the policy compares each reference value against that quote-bound map. The default stays accept-all and existing policies are unchanged.

### Technical Details

The stock measured-boot path lets an operator supply a reference state, but it does not pin the boot log's replayed PCR values against the values the quote actually bound. This policy fills that gap for operators who want the boot log checked against a known-good per-PCR outcome.

- The reference bank must match the quoted bank and be one the verifier can authenticate (sha1, sha256, sha384, sha512). Every reference PCR must be bound to the log by the quote and belong to `MEASUREDBOOT_PCRS`.

- Replay happens in the trusted parser, so the policy inherits its handling of StartupLocality and HCRTM. A within-PCR reorder that changes a PCR's final value is rejected. Endpoint-preserving reorders and cross-PCR interleaving are out of scope and documented as such.

- The policy pins the reference against each quote, so it runs on every attestation and during one-shot verification regardless of `measured_boot_evaluate`.

- An empty, missing, or malformed reference state no longer passes as accept-all. The first two fail closed for content-requiring policies and a malformed one is reported as an invalid operator policy instead of raising.

- An unregistered configured policy name is an operator error. The verifier refuses to start on one and the quote check fails closed if such a name still reaches it, hence a misspelled name cannot accept an empty reference state and pass.

- Capability hooks (`accepts_empty_refstate`, `requires_evaluation_every_quote`, `requires_log_bound_pcrs`) let a custom policy opt into these behaviors and reach evaluation instead of being short-circuited.

Compatibility: legacy custom implementations keep the original quote-PCR set positionally. The quoted bank and log-bound set are passed only as keywords to implementations that name them or accept keywords, therefore a four-argument implementation is never handed changed arguments.

## Documentation Updates Required
- [ ] Updated markdown docs (file path: ______)
- [x] Updated code comments/docstrings
- [x] Needs user guide updates (`docs/`) - updated `docs/user_guide/use_measured_boot.rst`
- [ ] Needs ReadTheDocs updates
- [ ] No docs needed (requires maintainer approval)

## Verification Process
1. Test environment: Python 3.12 virtualenv with project dev dependencies, on the branch head.
2. Procedure:
   - `python -m unittest test.test_ordered_replay_policy`
   - `python -m unittest test.test_tpm_check_pcrs test.test_mba_parsing test.test_tpm_engine test.test_tpm_verify`
   - `black --check`, `isort --check-only`, `mypy`, and `pylint --rcfile=pylintrc` on the changed files.
   - Import `keylime.cmd.verifier` and confirm the three built-in policies register.
3. Expected vs actual: all suites pass (33 in the ordered-replay suite, neighboring suites green); black, isort, and mypy report no issues; pylint scores 10.00/10. Startup validation raises on a misspelled policy name and the built-in policies register as expected.

## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context
Per-bank-width coverage and a fixture generated from a real `tpm2_eventlog` run are worthwhile follow-ups. They need dedicated tooling and captured logs, so they are left out of this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the built-in **ordered-replay** measured boot policy for validating PCR values and detecting replay reordering.
  * Improved measured boot verification across one-shot and ongoing quote evaluations.
  * Added validation for configured policy names, reference states, PCR banks, and quote context.

* **Documentation**
  * Expanded the Measured Boot guide with PCR replay behavior, empty-policy handling, and ordered replay requirements and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->