### PR TITLE
test: use per-case temp file instead of /dev/stdout in policy tests

### DIFF
--- a/test/test_create_runtime_policy.py
+++ b/test/test_create_runtime_policy.py
@@ -917,21 +917,26 @@ foobar.so(.*)?
         subparser = main_parser.add_subparsers(title="actions")
         parser = create_runtime_policy.get_arg_parser(subparser, parent_parser)
 
-        for case in test_cases:
-            cli_args = []
-            # Prepare argument input
-            for k in ["algo_opt", "base policy", "allowlist", "IMA measurement list", "rootfs"]:
-                cli_args.extend(case.get(k, []))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for i, case in enumerate(test_cases):
+                cli_args = []
+                # Prepare argument input
+                for k in ["algo_opt", "base policy", "allowlist", "IMA measurement list", "rootfs"]:
+                    cli_args.extend(case.get(k, []))
 
-            args = parser.parse_args(cli_args)
+                # Use a per-case temp file instead of /dev/stdout to avoid
+                # permission issues in restricted container environments (e.g. Konflux).
+                fd, output_file = tempfile.mkstemp(suffix=f"-{i}.json", dir=temp_dir)
+                os.close(fd)
+                args = parser.parse_args(cli_args + ["--output", output_file])
 
-            with keylimePolicyAssertLogs() as logs:
-                policy = create_runtime_policy.create_runtime_policy(args)
-                self.assertIn(
-                    f"The digest algorithm in the {case['source']} does not match the previously set 'sha1' algorithm",
-                    logs.getvalue(),
-                )
-                self.assertEqual(policy, None)
+                with keylimePolicyAssertLogs() as logs:
+                    policy = create_runtime_policy.create_runtime_policy(args)
+                    self.assertIn(
+                        f"The digest algorithm in the {case['source']} does not match the previously set 'sha1' algorithm",
+                        logs.getvalue(),
+                    )
+                    self.assertEqual(policy, None)
 
     def test_unknown_algorithm_sources(self):
         """Test that input with digests from unknown algorithms are not allowed"""
@@ -978,18 +983,23 @@ foobar.so(.*)?
         subparser = main_parser.add_subparsers(title="actions")
         parser = create_runtime_policy.get_arg_parser(subparser, parent_parser)
 
-        for case in test_cases:
-            cli_args = ["--verbose"]
-            # Prepare argument input
-            for k in ["algo_opt", "base policy", "allowlist", "IMA measurement list", "rootfs"]:
-                cli_args.extend(case.get(k, []))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for i, case in enumerate(test_cases):
+                cli_args = ["--verbose"]
+                # Prepare argument input
+                for k in ["algo_opt", "base policy", "allowlist", "IMA measurement list", "rootfs"]:
+                    cli_args.extend(case.get(k, []))
 
-            args = parser.parse_args(cli_args)
+                # Use a per-case temp file instead of /dev/stdout to avoid
+                # permission issues in restricted container environments (e.g. Konflux).
+                fd, output_file = tempfile.mkstemp(suffix=f"-{i}.json", dir=temp_dir)
+                os.close(fd)
+                args = parser.parse_args(cli_args + ["--output", output_file])
 
-            with keylimePolicyAssertLogs() as logs:
-                policy = create_runtime_policy.create_runtime_policy(args)
-                self.assertIn(
-                    f"Invalid digest algorithm found in the {case['source']}",
-                    logs.getvalue(),
-                )
-                self.assertEqual(policy, None)
+                with keylimePolicyAssertLogs() as logs:
+                    policy = create_runtime_policy.create_runtime_policy(args)
+                    self.assertIn(
+                        f"Invalid digest algorithm found in the {case['source']}",
+                        logs.getvalue(),
+                    )
+                    self.assertEqual(policy, None)

--- a/test/test_create_runtime_policy.py
+++ b/test/test_create_runtime_policy.py
@@ -771,23 +771,28 @@ foobar.so(.*)?
         subparser = main_parser.add_subparsers(title="actions")
         parser = create_runtime_policy.get_arg_parser(subparser, parent_parser)
 
-        for case in test_cases:
-            cli_args = ["--verbose"]
-            # Prepare argument input
-            for k in ["algo_opt", "base_policy", "allowlist", "ima_log", "rootfs"]:
-                cli_args.extend(case.get(k, []))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for i, case in enumerate(test_cases):
+                cli_args = ["--verbose"]
+                # Prepare argument input
+                for k in ["algo_opt", "base_policy", "allowlist", "ima_log", "rootfs"]:
+                    cli_args.extend(case.get(k, []))
 
-            args = parser.parse_args(cli_args)
-            expected_algo = case["expected_algo"]
-            expected_source = case["expected_source"]
+                # Use a per-case temp file instead of /dev/stdout to avoid
+                # permission issues in restricted container environments (e.g. Konflux).
+                fd, output_file = tempfile.mkstemp(suffix=f"-{i}.json", dir=temp_dir)
+                os.close(fd)
+                args = parser.parse_args(cli_args + ["--output", output_file])
+                expected_algo = case["expected_algo"]
+                expected_source = case["expected_source"]
 
-            with keylimePolicyAssertLogs() as logs:
-                _policy = create_runtime_policy.create_runtime_policy(args)
-                self.assertIn(
-                    f"Using digest algorithm '{expected_algo}' obtained from the {expected_source}",
-                    logs.getvalue(),
-                    msg=f"ARGS: {' '.join(cli_args)}",
-                )
+                with keylimePolicyAssertLogs() as logs:
+                    _policy = create_runtime_policy.create_runtime_policy(args)
+                    self.assertIn(
+                        f"Using digest algorithm '{expected_algo}' obtained from the {expected_source}",
+                        logs.getvalue(),
+                        msg=f"ARGS: {' '.join(cli_args)}",
+                    )
 
     def test_digest_algorithm_priority_exceptions(self):
         """Test priority algorithms exceptions"""
@@ -839,28 +844,33 @@ foobar.so(.*)?
         subparser = main_parser.add_subparsers(title="actions")
         parser = create_runtime_policy.get_arg_parser(subparser, parent_parser)
 
-        for case in test_cases:
-            cli_args = ["--verbose"]
-            # Prepare argument input
-            for k in ["base_policy", "allowlist", "ima_log"]:
-                cli_args.extend(case.get(k, []))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for i, case in enumerate(test_cases):
+                cli_args = ["--verbose"]
+                # Prepare argument input
+                for k in ["base_policy", "allowlist", "ima_log"]:
+                    cli_args.extend(case.get(k, []))
 
-            args = parser.parse_args(cli_args)
-            expected_algo = case["expected_algo"]
-            expected_source = case["expected_source"]
+                # Use a per-case temp file instead of /dev/stdout to avoid
+                # permission issues in restricted container environments (e.g. Konflux).
+                fd, output_file = tempfile.mkstemp(suffix=f"-{i}.json", dir=temp_dir)
+                os.close(fd)
+                args = parser.parse_args(cli_args + ["--output", output_file])
+                expected_algo = case["expected_algo"]
+                expected_source = case["expected_source"]
 
-            with keylimePolicyAssertLogs() as logs:
-                _policy = create_runtime_policy.create_runtime_policy(args)
-                if case["expected_mismatch"]:
-                    self.assertIn(
-                        f"The digest algorithm in the IMA measurement list does not match the previously set '{expected_algo}' algorithm",
-                        logs.getvalue(),
-                    )
-                else:
-                    self.assertIn(
-                        f"Using digest algorithm '{expected_algo}' obtained from the {expected_source}",
-                        logs.getvalue(),
-                    )
+                with keylimePolicyAssertLogs() as logs:
+                    _policy = create_runtime_policy.create_runtime_policy(args)
+                    if case["expected_mismatch"]:
+                        self.assertIn(
+                            f"The digest algorithm in the IMA measurement list does not match the previously set '{expected_algo}' algorithm",
+                            logs.getvalue(),
+                        )
+                    else:
+                        self.assertIn(
+                            f"Using digest algorithm '{expected_algo}' obtained from the {expected_source}",
+                            logs.getvalue(),
+                        )
 
     def test_mixed_algorithms_sources(self):
         """Test that mixing digests from different algorithms is not allowed"""

--- a/test/test_sign_runtime_policy.py
+++ b/test/test_sign_runtime_policy.py
@@ -169,7 +169,7 @@ class SignRuntimePolicy_Test(unittest.TestCase):
             with tempfile.TemporaryDirectory() as temp_dir:
                 os.chdir(temp_dir)
 
-                for case in test_cases:
+                for i, case in enumerate(test_cases):
                     expected = case["valid"]
                     del case["valid"]
                     missing_params = case["missing_params"]
@@ -184,7 +184,11 @@ class SignRuntimePolicy_Test(unittest.TestCase):
                         with self.assertRaises(SystemExit):
                             args = parser.parse_args(cli_args)
                     else:
-                        args = parser.parse_args(cli_args)
+                        # Use a per-case temp file instead of /dev/stdout to avoid
+                        # permission issues in restricted container environments (e.g. Konflux).
+                        fd, output_file = tempfile.mkstemp(suffix=f"-{i}.json", dir=temp_dir)
+                        os.close(fd)
+                        args = parser.parse_args(cli_args + ["--output", output_file])
                         self.assertTrue(args is not None)
 
                         signed = sign_runtime_policy.sign_runtime_policy(args)


### PR DESCRIPTION
# test: use per-case temp file instead of /dev/stdout in policy tests

## Type of Change
*(Select all that apply)*
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [x] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues

N/A

## Change Description

### Concise Summary

Fix `%check` failures caused by tests writing to `/dev/stdout` in
restricted container environments.

### Technical Details

Several tests in `test_sign_runtime_policy.py` and
`test_create_runtime_policy.py` call the policy CLI functions without
an explicit `--output` argument, causing them to use the default value
of `/dev/stdout`. In restricted container environments (e.g. podman
with `--network=none`), `/dev/stdout` is not writable, so these tests
fail with "Permission denied".

Affected tests:
- `test_sign_runtime_policy` in `test_sign_runtime_policy.py`
- `test_digest_algorithm_priority` in `test_create_runtime_policy.py`
- `test_digest_algorithm_priority_exceptions` in `test_create_runtime_policy.py`

Fix by explicitly passing `--output` with a per-case temp file created
via `tempfile.mkstemp()`. Using a case-indexed suffix ensures unique
filenames and avoids conflicts when tests run in parallel.

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. Standard Python test environment or restricted container (podman with `--network=none`)
2. Run `python -m pytest test/test_sign_runtime_policy.py test/test_create_runtime_policy.py`
3. All tests pass in both environments

## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [ ] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context

> **Note:** This PR was co-authored with the assistance of an AI language model.
