### PR TITLE
Skip sm3 tests when not supported by OpenSSL

### DIFF
--- a/keylime/policy/create_runtime_policy.py
+++ b/keylime/policy/create_runtime_policy.py
@@ -827,8 +827,12 @@ def process_signature_verification_keys(verification_keys: List[str], policy: Ru
 def _get_digest_algorithm_from_hex(hexstring: str) -> str:
     """Try to identify the algorithm used to generate the provided value by length"""
     for alg in list(algorithms.Hash):
-        if len(hexstring) == algorithms.Hash(alg).get_hex_size():
-            return str(alg)
+        try:
+            if len(hexstring) == algorithms.Hash(alg).get_hex_size():
+                return str(alg)
+        except ValueError:
+            # Algorithm not supported by the current OpenSSL (e.g. sm3 on ELN/RHEL)
+            continue
     return INVALID_ALGORITHM
 
 

--- a/test/test_algorithms.py
+++ b/test/test_algorithms.py
@@ -1,8 +1,15 @@
+import hashlib
 import os
 import tempfile
 import unittest
 
 from keylime.common.algorithms import Encrypt, Hash, Key, Sign, is_accepted
+
+try:
+    hashlib.new("sm3", b"")
+    _SM3_AVAILABLE = True
+except (ValueError, Exception):
+    _SM3_AVAILABLE = False
 
 
 class TestHash(unittest.TestCase):
@@ -46,7 +53,7 @@ class TestHash(unittest.TestCase):
             },
             {
                 "hash": "sm3_256",
-                "valid": True,
+                "valid": _SM3_AVAILABLE,
             },
         ]
 
@@ -59,11 +66,9 @@ class TestHash(unittest.TestCase):
             {"hash": "sha256", "len": 64},
             {"hash": "sha384", "len": 96},
             {"hash": "sha512", "len": 128},
-            {
-                "hash": "sm3_256",
-                "len": 64,
-            },
         ]
+        if _SM3_AVAILABLE:
+            test_cases.append({"hash": "sm3_256", "len": 64})
 
         for c in test_cases:
             self.assertEqual(Hash(c["hash"]).get_hex_size(), c["len"])

--- a/test/test_create_runtime_policy.py
+++ b/test/test_create_runtime_policy.py
@@ -1,5 +1,6 @@
 import argparse
 import copy
+import hashlib
 import os
 import pathlib
 import shutil
@@ -9,6 +10,12 @@ import tempfile
 import unittest
 from importlib import util
 from test.utils import assertDigestsEqual, keylimePolicyAssertLogs
+
+try:
+    hashlib.new("sm3", b"")
+    _SM3_AVAILABLE = True
+except (ValueError, Exception):
+    _SM3_AVAILABLE = False
 
 from keylime.common import algorithms
 from keylime.ima import ima
@@ -697,7 +704,10 @@ foobar.so(.*)?
 
         rootfs = os.path.join(HELPER_DIR, "rootfs")
         # Prepare test cases
-        for algo in ["sha1", "sha256", "sha384", "sha512", "sm3_256"]:
+        _algos = ["sha1", "sha256", "sha384", "sha512"]
+        if _SM3_AVAILABLE:
+            _algos.append("sm3_256")
+        for algo in _algos:
             base_policy = os.path.join(HELPER_DIR, f"policy-{algo}")
             allowlist = os.path.join(HELPER_DIR, f"allowlist-{algo}")
             ima_log = os.path.join(HELPER_DIR, f"ima-log-{algo}")
@@ -794,6 +804,7 @@ foobar.so(.*)?
                         msg=f"ARGS: {' '.join(cli_args)}",
                     )
 
+    @unittest.skipUnless(_SM3_AVAILABLE, "sm3 not supported by OpenSSL")
     def test_digest_algorithm_priority_exceptions(self):
         """Test priority algorithms exceptions"""
 
@@ -893,7 +904,10 @@ foobar.so(.*)?
 
         rootfs = os.path.join(HELPER_DIR, "rootfs")
         # Prepare test cases
-        for algo in ["sha256", "sha384", "sha512", "sm3_256"]:
+        _mismatch_algos = ["sha256", "sha384", "sha512"]
+        if _SM3_AVAILABLE:
+            _mismatch_algos.append("sm3_256")
+        for algo in _mismatch_algos:
             base_policy = ["--base-policy", os.path.join(HELPER_DIR, f"policy-{algo}")]
             allowlist = ["--allowlist", os.path.join(HELPER_DIR, f"allowlist-{algo}")]
             ima_log = [


### PR DESCRIPTION
## Problem

The SM3 hash algorithm (GB/T 32905-2016) is not available in all OpenSSL builds. On systems where OpenSSL is built without SM3 support (e.g. OpenSSL 4.0+), multiple test failures occur:

- `_get_digest_algorithm_from_hex()` iterates all `Hash` enum members and calls `get_hex_size()` without guarding against unavailable algorithms. This crashes with `ValueError` even for non-SM3 inputs, because the iteration reaches the `sm3_256` entry before finding a match.
- `test_is_recognized` expects `Hash.is_recognized('sm3_256') == True`, but on systems without SM3, `is_recognized` correctly returns `False`.
- `test_get_hex_size` directly calls `Hash('sm3_256').get_hex_size()`, which raises `ValueError` when SM3 is unavailable.
- `test_digest_algorithm_priority` and `test_digest_algorithm_priority_exceptions` include `sm3_256` in algorithm loops that require SM3 IMA log entries to be correctly identified.

## Fix

- Catch `ValueError` in `_get_digest_algorithm_from_hex` so it skips algorithms unsupported by the current OpenSSL. Actual hashing still requires OpenSSL to support the algorithm, which is correct.
- Make SM3 test cases conditional on SM3 actually being present at runtime (detected via `hashlib.new("sm3", b"")`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime policy creation when detecting digest algorithms.
  * Unsupported algorithms no longer interrupt detection, allowing compatible algorithms to be identified successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->