### PR TITLE
test: warning on empty max_workers config value

### DIFF
--- a/test/test_server_base.py
+++ b/test/test_server_base.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from keylime.web.base.server import Server
 
@@ -57,3 +57,14 @@ class TestWorkerCount(unittest.TestCase):
     def test_explicit_worker_count_no_limit(self):
         server = self._make_server(worker_count=20, max_workers=0)
         self.assertEqual(server.worker_count, 20)
+
+    def test_empty_max_workers_falls_back_with_warning(self):
+        server = self._make_server()
+        server._use_config("verifier")
+        mock_getint = MagicMock(side_effect=ValueError("invalid literal for int() with base 10: ''"))
+        with patch.dict(Server._TYPED_CONFIG_GETTERS, {int: mock_getint}):
+            with patch("keylime.web.base.server.config.get", return_value=""):
+                with self.assertLogs("keylime.web", level="WARNING") as log_ctx:
+                    server._set_max_workers(from_config="max_workers")
+        self.assertEqual(server.max_workers, 0)
+        self.assertTrue(any("Cannot parse" in msg for msg in log_ctx.output))


### PR DESCRIPTION
## Type of Change

- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [x] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)


## Change Description


Add unit test for empty max_workers fallback


## Documentation Updates Required

- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
Run in the keylime repo root:
   ```
   PYTHONPATH=. python3 -m unittest test.test_server_base.TestWorkerCount.test_empty_max_workers_falls_back_with_warning -v
   ```


## Checklist
- [ ] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [ ] Documentation updated (per above section)
- [ ] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [ ] All tests pass (local & CI)
