### PR TITLE
CI: Enable test for push-model attestation with PostgreSQL

### DIFF
--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -104,6 +104,7 @@ adjust:
      - /functional/attestation-mode-mismatch
      - /functional/push-attestation-on-localhost
      - /functional/push-authentication-*
+     - /functional/push-model-attestation-with-postgresql-db
      - /functional/verifier_registrar_unreachable/.*
      - /regression/cve-2023-38200
      - /regression/cve-2023-38201


### PR DESCRIPTION
Enables test `/functional/push-model-attestation-with-postgresql-db` in Packit CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added push model attestation with PostgreSQL database coverage to the first full end-to-end test plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->