### PR TITLE
Fix crash in check_tpm_origin on certs without TPM SAN

### DIFF
--- a/keylime/cert_utils.py
+++ b/keylime/cert_utils.py
@@ -150,11 +150,21 @@ def check_tpm_origin(cert: Certificate, cert_type: str = "") -> bool:
     :param cert_type: Type of certificate as string for logging
     :returns: True if the certificate came from a TPM, or we are not sure. False if it did not come from a TPM
     """
-    san_ext = cert.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
+    try:
+        san_ext = cert.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
+    except x509.ExtensionNotFound:
+        logger.warning("%s Certificate did not contain a SubjectAltName. This may not have come from a TPM.", cert_type)
+        return True
     if not isinstance(san_ext.value, x509.SubjectAlternativeName):
         logger.warning("%s Certificate did not contain a SubjectAltName. This may not have come from a TPM.", cert_type)
         return True
-    othername = san_ext.value.get_values_for_type(x509.OtherName)[0]
+    othernames = san_ext.value.get_values_for_type(x509.OtherName)
+    if not othernames:
+        logger.warning(
+            "%s Certificate did not contain the HW module name. This may not have come from a TPM.", cert_type
+        )
+        return True
+    othername = othernames[0]
     if othername.type_id.dotted_string != OID_HW_MODULE_NAME:
         logger.warning(
             "%s Certificate did not contain the HW module name. This may not have come from a TPM.", cert_type

--- a/test/test_cert_utils.py
+++ b/test/test_cert_utils.py
@@ -1,8 +1,13 @@
 import base64
+import datetime
 import os
 import unittest
 
 import cryptography
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
 
 from keylime import cert_utils, tpm_ek_ca
 
@@ -311,3 +316,34 @@ VMuvlCzEwd8V/FIw"""
 
         for index, c in enumerate(test_cases):
             self.assertEqual(cert_utils.is_x509_cert(c["data"]), c["valid"], msg=f"index is {index}")
+
+    @staticmethod
+    def _self_signed_cert(sans=None):
+        key = ec.generate_private_key(ec.SECP256R1())
+        name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "keylime-test")])
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(name)
+            .issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime(2020, 1, 1))
+            .not_valid_after(datetime.datetime(2030, 1, 1))
+        )
+        if sans is not None:
+            builder = builder.add_extension(x509.SubjectAlternativeName(sans), critical=False)
+        return builder.sign(key, hashes.SHA256())
+
+    def test_check_tpm_origin_no_subject_alt_name(self):
+        # A certificate without a SubjectAltName extension must not crash
+        # check_tpm_origin. Per the registrar's design (see issue #1612 / PR #1637)
+        # the check only warns and returns True ("we are not sure") instead of
+        # raising ExtensionNotFound.
+        cert = self._self_signed_cert(sans=None)
+        self.assertTrue(cert_utils.check_tpm_origin(cert, "IDevID"))
+
+    def test_check_tpm_origin_san_without_othername(self):
+        # A SubjectAltName that contains no OtherName entry must not crash
+        # check_tpm_origin with an IndexError; it should warn and return True.
+        cert = self._self_signed_cert(sans=[x509.DNSName("example.com")])
+        self.assertTrue(cert_utils.check_tpm_origin(cert, "IAK"))


### PR DESCRIPTION
## Type of Change
- [x] Bug fix (non-breaking change)

## Related Issues
**Resolves:** #1943

## Change Description

`check_tpm_origin()` is documented to only *warn* and return `True` when an IDevID/IAK certificate lacks the expected TPM `SubjectAltName` fields, so that registration is not blocked (behaviour established in #1612 / #1637). Two paths raised an unhandled exception instead:

- `get_extension_for_oid(SUBJECT_ALTERNATIVE_NAME)` raises `cryptography.x509.ExtensionNotFound` when the certificate has **no** `SubjectAltName` extension. It was neither imported nor caught, so it propagated through `iak_idevid_cert_checks()` and crashed registrar processing. The pre-existing `isinstance()` guard for the missing-SAN case was dead code that could never run.
- `get_values_for_type(x509.OtherName)[0]` raises `IndexError` when a `SubjectAltName` is present but contains no `OtherName` entry.

This change catches `ExtensionNotFound` and guards the empty `OtherName` list, warning and returning `True` in both cases to match the documented contract.

## How was this tested?

- Added two unit tests in `test/test_cert_utils.py` (`test_check_tpm_origin_no_subject_alt_name`, `test_check_tpm_origin_san_without_othername`) that build certificates with `cryptography` (no TPM/hardware needed). Both **fail before** this change (`ExtensionNotFound` / `IndexError`) and **pass after**.
- `test/test_cert_utils.py` passes in full.
- `black` (23.10.0), `isort`, and `mypy` are clean on the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
* Improved certificate validation for certificates without Subject Alternative Name entries or without TPM-related SAN values.
* Prevented validation errors when certificate metadata is incomplete, while preserving existing type and hardware checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
