### PR TITLE
fix: Unwrap OCTET STRING wrapped EK certificates

### DIFF
--- a/keylime/cert_utils.py
+++ b/keylime/cert_utils.py
@@ -13,6 +13,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.x509 import Certificate
 from cryptography.x509.oid import ExtensionOID
 from pyasn1.codec.der import decoder, encoder
+from pyasn1.type import univ
 from pyasn1_modules import pem, rfc2459, rfc4108
 
 from keylime import keylime_logging, tpm_ek_ca
@@ -59,12 +60,40 @@ def x509_der_cert(der_cert_data: bytes) -> Certificate:
     :type der_cert_data: bytes
     :returns: cryptography.x509.Certificate
     """
+    der_cert_data = unwrap_x509_octet_string(der_cert_data)
+
     try:
         return x509.load_der_x509_certificate(data=der_cert_data, backend=default_backend())
     except Exception as err:
         logger.warning("Failed to parse DER data with python-cryptography: %s", err)
         pyasn1_cert = decoder.decode(der_cert_data, asn1Spec=rfc2459.Certificate())[0]
         return x509.load_der_x509_certificate(data=encoder.encode(pyasn1_cert), backend=default_backend())
+
+
+def unwrap_x509_octet_string(der_cert_data: bytes) -> bytes:
+    """If der_cert_data is an ASN.1 OCTET STRING wrapping a DER certificate,
+    unwrap it and return the inner DER bytes. Otherwise, return der_cert_data unchanged.
+    """
+    if not der_cert_data or der_cert_data[0] != 0x04:
+        return der_cert_data
+
+    try:
+        octet_string, _ = decoder.decode(der_cert_data, asn1Spec=univ.OctetString())
+        unwrapped = bytes(octet_string)
+    except Exception as err:
+        logger.warning(
+            "Data starts with OCTET STRING tag (0x04) but unwrapping failed; passing through original data: %s", err
+        )
+        return der_cert_data
+
+    if unwrapped and unwrapped[0] == 0x30:
+        return unwrapped
+
+    logger.warning(
+        "Data starts with OCTET STRING tag (0x04) and was unwrapped, but the inner content "
+        "does not start with a SEQUENCE tag (0x30); passing through original data."
+    )
+    return der_cert_data
 
 
 def x509_pem_cert(pem_cert_data: str) -> Certificate:

--- a/keylime/models/base/types/certificate.py
+++ b/keylime/models/base/types/certificate.py
@@ -12,6 +12,7 @@ from pyasn1_modules import pem as pyasn1_pem
 from pyasn1_modules import rfc2459 as pyasn1_rfc2459
 from sqlalchemy.types import Text
 
+from keylime import cert_utils
 from keylime.certificate_wrapper import CertificateWrapper, wrap_certificate
 from keylime.models.base.type import ModelType
 
@@ -110,6 +111,7 @@ class Certificate(ModelType):
 
         :returns: A ``CertificateWrapper`` object
         """
+        der_cert_data = cert_utils.unwrap_x509_octet_string(der_cert_data)
 
         try:
             cert = cryptography.x509.load_der_x509_certificate(der_cert_data)

--- a/test/test_cert_utils.py
+++ b/test/test_cert_utils.py
@@ -3,6 +3,8 @@ import os
 import unittest
 
 import cryptography
+from pyasn1.codec.der import encoder
+from pyasn1.type import univ
 
 from keylime import cert_utils, tpm_ek_ca
 
@@ -311,3 +313,30 @@ VMuvlCzEwd8V/FIw"""
 
         for index, c in enumerate(test_cases):
             self.assertEqual(cert_utils.is_x509_cert(c["data"]), c["valid"], msg=f"index is {index}")
+
+    def test_x509_der_cert_octet_string_wrapped(self):
+        # Some hardware TPMs store the EK certificate in NV RAM wrapped in an
+        # ASN.1 OCTET STRING (tag 0x04) instead of raw DER (tag 0x30 SEQUENCE).
+        der_cert_data = base64.b64decode(st_sha256_with_rsa_der)
+        wrapped_der_cert_data = encoder.encode(univ.OctetString(der_cert_data))
+
+        expected = cert_utils.x509_der_cert(der_cert_data)
+        result = cert_utils.x509_der_cert(wrapped_der_cert_data)
+        self.assertEqual(expected.subject, result.subject)
+        self.assertEqual(expected.serial_number, result.serial_number)
+
+    def test_unwrap_x509_octet_string_malformed_octet_string(self):
+        # Oversized length field; pyasn1 raises OverflowError here, not PyAsn1Error.
+        malformed = bytes.fromhex("04888e2e6120439b1f6a")
+        with self.assertLogs("keylime.cert_utils", level="WARNING") as log:
+            result = cert_utils.unwrap_x509_octet_string(malformed)
+        self.assertEqual(result, malformed)
+        self.assertTrue(any("unwrapping failed" in msg for msg in log.output))
+
+    def test_unwrap_x509_octet_string_not_a_certificate_inside(self):
+        # Valid OCTET STRING, but the content inside isn't a certificate.
+        wrapped_non_cert = encoder.encode(univ.OctetString(b"not a certificate"))
+        with self.assertLogs("keylime.cert_utils", level="WARNING") as log:
+            result = cert_utils.unwrap_x509_octet_string(wrapped_non_cert)
+        self.assertEqual(result, wrapped_non_cert)
+        self.assertTrue(any("does not start with a SEQUENCE tag" in msg for msg in log.output))

--- a/test/test_certificate_modeltype.py
+++ b/test/test_certificate_modeltype.py
@@ -10,6 +10,8 @@ import unittest
 
 import cryptography.x509
 from cryptography.hazmat.primitives.serialization import Encoding
+from pyasn1.codec.der import encoder as pyasn1_encoder
+from pyasn1.type import univ as pyasn1_univ
 
 from keylime.certificate_wrapper import CertificateWrapper, wrap_certificate
 from keylime.models.base.types.certificate import Certificate
@@ -181,6 +183,16 @@ d4wslruibXBsLPtJw2c6vTC2SV2F1PXwy5j1OKU+D6nxaaItQvWADEjcTg==
         der_bytes = self.compliant_cert.public_bytes(Encoding.DER)
         result = self.cert_type.cast(der_bytes)
         self.assertIsInstance(result, CertificateWrapper)
+
+    def test_cast_octet_string_wrapped_der_bytes(self):
+        """Test casting OCTET-STRING-wrapped DER bytes (not CertificateWrapper "wrapping")."""
+        der_bytes = self.compliant_cert.public_bytes(Encoding.DER)
+        octet_string_wrapped_der_bytes = pyasn1_encoder.encode(pyasn1_univ.OctetString(der_bytes))
+        result = self.cert_type.cast(octet_string_wrapped_der_bytes)
+        self.assertIsInstance(result, CertificateWrapper)
+        assert result is not None
+        self.assertEqual(result.subject, self.compliant_cert.subject)
+        self.assertEqual(result.serial_number, self.compliant_cert.serial_number)
 
     def test_cast_none_value(self):
         """Test that None values return None."""


### PR DESCRIPTION
# PR Title 
fix: Unwrap OCTET STRING wrapped EK certificates

## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [x] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
**Resolves:** #1891 

## Change Description

### Concise Summary
Unwrap OCTET STRING wrapped EK certificates

### Technical Details
Some hardware TPMs store the EK certificate in NV RAM wrapped in an ASN.1 OCTET STRING (tag 0x04) instead of raw DER (tag 0x30), causing both `cert_utils.x509_der_cert()` and `certificate.py`'s `_load_der_cert()` to reject it, which makes agent registration fail with a 400 response.

- Added `unwrap_x509_octet_string()` in `cert_utils.py` that detects the  OCTET STRING wrapper, unwraps it, and verifies the inner content starts with a SEQUENCE tag (0x30) before trusting it.
- If the inner content doesn't look like a certificate, the original bytes are returned unchanged, so unrelated/malformed input isn't misinterpreted.
- Called from both affected code paths.
- Alternative considered: unwrapping without the inner 0x30 check — rejected since it could misidentify arbitrary OCTET-STRING-encoded non-cert data.

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. Added `test_x509_der_cert_octet_string_wrapped` unit test reproducing the exact error from the issue against a real EK certificate wrapped in OCTET STRING; confirmed it fails before the fix and passes after.
2. Verified against a real registrar on Testing Farm (CentOS Stream 10): registered a fake agent with a real swtpm-issued EK cert wrapped in OCTET STRING via the registrar's HTTP API — fails pre-fix, succeeds post-fix, matching a non-wrapped control case.
3. Ran full existing test suite (61 tests) — no regressions.

## Checklist
- [x] Code follows project style guidelines
- [x] Unit/integration tests added/updated
- [ ] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [ ] All tests pass (local & CI)

## Additional Context
*(Optional: follow-up tasks, special considerations)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of X.509 certificates wrapped in ASN.1 OCTET STRING data.
  * Certificates are now unwrapped and parsed correctly across supported certificate-loading paths.
  * Malformed or unexpected certificate data is preserved safely, with warnings logged instead of causing unintended processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->