### PR TITLE
CI: Pass PR number to codecov to enable comments

### DIFF
--- a/.github/workflows/submit-PR-coverage.yaml
+++ b/.github/workflows/submit-PR-coverage.yaml
@@ -1,5 +1,12 @@
 name: PR code coverage measurement on codecov.io
 
+# This workflow handles fork-based PRs where the commit SHA originates from
+# the contributor's fork. Because the workflow is triggered by check_run
+# events rather than pull_request events, codecov cannot automatically
+# determine the associated PR. The commit SHA (head_sha) belongs to the
+# fork's branch, so we explicitly query the upstream repository's API to
+# resolve the PR number and pass it to codecov via override_pr.
+
 on:
   check_run:
     types: [completed]
@@ -26,6 +33,21 @@ jobs:
         SLEEP_DELAY: 120
     - name: List downloaded files
       run: ls coverage*
+    - name: Fetch PR number for Commit
+      id: get_pr
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HEAD_SHA: ${{ github.event.check_run.head_sha }}
+      run: |
+        # Query the original repository for PRs associated with the fork's commit SHA
+        PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/$HEAD_SHA/pulls" --jq '.[0].number' 2>/dev/null)
+        if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
+          echo "::warning::No open PR found for commit $HEAD_SHA - coverage will be visible in codecov WebUI but no PR comment will be posted"
+          PR_NUMBER=""
+        else
+          echo "Found PR: $PR_NUMBER"
+        fi
+        echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
     - name: Upload coverage.unittests.xml report to Codecov with GitHub Action
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
       env:
@@ -34,6 +56,8 @@ jobs:
         files: scripts/coverage.unittests.xml
         disable_search: true
         flags: unittests
+        override_commit: ${{ github.event.check_run.head_sha }}
+        override_pr: ${{ steps.get_pr.outputs.pr_number }}
     - name: Upload coverage.testsuite.xml report to Codecov with GitHub Action
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
       env:
@@ -42,6 +66,8 @@ jobs:
         files: scripts/coverage.testsuite.xml
         disable_search: true
         flags: testsuite
+        override_commit: ${{ github.event.check_run.head_sha }}
+        override_pr: ${{ steps.get_pr.outputs.pr_number }}
     - name: Upload coverage.packit.xml report to Codecov with GitHub Action
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
       env:
@@ -50,3 +76,5 @@ jobs:
         files: scripts/coverage.packit.xml
         disable_search: true
         flags: packit-e2e
+        override_commit: ${{ github.event.check_run.head_sha }}
+        override_pr: ${{ steps.get_pr.outputs.pr_number }}

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,7 +18,7 @@ jobs:
   trigger: pull_request
   identifier: fast
   targets:
-    - fedora-latest
+    - fedora-latest-stable
   skip_build: true
   require:
     label:


### PR DESCRIPTION
## Type of Change
*(Select all that apply)*
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [ ] Test cases (added/modified)
- [x] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
none

## Change Description

### Concise Summary
Because we are now submitting coverage data from a standalone action, codecov cannot associate these data with a PR. We need to pass PR number explicitly to re-enable comments.

## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. Describe test environment
2. Step-by-step validation procedure
3. Expected vs actual results

codecov.io adds comments to a PR with code coverage stats.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [ ] Documentation updated (per above section)
- [ ] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [ ] All tests pass (local & CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved code coverage reporting for pull requests by associating uploaded reports with the correct commit and pull request.
  * Added a warning when no matching open pull request is found.
  * Updated fast test runs to use the latest stable Fedora environment for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->