### PR TITLE
verifier: warn when accept-all ignores non-empty measured boot refstate

### DIFF
--- a/keylime/cloud_verifier_common.py
+++ b/keylime/cloud_verifier_common.py
@@ -187,6 +187,27 @@ def process_quote_response(
     tenant_keyring = file_signatures.ImaKeyring.from_string(verification_key_string)
     ima_keyrings.set_tenant_keyring(tenant_keyring)
 
+    # Warn when accept-all ignores a non-empty measured boot reference state.
+    # This warning is intentionally emitted only once per agent attestation lifetime.
+
+    if mb_policy_name == "accept-all" and mb_policy:
+        try:
+            parsed_mb = json.loads(mb_policy)
+            has_nonempty_refstate = bool(parsed_mb) if isinstance(parsed_mb, dict) else True
+        except Exception:
+            has_nonempty_refstate = bool(mb_policy.strip())
+
+        if has_nonempty_refstate and not getattr(
+            agentAttestState, "_warned_mb_refstate_ignored", False
+        ):  # pylint: disable=protected-access  # pylint: disable=protected-access
+            logger.warning(
+                "Boot reference state for agent %s is being ignored because policy "
+                '"accept-all" is active. Keylime is only checking that the boot log matches '
+                "the PCR values in the TPM quote.",
+                agent_id,
+            )
+            agentAttestState._warned_mb_refstate_ignored = True  # pylint: disable=protected-access
+
     if agent.get("tpm_clockinfo"):
         agentAttestState.set_tpm_clockinfo(TPMClockInfo.from_dict(agent["tpm_clockinfo"]))
 

--- a/test/test_cloud_verifier_common.py
+++ b/test/test_cloud_verifier_common.py
@@ -1009,5 +1009,202 @@ class TestProcessGetStatus(unittest.TestCase):
         self.assertEqual(status["attestation_status"], "PENDING")
 
 
+class TestProcessQuoteResponseMbRefstateWarning(unittest.TestCase):
+    """Test the measured boot refstate warning in process_quote_response().
+
+    These tests verify that a WARNING is emitted exactly once per agent
+    when the active measured boot policy is "accept-all" but the agent
+    carries a non-empty boot reference state.
+
+    Regression test for: https://github.com/keylime/keylime/issues/1932
+    """
+
+    def _make_agent(self) -> dict:
+        """Return a minimal agent dict that passes early guards."""
+        return {
+            "agent_id": "test-agent-uuid",
+            "nonce": "deadbeef",
+            "public_key": "",
+            "v": "",
+            "b64_encrypted_V": "",
+            "provide_V": True,
+            "ak_tpm": "ak-tpm-data",
+            "tpm_policy": '{"mask": "0x0"}',
+            "ima_sign_verification_keys": "",
+            "accept_tpm_hash_algs": ["sha256"],
+            "accept_tpm_encryption_algs": ["rsa"],
+            "accept_tpm_signing_algs": ["rsassa"],
+            "supported_version": "2.5",
+            "attestation_count": 0,
+            "tpm_clockinfo": None,
+        }
+
+    def _make_json_response(self) -> dict:
+        """Return a minimal quote response."""
+        return {
+            "quote": "r/1RDR4AYAC...",
+            "hash_alg": "sha256",
+            "enc_alg": "rsa2048",
+            "sign_alg": "rsassa",
+            "pubkey": "",
+            "ima_measurement_list": None,
+            "ima_measurement_list_entry": 0,
+            "mb_measurement_list": None,
+            "boottime": 0,
+        }
+
+    @patch("keylime.cloud_verifier_common.get_tpm_instance")
+    def test_warns_once_on_accept_all_with_nonempty_refstate(self, mock_get_tpm):
+        """Warning is emitted exactly once when accept-all ignores a non-empty refstate."""
+        from keylime.agentstates import AgentAttestState  # pylint: disable=import-outside-toplevel
+        from keylime.failure import Component, Failure  # pylint: disable=import-outside-toplevel
+
+        mock_tpm = MagicMock()
+        mock_tpm.check_quote.return_value = Failure(Component.DEFAULT)
+        mock_get_tpm.return_value = mock_tpm
+
+        agent = self._make_agent()
+        agentAttestState = AgentAttestState(agent["agent_id"])
+        json_response = self._make_json_response()
+        mb_policy = '{"secureboot": true, "bootloader": "shim"}'
+        mb_policy_name = "accept-all"
+
+        import logging  # pylint: disable=import-outside-toplevel
+
+        logger = logging.getLogger("keylime.cloudverifier_common")
+
+        # First call should emit the warning
+        with patch.object(logger, "warning") as mock_warn:
+            cloud_verifier_common.process_quote_response(
+                agent, mb_policy, None, json_response, agentAttestState, mb_policy_name
+            )
+            mock_warn.assert_called_once()
+            self.assertIn("is being ignored because policy", mock_warn.call_args[0][0])
+            self.assertIn("accept-all", mock_warn.call_args[0][0])
+
+        # Second call should NOT emit the warning again (deduplication)
+        with patch.object(logger, "warning") as mock_warn:
+            cloud_verifier_common.process_quote_response(
+                agent, mb_policy, None, json_response, agentAttestState, mb_policy_name
+            )
+            mock_warn.assert_not_called()
+
+    @patch("keylime.cloud_verifier_common.get_tpm_instance")
+    def test_no_warning_when_refstate_is_empty_dict(self, mock_get_tpm):
+        """No warning when mb_policy is empty dict {} under accept-all."""
+        from keylime.agentstates import AgentAttestState  # pylint: disable=import-outside-toplevel
+        from keylime.failure import Component, Failure  # pylint: disable=import-outside-toplevel
+
+        mock_tpm = MagicMock()
+        mock_tpm.check_quote.return_value = Failure(Component.DEFAULT)
+        mock_get_tpm.return_value = mock_tpm
+
+        agent = self._make_agent()
+        agentAttestState = AgentAttestState(agent["agent_id"])
+        json_response = self._make_json_response()
+
+        import logging  # pylint: disable=import-outside-toplevel
+
+        logger = logging.getLogger("keylime.cloudverifier_common")
+        with patch.object(logger, "warning") as mock_warn:
+            cloud_verifier_common.process_quote_response(
+                agent, "{}", None, json_response, agentAttestState, "accept-all"
+            )
+            mock_warn.assert_not_called()
+
+    @patch("keylime.cloud_verifier_common.get_tpm_instance")
+    def test_no_warning_when_refstate_is_none(self, mock_get_tpm):
+        """No warning when mb_policy is None under accept-all."""
+        from keylime.agentstates import AgentAttestState  # pylint: disable=import-outside-toplevel
+        from keylime.failure import Component, Failure  # pylint: disable=import-outside-toplevel
+
+        mock_tpm = MagicMock()
+        mock_tpm.check_quote.return_value = Failure(Component.DEFAULT)
+        mock_get_tpm.return_value = mock_tpm
+
+        agent = self._make_agent()
+        agentAttestState = AgentAttestState(agent["agent_id"])
+        json_response = self._make_json_response()
+
+        import logging  # pylint: disable=import-outside-toplevel
+
+        logger = logging.getLogger("keylime.cloudverifier_common")
+        with patch.object(logger, "warning") as mock_warn:
+            cloud_verifier_common.process_quote_response(
+                agent, None, None, json_response, agentAttestState, "accept-all"
+            )
+            mock_warn.assert_not_called()
+
+    @patch("keylime.cloud_verifier_common.get_tpm_instance")
+    def test_no_warning_when_policy_is_not_accept_all(self, mock_get_tpm):
+        """No warning when policy name is not accept-all, even with non-empty refstate."""
+        from keylime.agentstates import AgentAttestState  # pylint: disable=import-outside-toplevel
+        from keylime.failure import Component, Failure  # pylint: disable=import-outside-toplevel
+
+        mock_tpm = MagicMock()
+        mock_tpm.check_quote.return_value = Failure(Component.DEFAULT)
+        mock_get_tpm.return_value = mock_tpm
+
+        agent = self._make_agent()
+        agentAttestState = AgentAttestState(agent["agent_id"])
+        json_response = self._make_json_response()
+        mb_policy = '{"secureboot": true}'
+
+        import logging  # pylint: disable=import-outside-toplevel
+
+        logger = logging.getLogger("keylime.cloudverifier_common")
+        with patch.object(logger, "warning") as mock_warn:
+            cloud_verifier_common.process_quote_response(
+                agent, mb_policy, None, json_response, agentAttestState, "example-policy"
+            )
+            mock_warn.assert_not_called()
+
+    @patch("keylime.cloud_verifier_common.get_tpm_instance")
+    def test_warning_sets_flag_on_agent_attest_state(self, mock_get_tpm):
+        """The _warned_mb_refstate_ignored flag is set on agentAttestState after warning."""
+        from keylime.agentstates import AgentAttestState  # pylint: disable=import-outside-toplevel
+        from keylime.failure import Component, Failure  # pylint: disable=import-outside-toplevel
+
+        mock_tpm = MagicMock()
+        mock_tpm.check_quote.return_value = Failure(Component.DEFAULT)
+        mock_get_tpm.return_value = mock_tpm
+
+        agent = self._make_agent()
+        agentAttestState = AgentAttestState(agent["agent_id"])
+        self.assertFalse(getattr(agentAttestState, "_warned_mb_refstate_ignored", False))
+
+        json_response = self._make_json_response()
+        cloud_verifier_common.process_quote_response(
+            agent, '{"foo": "bar"}', None, json_response, agentAttestState, "accept-all"
+        )
+
+        self.assertTrue(agentAttestState._warned_mb_refstate_ignored)  # pylint: disable=protected-access,no-member
+
+    @patch("keylime.cloud_verifier_common.get_tpm_instance")
+    def test_warning_with_non_dict_json_refstate(self, mock_get_tpm):
+        """Warning is emitted for non-dict JSON (e.g., list) under accept-all."""
+        from keylime.agentstates import AgentAttestState  # pylint: disable=import-outside-toplevel
+        from keylime.failure import Component, Failure  # pylint: disable=import-outside-toplevel
+
+        mock_tpm = MagicMock()
+        mock_tpm.check_quote.return_value = Failure(Component.DEFAULT)
+        mock_get_tpm.return_value = mock_tpm
+
+        agent = self._make_agent()
+        agentAttestState = AgentAttestState(agent["agent_id"])
+        json_response = self._make_json_response()
+
+        import logging  # pylint: disable=import-outside-toplevel
+
+        logger = logging.getLogger("keylime.cloudverifier_common")
+
+        with patch.object(logger, "warning") as mock_warn:
+            cloud_verifier_common.process_quote_response(
+                agent, '["event1", "event2"]', None, json_response, agentAttestState, "accept-all"
+            )
+            mock_warn.assert_called_once()
+            self.assertIn("is being ignored because policy", mock_warn.call_args[0][0])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

When the verifier's measured boot policy is set to `"accept-all"`, the verifier silently ignores any non-empty boot reference state (`mb_refstate`) that the agent may carry. It only checks that the boot log's PCR values match the TPM quote — it does not evaluate the actual boot log contents against the reference state.

This PR emits a single `WARNING` log per agent when this misconfiguration is detected, making it obvious to operators that their supplied reference state is not being enforced.

Fixes #1932

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactor
- [x] Test cases (added/modified)
- [ ] CI/CD changes

## Change Description

### Concise Summary
verifier: warn when accept-all ignores non-empty measured boot refstate

### Technical Details
- Added warning logic in `process_quote_response()` in `keylime/cloud_verifier_common.py`
- Warning fires when `mb_policy_name == "accept-all"` AND `mb_policy` contains non-empty data
- Deduplicated via `agentAttestState._warned_mb_refstate_ignored` flag (once per agent lifetime)
- Added 6 unit tests covering: warning emission, deduplication, empty refstate, None refstate, non-accept-all policy, and non-dict JSON refstate

## Documentation Updates Required
- [ ] Updated markdown docs
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates
- [ ] Needs ReadTheDocs updates
- [x] No docs needed

## Verification Process
1. Ran `python -m unittest test.test_cloud_verifier_common.TestProcessQuoteResponseMbRefstateWarning -v` — all 6 tests pass
2. Ran `black --check` on modified files — formatting clean
3. Ran `isort --check` on modified files — imports clean

## Checklist
- [x] Code follows project style guidelines (black, isort)
- [x] Unit tests added
- [x] Commit messages follow project conventions
- [x] All local tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when a measured boot reference state is configured but ignored because the active policy accepts all measurements.
  * Limited this warning to once per agent attestation session to reduce repeated messages.
  * Improved detection of non-empty measured boot reference states across supported policy formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->