### PR TITLE
fix: intermittent FileNotFoundError in RpmRepo_Test teardown

### DIFF
--- a/test/data/create-runtime-policy/setup-rpm-tests
+++ b/test/data/create-runtime-policy/setup-rpm-tests
@@ -338,6 +338,15 @@ prepare_rpms() {
         rpmsign --load="${MACROS_RC_SIG}" --addsign --signfiles {} \;
 }
 
+cleanup_gpg_agents() {
+    # create_keys() implicitly starts a gpg-agent per homedir (RSA and ECC),
+    # and prepare_rpms() keeps using them for signing. Nothing needs them
+    # once this script is done.
+    gpgconf --homedir "${GPGDIR_RSA}" --kill gpg-agent || true
+    gpgconf --homedir "${GPGDIR_ECC}" --kill gpg-agent || true
+}
+
 sanity_check
 create_keys
 prepare_rpms
+cleanup_gpg_agents

--- a/test/test_rpm_repo.py
+++ b/test/test_rpm_repo.py
@@ -72,7 +72,19 @@ class RpmRepo_Test(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         if cls.dirpath is not None:
-            shutil.rmtree(cls.dirpath)
+            # setup-rpm-tests spawns gpg-agent, which removes its socket files async on
+            # exit; rmtree may race this and find a socket that's already gone—ignore it.
+            # `onerror` is deprecated since Python 3.12 in favor of `onexc`, but the
+            # latter isn't available on the older versions this project still supports.
+            def _ignore_already_removed(_func, _path, exc):
+                err = exc[1] if isinstance(exc, tuple) else exc
+                if not isinstance(err, FileNotFoundError):
+                    raise err
+
+            if sys.version_info >= (3, 12):
+                shutil.rmtree(cls.dirpath, onexc=_ignore_already_removed)
+            else:
+                shutil.rmtree(cls.dirpath, onerror=_ignore_already_removed)
 
     def test_analyze_local_repo(self):
         test_cases = [


### PR DESCRIPTION
# PR Title 
fix: intermittent FileNotFoundError in RpmRepo_Test teardown

## Type of Change
*(Select all that apply)*
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix/feature causing existing behavior to change)
- [ ] Documentation update (standalone)
- [ ] Code refactor (no functional changes)
- [x] Test cases (added/modified)
- [ ] CI/CD changes
- [ ] Other (please specify: ______)

## Related Issues
*(If you use an issue tracker, please put references to them)*  
**Resolves:** #1937

## Change Description

### Concise Summary
Kill lingering gpg-agents; make rmtree tolerate races 

### Technical Details
 Motivation behind the change

- setup-rpm-tests generates GPG keys (RSA and ECC) to sign repos/RPMs, which implicitly spawns a gpg-agent per homedir
- These agents keep running after the script exits, with nothing left to use them once signing is done
- tearDownClass's shutil.rmtree races against the agent's own async socket cleanup: it can enumerate a socket file, then fail to unlink it because gpg-agent has already removed it in the meantime

Architectural decisions

- Explicitly kill both gpg-agents at the end of setup-rpm-tests, since nothing downstream needs them once signing is complete
- Additionally harden rmtree to tolerate a file vanishing mid-walk, since gpgconf --kill doesn't guarantee sockets are gone by the time tearDownClass runs — the two fixes are complementary, not redundant

Unintended side effects

- None expected; the agents were not being reused after signing, so killing them earlier has no functional impact on the test flow


## Documentation Updates Required
*(Check all that apply)*
- [ ] Updated markdown docs (file path: ______)
- [ ] Updated code comments/docstrings
- [ ] Needs user guide updates (`docs/`)
- [ ] Needs ReadTheDocs updates
- [x] No docs needed (requires maintainer approval)

## Verification Process
1. Ran python -m pytest test/test_rpm_repo.py -v — all 4 tests passed
2. Ran isort and black (pre-commit), both passed

## Checklist
- [x] Code follows project style guidelines
- [ ] Unit/integration tests added/updated
- [x] Documentation updated (per above section)
- [x] Commit messages follow [Chris Beams' How to Write a Git Commit Message article] (https://chris.beams.io/posts/git-commit/)
- [ ] CHANGELOG updated (if applicable)
- [x] All tests pass (local & CI)

## Additional Context
This issue is difficult to reproduce reliably since it is an intermittent race condition, but under normal circumstances the test passes, and this change is expected to resolve the problem.